### PR TITLE
odata load artifacts for a specific schema

### DIFF
--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DBMetadataUtil.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DBMetadataUtil.java
@@ -17,6 +17,7 @@ import org.eclipse.dirigible.database.ds.model.IDataStructureModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableColumnModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableRelationModel;
+import org.eclipse.dirigible.database.sql.ISqlKeywords;
 import org.eclipse.dirigible.engine.odata2.definition.ODataProperty;
 
 import javax.inject.Inject;
@@ -215,6 +216,27 @@ public class DBMetadataUtil {
         }
         while (tables.next()) {
             tableMetadata.setTableType(tables.getString("TABLE_TYPE"));
+        }
+    }
+
+    /**
+     * Find schema of a given artifact name.
+     * The searchable artifacts are TABLE, VIEW, CALC_VIEW
+     */
+    public String getOdataArtifactTypeSchema( String artifactName) throws SQLException {
+        return getArtifactSchema(artifactName, new String[]{ISqlKeywords.METADATA_TABLE, ISqlKeywords.METADATA_VIEW, ISqlKeywords.METADATA_CALC_VIEW});
+    }
+
+    public String getArtifactSchema( String artifactName, String[] types) throws SQLException {
+        try (Connection connection = dataSource.getConnection()) {
+            DatabaseMetaData databaseMetadata = connection.getMetaData();
+            ResultSet rs = databaseMetadata.getTables(connection.getCatalog(), null, artifactName, types);
+            if (rs.next()) {
+                return rs.getString("TABLE_SCHEM");
+            }
+            return null;
+        } catch (SQLException e) {
+            throw e;
         }
     }
 

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
@@ -50,7 +50,7 @@ public class OData2ODataMTransformer {
 
             boolean isPretty = Boolean.parseBoolean(Configuration.get(DBMetadataUtil.DIRIGIBLE_GENERATE_PRETTY_NAMES, "true"));
 
-            PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(entity.getTable());
+            PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(entity.getTable(), dbMetadataUtil.getOdataArtifactTypeSchema(entity.getTable()));
             List<PersistenceTableColumnModel> idColumns = tableMetadata.getColumns().stream().filter(PersistenceTableColumnModel::isPrimaryKey).collect(Collectors.toList());
 
             if (tableMetadata.getTableType() == null || (idColumns.isEmpty() && ISqlKeywords.METADATA_TABLE.equals(tableMetadata.getTableType()))) {
@@ -154,15 +154,14 @@ public class OData2ODataMTransformer {
         return null;
     }
 
-
-
     private void validateAssociationProperties(ODataAssociationDefinition association, ODataDefinition model) throws SQLException {
         validateAssociationProperty(association.getFrom(), model);
         validateAssociationProperty(association.getTo(), model);
     }
 
     private void validateAssociationProperty(ODataAssociationEndDefinition assEndDefinition, ODataDefinition model) throws SQLException {
-        PersistenceTableModel dbTable = dbMetadataUtil.getTableMetadata(ODataMetadataUtil.getTableNameByEntity(model, assEndDefinition.getEntity()));
+        String tableName = ODataMetadataUtil.getTableNameByEntity(model, assEndDefinition.getEntity());
+        PersistenceTableModel dbTable = dbMetadataUtil.getTableMetadata(tableName, dbMetadataUtil.getOdataArtifactTypeSchema(tableName));
         ArrayList<String> invalidProps = new ArrayList<>();
         assEndDefinition.getProperty().forEach(assProp -> {
             List<PersistenceTableColumnModel> consistentProps = dbTable.getColumns().stream().filter(prop -> prop.getName().equals(assProp)).collect(Collectors.toList());

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
@@ -48,7 +48,7 @@ public class OData2ODataXTransformer {
         StringBuilder entitySets = new StringBuilder();
         StringBuilder associationsSets = new StringBuilder();
         for (ODataEntityDefinition entity : model.getEntities()) {
-            PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(entity.getTable());
+            PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(entity.getTable(),dbMetadataUtil.getOdataArtifactTypeSchema(entity.getTable()));
             List<PersistenceTableColumnModel> idColumns = tableMetadata.getColumns().stream().filter(PersistenceTableColumnModel::isPrimaryKey).collect(Collectors.toList());
 
             if (tableMetadata.getTableType() == null || (idColumns.isEmpty() && ISqlKeywords.METADATA_TABLE.equals(tableMetadata.getTableType()))) {

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
@@ -15,7 +15,6 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableColumnModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableRelationModel;
-import org.eclipse.dirigible.database.sql.ISqlKeywords;
 import org.eclipse.dirigible.engine.odata2.definition.ODataDefinition;
 import org.eclipse.dirigible.engine.odata2.definition.ODataDefinitionFactoryTest;
 import org.eclipse.dirigible.engine.odata2.definition.factory.ODataDefinitionFactory;
@@ -53,13 +52,13 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("Id", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("Customer", "Edm.String", false);
         PersistenceTableModel model = new PersistenceTableModel("ORDERS", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("ORDERS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ORDERS", null)).thenReturn(model);
 
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("Id", "Edm.Int32", true);
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("OrderId", "Edm.Int32", false);
         PersistenceTableRelationModel rel = new PersistenceTableRelationModel("ITEMS", "ORDERS", "OrderId", "Id", "fkName", "PRIMARY_KEY_8B");
         model = new PersistenceTableModel("ITEMS", Arrays.asList(column3, column4), Collections.singletonList(rel));
-        when(dbMetadataUtil.getTableMetadata("ITEMS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ITEMS", null)).thenReturn(model);
 
         String entityOrder = "{\n" +
                 "\t\"edmType\": \"OrderType\",\n" +
@@ -98,13 +97,13 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("ID", "Edm.Int32", true);
         PersistenceTableColumnModel column8 = new PersistenceTableColumnModel("FK_PHONE", "Edm.Int32", false);
         PersistenceTableRelationModel relPhone = new PersistenceTableRelationModel("ADDRESS", "PHONES", "FK_PHONE", "ID", "CONSTRAINT_8C9F7", "CONSTRAINT_INDEX_E67");
         model = new PersistenceTableModel("ADDRESS", Arrays.asList(column7, column8), Collections.singletonList(relPhone));
-        when(dbMetadataUtil.getTableMetadata("ADDRESS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ADDRESS", null)).thenReturn(model);
 
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
@@ -112,7 +111,7 @@ public class OData2ODataMTransformerTest {
         PersistenceTableRelationModel rel = new PersistenceTableRelationModel("PHONES", "EMPLOYEES", "FK_COMPANY_ID", "COMPANY_ID", "CONSTRAINT_8C", "CONSTRAINT_INDEX_4");
         PersistenceTableRelationModel rel2 = new PersistenceTableRelationModel("PHONES", "EMPLOYEES", "FK_EMPLOYEE_NUMBER", "EMPLOYEE_NUMBER", "CONSTRAINT_8C9", "CONSTRAINT_INDEX_43");
         model = new PersistenceTableModel("PHONES", Arrays.asList(column3, column4, column5), Arrays.asList(rel, rel2));
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entityEmployee = "{\n" +
                 "\t\"edmType\": \"employeeType\",\n" +
@@ -172,18 +171,18 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("ID", "Edm.Int32", true);
         PersistenceTableColumnModel column8 = new PersistenceTableColumnModel("FK_PHONE", "Edm.Int32", false);
         model = new PersistenceTableModel("ADDRESS", Arrays.asList(column7, column8), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("ADDRESS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ADDRESS", null)).thenReturn(model);
 
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
         model = new PersistenceTableModel("PHONES", Arrays.asList(column3, column4, column5), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entityEmployee = "{\n" +
                 "\t\"edmType\": \"employeeType\",\n" +
@@ -243,13 +242,13 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("ID", "Edm.Int32", true);
         PersistenceTableColumnModel column8 = new PersistenceTableColumnModel("FK_PHONE", "Edm.Int32", false);
         PersistenceTableRelationModel relPhone = new PersistenceTableRelationModel("ADDRESS", "PHONES", "FK_PHONE", "ID", "CONSTRAINT_8C9F7", "CONSTRAINT_INDEX_E67");
         model = new PersistenceTableModel("ADDRESS", Arrays.asList(column7, column8), Collections.singletonList(relPhone));
-        when(dbMetadataUtil.getTableMetadata("ADDRESS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ADDRESS", null)).thenReturn(model);
 
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
@@ -257,7 +256,7 @@ public class OData2ODataMTransformerTest {
         PersistenceTableRelationModel rel = new PersistenceTableRelationModel("PHONES", "EMPLOYEES", "FK_COMPANY_ID", "COMPANY_ID", "CONSTRAINT_8C", "CONSTRAINT_INDEX_4");
         PersistenceTableRelationModel rel2 = new PersistenceTableRelationModel("PHONES", "EMPLOYEES", "FK_EMPLOYEE_NUMBER", "EMPLOYEE_NUMBER", "CONSTRAINT_8C9", "CONSTRAINT_INDEX_43");
         model = new PersistenceTableModel("PHONES", Arrays.asList(column3, column4, column5), Arrays.asList(rel, rel2));
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entityEmployee = "{\n" +
                 "\t\"edmType\": \"employeeType\",\n" +
@@ -296,13 +295,13 @@ public class OData2ODataMTransformerTest {
         String employee = IOUtils.toString(ODataDefinitionFactoryTest.class.getResourceAsStream("/transformers/EmployeeCompositePrimaryKey.odata"), Charset.defaultCharset());
         ODataDefinition definition = ODataDefinitionFactory.parseOData("/transformers/EmployeeCompositePrimaryKey.odata", employee);
 
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(new PersistenceTableModel("PHONES", new ArrayList<>(), new ArrayList<>()));
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(new PersistenceTableModel("EMPLOYEES", new ArrayList<>(), new ArrayList<>()));
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(new PersistenceTableModel("PHONES", new ArrayList<>(), new ArrayList<>()));
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(new PersistenceTableModel("EMPLOYEES", new ArrayList<>(), new ArrayList<>()));
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("ID", "Edm.Int32", true);
         PersistenceTableColumnModel column8 = new PersistenceTableColumnModel("FK_PHONE", "Edm.Int32", false);
         PersistenceTableRelationModel relPhone = new PersistenceTableRelationModel("ADDRESS", "PHONES", "FK_PHONE_WRONG", "ID", "CONSTRAINT_8C9F7", "CONSTRAINT_INDEX_E67");
         PersistenceTableModel model = new PersistenceTableModel("ADDRESS", Arrays.asList(column7, column8), Collections.singletonList(relPhone));
-        when(dbMetadataUtil.getTableMetadata("ADDRESS")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("ADDRESS", null)).thenReturn(model);
 
         odata2ODataMTransformer.transform(definition);
     }
@@ -316,13 +315,13 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("ORDER_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column6 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
         model = new PersistenceTableModel("PHONES", Arrays.asList(column5, column6, column7), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entityEmployee = "{\n" +
                 "\t\"edmType\": \"employeeType\",\n" +
@@ -356,13 +355,13 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column3 = new PersistenceTableColumnModel("ORDER_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES",null)).thenReturn(model);
 
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column6 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
         model = new PersistenceTableModel("PHONES", Arrays.asList(column5, column6, column7), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entityEmployee = "{\n" +
                 "\t\"edmType\": \"employeeType\",\n" +
@@ -395,7 +394,7 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         odata2ODataMTransformer.transform(definition);
     }
@@ -408,7 +407,7 @@ public class OData2ODataMTransformerTest {
         PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("COMPANY_ID", "Edm.Int32", true);
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         odata2ODataMTransformer.transform(definition);
     }

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformerTest.java
@@ -52,7 +52,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         odata2ODataXTransformer.transform(definition);
     }
@@ -68,14 +68,14 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column6 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
         model = new PersistenceTableModel("PHONES", Arrays.asList(column5, column6, column7), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -113,7 +113,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         odata2ODataXTransformer.transform(definition);
     }
@@ -137,14 +137,14 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("EMPLOYEE_NUMBER", "Edm.Int32", true);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("NUMBER", "Edm.Int32", true);
         PersistenceTableColumnModel column6 = new PersistenceTableColumnModel("FK_COMPANY_ID", "Edm.Int32", false);
         PersistenceTableColumnModel column7 = new PersistenceTableColumnModel("FK_EMPLOYEE_NUMBER", "Edm.Int32", false);
         model = new PersistenceTableModel("PHONES", Arrays.asList(column5, column6, column7), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_TABLE);
-        when(dbMetadataUtil.getTableMetadata("PHONES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("PHONES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -193,7 +193,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -227,7 +227,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -265,7 +265,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -298,7 +298,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column5 = new PersistenceTableColumnModel("ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4, column5), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -334,7 +334,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
@@ -367,7 +367,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_VIEW);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
 
         odata2ODataXTransformer.transform(definition);
     }
@@ -383,7 +383,7 @@ public class OData2ODataXTransformerTest {
         PersistenceTableColumnModel column4 = new PersistenceTableColumnModel("ADDRESS_ID", "Edm.Int32", false);
         PersistenceTableModel model = new PersistenceTableModel("EMPLOYEES", Arrays.asList(column1, column2, column3, column4), new ArrayList<>());
         model.setTableType(ISqlKeywords.METADATA_SYNONYM);
-        when(dbMetadataUtil.getTableMetadata("EMPLOYEES")).thenReturn(model);
+        when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(model);
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +
                 "</Schema>\n";


### PR DESCRIPTION
Continue on issue: https://github.com/eclipse/dirigible/issues/958
When there is a synonyms with the same names as the entities, they need to be search from the DB by the scheme.