### PR TITLE
Removed redundant slash that was preventing the copying of the war

### DIFF
--- a/releng/desktop-all/pom.xml
+++ b/releng/desktop-all/pom.xml
@@ -104,7 +104,7 @@
 									<overwrite>true</overwrite>
 									<resources>
 										<resource>
-											<directory>/target</directory>
+											<directory>target</directory>
 											<includes>
 												<include>ROOT.war</include>
 											</includes>


### PR DESCRIPTION
Signed-off-by: Nenchovski <26414287+BorisNen@users.noreply.github.com>

### What does this PR do?
Removes an unnecessary slash for accessing the target directory and copying ROOT.war from desktop-all to CATALINA_HOME. The slash prevented the war copying on MacOS.

### What issues does this PR fix or reference?

None

#### Release Notes

#### Documentation
