### PR TITLE
Enhanced persistence models 

### DIFF
--- a/modules/database/database-persistence/src/main/java/org/eclipse/dirigible/database/persistence/model/PersistenceTableModel.java
+++ b/modules/database/database-persistence/src/main/java/org/eclipse/dirigible/database/persistence/model/PersistenceTableModel.java
@@ -4,14 +4,15 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * <p>
  * Contributors:
- *   SAP - initial API and implementation
+ * SAP - initial API and implementation
  */
 package org.eclipse.dirigible.database.persistence.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The Persistence Table Model transport object.
@@ -24,7 +25,18 @@ public class PersistenceTableModel {
 
 	private String schemaName;
 
-	private List<PersistenceTableColumnModel> columns = new ArrayList<PersistenceTableColumnModel>();
+	private List<PersistenceTableColumnModel> columns = new ArrayList<>();
+
+	private List<PersistenceTableRelationModel> relations = new ArrayList<>();
+
+	public PersistenceTableModel(String tableName, List<PersistenceTableColumnModel> columns, List<PersistenceTableRelationModel> relations) {
+		this.tableName = tableName;
+		this.columns = columns;
+		this.relations = relations;
+	}
+
+	public PersistenceTableModel() {
+	}
 
 	/**
 	 * Gets the class name.
@@ -102,4 +114,37 @@ public class PersistenceTableModel {
 		this.columns = columns;
 	}
 
+	/**
+	 * gets the relations.
+	 *
+	 *            the new columns
+	 */
+	public List<PersistenceTableRelationModel> getRelations() {
+		return relations;
+	}
+
+	/**
+	 * Sets the relations.
+	 *
+	 * @param relations
+	 *            the new columns
+	 */
+	public void setRelations(List<PersistenceTableRelationModel> relations) {
+		this.relations = relations;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		PersistenceTableModel that = (PersistenceTableModel) o;
+		return Objects.equals(className, that.className) &&
+				tableName.equals(that.tableName) &&
+				Objects.equals(schemaName, that.schemaName);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(className, tableName, schemaName);
+	}
 }

--- a/modules/database/database-persistence/src/main/java/org/eclipse/dirigible/database/persistence/model/PersistenceTableRelationModel.java
+++ b/modules/database/database-persistence/src/main/java/org/eclipse/dirigible/database/persistence/model/PersistenceTableRelationModel.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2010-2018 SAP and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * <p>
+ * Contributors:
+ * SAP - initial API and implementation
+ */
+package org.eclipse.dirigible.database.persistence.model;
+
+/**
+ * The relation element of the persistence model transport object.
+ */
+public class PersistenceTableRelationModel {
+
+    private String fromTableName;
+
+    private String toTableName;
+
+    private String fkColumnName;
+
+    private String pkColumnName;
+
+    public PersistenceTableRelationModel() {
+    }
+
+    public PersistenceTableRelationModel(String fromTableName, String toTableName, String fkColumnName, String pkColumnName) {
+        this.fromTableName = fromTableName;
+        this.toTableName = toTableName;
+        this.fkColumnName = fkColumnName;
+        this.pkColumnName = pkColumnName;
+    }
+
+    /**
+     * Gets the name of the table with the foreign key.
+     * <p>
+     * the new columns
+     */
+    public String getFromTableName() {
+        return fromTableName;
+    }
+
+    /**
+     * Sets the name of the table with the foreign key.
+     *
+     * @param fromTableName
+     */
+    public void setFromTableName(String fromTableName) {
+        this.fromTableName = fromTableName;
+    }
+
+    /**
+     * Gets the name of the table with the primary key.
+     */
+    public String getToTableName() {
+        return toTableName;
+    }
+
+    /**
+     * Sets the name of the table with the primary key.
+     *
+     * @param toTableName
+     */
+    public void setToTableName(String toTableName) {
+        this.toTableName = toTableName;
+    }
+
+    /**
+     * Gets the name of the foreign key column.
+     */
+    public String getFkColumnName() {
+        return fkColumnName;
+    }
+
+    /**
+     * Sets the name of the foreign key column.
+     *
+     * @param fkColumnName
+     */
+    public void setFkColumnName(String fkColumnName) {
+        this.fkColumnName = fkColumnName;
+    }
+
+    /**
+     * Gets the name of the primary key column.
+     */
+    public String getPkColumnName() {
+        return pkColumnName;
+    }
+
+    /**
+     * Sets the name of the primary key column.
+     *
+     * @param pkColumnName
+     */
+    public void setPkColumnName(String pkColumnName) {
+        this.pkColumnName = pkColumnName;
+    }
+}
+


### PR DESCRIPTION
Added additional logic in the PersistenceModels in order to use them for the oData mappings:

-PersistenceTableRelationModel in order to store the relations between tables later used in the creation of odataM and odataX files.