### PR TITLE
Fix in paths for Windows for Zip importer

### DIFF
--- a/modules/repository/repository-zip/src/main/java/org/eclipse/dirigible/repository/zip/RepositoryZipImporter.java
+++ b/modules/repository/repository-zip/src/main/java/org/eclipse/dirigible/repository/zip/RepositoryZipImporter.java
@@ -131,6 +131,7 @@ public class RepositoryZipImporter {
 
 					String entryName = getEntryName(entry, parentFolder, excludeRootFolderName);
 					entryName = Paths.get(FilenameUtils.normalize(entryName)).normalize().toString();
+					entryName = entryName.replace('\\', '/');
 					logger.debug("importZip entryName: " + entryName);
 					String outpath = relativeRoot + ((relativeRoot.endsWith(IRepository.SEPARATOR)) ? "" : IRepository.SEPARATOR) + entryName;
 					logger.debug("importZip outpath: " + outpath);


### PR DESCRIPTION
Signed-off-by: km2k <k.momchev@abv.bg>

<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?
Fix for Windows-style paths in Zip import functionality

### What issues does this PR fix or reference?
https://github.com/eclipse/dirigible/issues/505

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Documentation
<!-- Please add a matching PR to [the docs repo](https://github.com/dirigible-io/dirigible-io.github.io) and link that PR to this issue.
Both will be merged at the same time. -->
