### PR TITLE
PostgreCreateViewBuilder & MySQLCreateViewBuilder adapted for xsk hdbview

### DIFF
--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mysql/MySQLCreateBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mysql/MySQLCreateBranchingBuilder.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2010-2020 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * Copyright (c) 2010-2021 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
  *
- * SPDX-FileCopyrightText: 2010-2020 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-FileCopyrightText: 2010-2021 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.dirigible.database.sql.dialects.mysql;
@@ -20,23 +20,31 @@ import org.eclipse.dirigible.database.sql.builders.sequence.CreateSequenceBuilde
  */
 public class MySQLCreateBranchingBuilder extends CreateBranchingBuilder {
 
-	/**
-	 * Instantiates a new mySQL create branching builder.
-	 *
-	 * @param dialect
-	 *            the dialect
-	 */
-	public MySQLCreateBranchingBuilder(ISqlDialect dialect) {
-		super(dialect);
-	}
+    /**
+     * Instantiates a new mySQL create branching builder.
+     *
+     * @param dialect the dialect
+     */
+    public MySQLCreateBranchingBuilder(ISqlDialect dialect) {
+        super(dialect);
+    }
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder#sequence(java.lang.String)
-	 */
-	@Override
-	public CreateSequenceBuilder sequence(String sequence) {
-		return new MySQLCreateSequenceBuilder(this.getDialect(), sequence);
-	}
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder#sequence(java.lang.String)
+     */
+    @Override
+    public CreateSequenceBuilder sequence(String sequence) {
+        return new MySQLCreateSequenceBuilder(this.getDialect(), sequence);
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder#view(java.lang.String)
+     */
+    @Override
+    public MySQLCreateViewBuilder view(String view) {
+        return new MySQLCreateViewBuilder(this.getDialect(), view);
+    }
 
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mysql/MySQLCreateViewBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/mysql/MySQLCreateViewBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2021 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2010-2021 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.mysql;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.view.CreateViewBuilder;
+
+public class MySQLCreateViewBuilder extends CreateViewBuilder {
+
+    private String values = null;
+
+
+    public MySQLCreateViewBuilder(ISqlDialect dialect, String view) {
+        super(dialect, view);
+    }
+
+
+    @Override
+    public MySQLCreateViewBuilder asSelect(String select) {
+
+        if (this.values != null) {
+            throw new IllegalStateException("Create VIEW can use either AS SELECT or AS VALUES, but not both.");
+        }
+        setSelect(this.getSelectProperEscaping(this.getSelectProperEscaping(select)));
+        return this;
+    }
+
+    private String getSelectProperEscaping(String select) {
+        return select.replaceAll("\"", "`");
+    }
+
+
+}


### PR DESCRIPTION
Introduces implementation logic for these [integration tests](https://github.com/SAP/xsk/issues/168).

It appears that for postgresql, only table/view names should be escaped solely. Other properties should not be escaped.
The following sql is a good working example:
```sql
CREATE VIEW "hdbview-itest::SamplePostgreXSClassicViewppp" AS SELECT T1.Column2 FROM "public"."acme.com.test.tables::MY_TABLE1" AS T1 LEFT JOIN "public"."acme.com.test.views::MY_VIEW1" AS T2 ON T1.Column1 = T2.Column1;
```

For MySQL, the proper [escaping symbol](https://github.com/eclipse/dirigible/issues/850) is considered.