### PR TITLE
Downgraded jackson-databind to 2.10.5.1 for Apache Spark integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,17 @@
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-rs-service-description-swagger</artifactId>
 			<version>${cxf.version}</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>jackson-databind</artifactId>
+					<groupId>com.fasterxml.jackson.core</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.10.5.1</version>
 		</dependency>
 
 		<!-- Java 11 Dependencies -->


### PR DESCRIPTION
Signed-off-by: borisnen <26414287+BorisNen@users.noreply.github.com>

### What does this PR do?
Downgrades jackson-databind's version from 2.11.1 to 2.10.5.1. This is an inner dependency of "cxf-rt-rs-service-description-swagger". Downgrade is necessary for future Apache Spark integration since the official Spark release works only with jackson-databind < 2.11.1.

### What issues does this PR fix or reference?
None

#### Release Notes

#### Documentation
