### PR TITLE
Use AtomicLong for object ID generation.

### DIFF
--- a/api/api-facades/api-core/src/main/java/org/eclipse/dirigible/api/v3/core/JavaFacade.java
+++ b/api/api-facades/api-core/src/main/java/org/eclipse/dirigible/api/v3/core/JavaFacade.java
@@ -43,9 +43,7 @@ public class JavaFacade {
 					return json;
 				}
 				// non primitive result - add to the context
-				String resultUuid = generateUuid();
-				ThreadContextFacade.setProxy(resultUuid, result);
-				return resultUuid;
+				return ThreadContextFacade.setProxy(result);
 			}
 
 			return result;
@@ -118,9 +116,7 @@ public class JavaFacade {
 			Object result;
 			try {
 				result = constructor.newInstance(params.toArray(new Object[] {}));
-				String uuid = generateUuid();
-				ThreadContextFacade.setProxy(uuid, result);
-				return uuid;
+				return ThreadContextFacade.setProxy(result);
 			} catch (Throwable t) {
 				logger.error(t.getMessage(), t);
 			}
@@ -156,9 +152,7 @@ public class JavaFacade {
 					return json;
 				}
 				// non primitive result - add to the context
-				String resultUuid = generateUuid();
-				ThreadContextFacade.setProxy(resultUuid, result);
-				return resultUuid;
+				return ThreadContextFacade.setProxy(result);
 			}
 
 			return result;
@@ -166,10 +160,6 @@ public class JavaFacade {
 		String message = format("No such method [{0}] in class [{1}]", methodName, clazz.getName());
 		logger.error(message);
 		throw new NoSuchMethodException(message);
-	}
-
-	private static String generateUuid() {
-		return UUID.randomUUID().toString();
 	}
 
 	public static final void free(String uuid) throws ContextException {

--- a/modules/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
+++ b/modules/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
@@ -1,10 +1,11 @@
 package org.eclipse.dirigible.commons.api.context;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Scripting context facade is the centralized place where the different scripting facade providers
@@ -17,6 +18,8 @@ public class ThreadContextFacade {
 	private static final ThreadLocal<Map<String, Object>> CONTEXT = new ThreadLocal<Map<String, Object>>();
 
 	private static final ThreadLocal<Map<String, Object>> PROXIES = new ThreadLocal<Map<String, Object>>();
+
+	private static final AtomicLong UUID_GENERATOR = new AtomicLong(Long.MIN_VALUE);
 
 	/**
 	 * Initializes the context. This has to be called at the very first (as possible) place at the service entry point
@@ -60,6 +63,21 @@ public class ThreadContextFacade {
 
 	/**
 	 * Set a context scripting object
+	 *
+	 * @param value the value
+	 * @return the UUID of the object
+	 * @throws ContextException in case of an error
+	 */
+	public static final String set(Object value) throws ContextException {
+		final String uuid = generateObjectId();
+		set(uuid, value);
+		return uuid;
+	}
+
+	/**
+	 * Set a context scripting object. If object with
+	 * with this key exists, it will be replaced with
+	 * the new object
 	 *
 	 * @param key
 	 *            the key
@@ -119,6 +137,25 @@ public class ThreadContextFacade {
 
 	/**
 	 * Set a proxy scripting object
+	 *
+	 * @param value the value
+	 * @return the UUID of the object
+	 * @throws ContextException in case of an error
+	 */
+	public static final String setProxy(Object value) throws ContextException {
+		final String uuid = generateObjectId();
+		setProxy(uuid, value);
+		return uuid;
+	}
+
+	private static String generateObjectId() {
+		return Long.toString(UUID_GENERATOR.incrementAndGet(), Character.MAX_RADIX);
+	}
+
+	/**
+	 * Set a proxy scripting object. If proxy object
+	 * with this key exists, it will be replaced with
+	 * the new object
 	 *
 	 * @param key
 	 *            the key


### PR DESCRIPTION
The long type provides wide enough namespace for unique IDs
and the AtomicLong type provides faster way to generate unique
object IDs than the UUID class.