### PR TITLE
odata-core java compatibility set to 1.8 to enable more use cases

### DIFF
--- a/modules/odata/odata-core/pom.xml
+++ b/modules/odata/odata-core/pom.xml
@@ -22,7 +22,7 @@
 				<version>${maven.compiler.plugin.version}</version>
 				<configuration>
 					<source>${maven.compiler.source}</source>
-					<target>${maven.compiler.target}</target>
+					<target>1.8</target>
 					<debug>true</debug>
 					<debuglevel>lines,vars,source</debuglevel>
 				</configuration>

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionDelete.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionDelete.java
@@ -13,23 +13,20 @@ package org.eclipse.dirigible.engine.odata2.sql.builder.expression;
 
 import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.fqn;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.olingo.odata2.api.commons.HttpStatusCodes;
 import org.apache.olingo.odata2.api.edm.EdmException;
-import org.apache.olingo.odata2.api.edm.EdmProperty;
 import org.apache.olingo.odata2.api.edm.EdmStructuralType;
-import org.apache.olingo.odata2.api.edm.EdmTypeKind;
-import org.apache.olingo.odata2.api.edm.EdmTyped;
 import org.apache.olingo.odata2.api.exception.ODataException;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.engine.odata2.sql.api.OData2Exception;
-import org.eclipse.dirigible.engine.odata2.sql.builder.EdmUtils;
 import org.eclipse.dirigible.engine.odata2.sql.builder.SQLContext;
 import org.eclipse.dirigible.engine.odata2.sql.builder.SQLQuery;
-import org.eclipse.dirigible.engine.odata2.sql.builder.SQLQuery.EdmTarget;
 
 public final class SQLExpressionDelete implements SQLExpression {
     
@@ -108,17 +105,13 @@ public final class SQLExpressionDelete implements SQLExpression {
     }
 
     private String buildKeys(final SQLContext context) throws EdmException {
-    	StringBuilder deleteQuery = new StringBuilder();
+    	List<String> deleteKeys = new ArrayList<String>();
     	Iterator<Map.Entry<String, Object>> i = keys.entrySet().iterator();
         while (i.hasNext()) {
         	Map.Entry<String, Object> key = i.next();
-        	deleteQuery.append(" " + key.getKey() + " = ? ");
-        	
-            if (i.hasNext()) {
-                deleteQuery.append(", ");
-            }
+        	deleteKeys.add(" " + key.getKey() + " = ? ");
         }
-        return deleteQuery.toString();
+        return deleteKeys.stream().collect(Collectors.joining(","));
     }
     
     public Map<String, Object> getKeys() {

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionInsert.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionInsert.java
@@ -12,10 +12,14 @@
 package org.eclipse.dirigible.engine.odata2.sql.builder.expression;
 
 import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.fqn;
+import static org.eclipse.dirigible.engine.odata2.sql.builder.expression.SQLExpressionUtils.csvInBrackets;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.olingo.odata2.api.commons.HttpStatusCodes;
 import org.apache.olingo.odata2.api.edm.EdmException;
@@ -121,8 +125,7 @@ public final class SQLExpressionInsert implements SQLExpression {
 				break;
 			}
 		}
-
-		into.append(" (").append(buildColumnList(context)).append(") ");
+		into.append(buildColumnList(context));
 
 		return into.toString();
 	}
@@ -134,8 +137,9 @@ public final class SQLExpressionInsert implements SQLExpression {
 
 	private String buildColumnList(final SQLContext context) throws EdmException {
 
-		StringBuilder insert = new StringBuilder();
 		Iterator<Integer> i = columnMapping.keySet().iterator();
+		List<String> columnNames = new ArrayList<>();
+		
 		while (i.hasNext()) {
 			Integer column = i.next();
 			EdmStructuralType type = getTargetType(column);
@@ -147,28 +151,23 @@ public final class SQLExpressionInsert implements SQLExpression {
 						HttpStatusCodes.INTERNAL_SERVER_ERROR);
 			if (p.getType().getKind() == EdmTypeKind.SIMPLE) {
 				if (values.containsKey(p.getName())) {
-					EdmProperty prop = (EdmProperty) p;
-					insert.append(tableColumnForInsert(type, prop));
 					
-					if (i.hasNext()) {
-						insert.append(", ");
-					}
+					EdmProperty prop = (EdmProperty) p;
+					columnNames.add(tableColumnForInsert(type, prop));
 				}
 			} else {
 				throw new IllegalStateException("Unable to handle property " + p);
 			}
 		}
-		return insert.toString();
-
+		return csvInBrackets(columnNames);
 	}
 
-	private Object tableColumnForInsert(final EdmStructuralType type, final EdmProperty prop) throws EdmException {
+	private String tableColumnForInsert(final EdmStructuralType type, final EdmProperty prop) throws EdmException {
 		return query.getSQLTableColumnNoAlias(type, prop);
 	}
 
 	private String buildValues(final SQLContext context) throws EdmException {
-		StringBuilder insert = new StringBuilder();
-		insert.append(" (");
+		List<String> columnValues = new ArrayList<>();
 		Iterator<Integer> i = columnMapping.keySet().iterator();
 		while (i.hasNext()) {
 			Integer column = i.next();
@@ -181,17 +180,13 @@ public final class SQLExpressionInsert implements SQLExpression {
 						HttpStatusCodes.INTERNAL_SERVER_ERROR);
 			if (p.getType().getKind() == EdmTypeKind.SIMPLE) {
 				if (values.containsKey(p.getName())) {
-					insert.append("?");
-					if (i.hasNext()) {
-						insert.append(", ");
-					}
+					columnValues.add("?");
 				}
 			} else {
 				throw new IllegalStateException("Unable to handle property " + p);
 			}
 		}
-		insert.append(" )");
-		return insert.toString();
+		return csvInBrackets(columnValues);
 	}
 
 	public Map<String, Object> getValues() {

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionSelect.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionSelect.java
@@ -12,6 +12,7 @@
 package org.eclipse.dirigible.engine.odata2.sql.builder.expression;
 
 import static java.util.Collections.EMPTY_LIST;
+import static org.eclipse.dirigible.engine.odata2.sql.builder.expression.SQLExpressionUtils.csv;
 import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.fqn;
 import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.hasExpand;
 
@@ -202,7 +203,7 @@ public final class SQLExpressionSelect implements SQLExpression {
     }
 
     private String buildFrom(final SQLContext context) throws EdmException {
-        StringBuilder from = new StringBuilder();
+        List<String> tables = new ArrayList<>();
         Iterator<String> it = query.getTablesAliasesForEntitiesInQuery();
         while (it.hasNext()) {
             String tableAlias = it.next();
@@ -210,20 +211,14 @@ public final class SQLExpressionSelect implements SQLExpression {
             if (isSelectTarget(target)) {
             	boolean caseSensitive = Boolean.parseBoolean(Configuration.get("DIRIGIBLE_DATABASE_NAMES_CASE_SENSITIVE", "false"));
             	if (caseSensitive) {
-            		from.append("\"" + query.getSQLTableName(target) + "\"").append(" AS ").append("\"" + tableAlias + "\"");
+            		tables.add("\"" + query.getSQLTableName(target) + "\"" + " AS " + "\"" + tableAlias + "\"");
             	} else {
-            		from.append(query.getSQLTableName(target)).append(" AS ").append(tableAlias);
+            		tables.add(query.getSQLTableName(target) + " AS " + tableAlias);
             	}
-                if (it.hasNext()) {
-                    from.append(", ");
-                }
-            } else {
-                if (from.indexOf(",") > 0) {
-                    from.delete(from.lastIndexOf(","), from.length());
-                }
+               
             }
         }
-        return from.toString();
+        return csv(tables);
     }
 
     private boolean isSelectTarget(final EdmStructuralType target) {

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionUpdate.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionUpdate.java
@@ -11,11 +11,15 @@
  */
 package org.eclipse.dirigible.engine.odata2.sql.builder.expression;
 
+import static org.eclipse.dirigible.engine.odata2.sql.builder.expression.SQLExpressionUtils.csv;
 import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.fqn;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.olingo.odata2.api.commons.HttpStatusCodes;
 import org.apache.olingo.odata2.api.edm.EdmException;
@@ -135,7 +139,7 @@ public final class SQLExpressionUpdate implements SQLExpression {
 
 	private String buildColumnList(final SQLContext context) throws EdmException {
 
-		StringBuilder update = new StringBuilder();
+		List<String> columns = new ArrayList<String>();
 		Iterator<Integer> i = columnMapping.keySet().iterator();
 		while (i.hasNext()) {
 			Integer column = i.next();
@@ -148,19 +152,15 @@ public final class SQLExpressionUpdate implements SQLExpression {
 						HttpStatusCodes.INTERNAL_SERVER_ERROR);
 			if (p.getType().getKind() == EdmTypeKind.SIMPLE) {
 				if (values.containsKey(p.getName()) && !keys.containsKey(p.getName())) {
+					
 					EdmProperty prop = (EdmProperty) p;
-					update.append(tableColumnForUpdate(type, prop) + " = ?");
-					if (i.hasNext()) {
-						update.append(", ");
-					}
+					columns.add(tableColumnForUpdate(type, prop) + " = ?");
 				}
-				
 			} else {
 				throw new IllegalStateException("Unable to handle property " + p);
 			}
-			
 		}
-		return update.toString();
+		return csv(columns);
 
 	}
 
@@ -177,17 +177,13 @@ public final class SQLExpressionUpdate implements SQLExpression {
 	}
 
 	private String buildKeys(final SQLContext context) throws EdmException {
-		StringBuilder updateQuery = new StringBuilder();
+		List<String> updates = new ArrayList<>();
 		Iterator<Map.Entry<String, Object>> i = keys.entrySet().iterator();
 		while (i.hasNext()) {
 			Map.Entry<String, Object> key = i.next();
-			updateQuery.append(" " + key.getKey() + " = ? ");
-
-			if (i.hasNext()) {
-				updateQuery.append(", ");
-			}
+			updates.add(" " + key.getKey() + " = ? ");
 		}
-		return updateQuery.toString();
+		return csv(updates);
 	}
 
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionUtils.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/expression/SQLExpressionUtils.java
@@ -16,6 +16,7 @@ import static org.eclipse.dirigible.engine.odata2.sql.builder.EdmUtils.evaluateD
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.olingo.odata2.api.edm.EdmException;
 import org.apache.olingo.odata2.api.edm.EdmProperty;
@@ -74,4 +75,14 @@ public final class SQLExpressionUtils {
             return new SQLExpressionWhere();
         }
     }
+    
+
+	public static String csvInBrackets(List<String> columnValues) {
+		return columnValues.stream().collect(Collectors.joining( ",", "(", ")"));
+	}
+	
+	public static String csv(List<String> values) {
+		return values.stream().collect(Collectors.joining(","));
+	}
+
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?
increases the JDK compatibility of odata-core-module


### What issues does this PR fix or reference?
Fix a bug with wrong SQL generation on update/create of odata2 entities
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Documentation
<!-- Please add a matching PR to [the docs repo](https://github.com/dirigible-io/dirigible-io.github.io) and link that PR to this issue.
Both will be merged at the same time. -->
