### PR TITLE
Upload API - getting multipart request headers.

### DIFF
--- a/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpUploadFacade.java
+++ b/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpUploadFacade.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.dirigible.api.v3.http;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -63,6 +65,20 @@ public class HttpUploadFacade implements IScriptingFacade {
 		}
 		List<FileItem> fileItems = servletFileUpload.parseRequest(request);
 		return fileItems;
+	}
+
+	/**
+	 * Converts header names iterator object to list object.
+	 *
+	 * @param headerNames header names iterator
+	 * @return A list of String elements which represent the name of the multipart request headers.
+	 */
+	public static final List<String> headerNamesToList(Iterator<String> headerNames) {
+		List<String> headerNamesList = new ArrayList<String>();
+		while (headerNames.hasNext()) {
+			headerNamesList.add(headerNames.next());
+		}
+		return headerNamesList;
 	}
 
 }

--- a/api/api-javascript/api-http/src/main/resources/http/v4/upload.js
+++ b/api/api-javascript/api-http/src/main/resources/http/v4/upload.js
@@ -108,7 +108,7 @@ function FileItem() {
 function Headers() {
 
 	this.getHeaderNames = function() {
-		return this.native.getHeaderNames();
+		return org.eclipse.dirigible.api.v3.http.HttpUploadFacade.headerNamesToList(this.native.getHeaderNames());
 	};
 
 	this.getHeader = function(headerName) {

--- a/api/api-javascript/api-http/src/main/resources/http/v4/upload.js
+++ b/api/api-javascript/api-http/src/main/resources/http/v4/upload.js
@@ -11,7 +11,7 @@
  */
 /**
  * API v4 Upload
- * 
+ *
  * Note: This module is supported only with the Mozilla Rhino engine
  */
 
@@ -34,7 +34,7 @@ exports.parseRequest = function() {
  * FileItems object
  */
 function FileItems() {
-	
+
 	this.get = function(index) {
 		var fileItem = new FileItem();
 		var native = this.native.get(index);
@@ -51,7 +51,7 @@ function FileItems() {
  * FileItem object
  */
 function FileItem() {
-	
+
 	this.getInputStream = function() {
 		var inputStream = new streams.InputStream();
 		var native = this.native.getInputStream();
@@ -62,35 +62,57 @@ function FileItem() {
 	this.getContentType = function() {
 		return this.native.getContentType();
 	};
-	
+
 	this.getName = function() {
 		return this.native.getName();
 	};
-	
+
 	this.getSize = function() {
 		return this.native.getSize();
 	};
-	
+
 	this.getBytes = function() {
 		var data = this.native.get();
 		return bytes.toJavaScriptBytes(data);
 	};
-	
+
 	this.getBytesNative = function() {
 		var data = this.native.get();
 		return data;
 	};
-	
+
 	this.getText = function() {
 		return this.native.getString();
 	};
-	
+
 	this.isFormField = function() {
 		return this.native.isFormField();
 	};
-	
+
 	this.getFieldName = function() {
 		return this.native.getFieldName();
 	};
-	
+
+	this.getHeaders = function() {
+		var headers = new Headers();
+		var native = this.native.getHeaders();
+		headers.native = native;
+		return headers;
+	};
+
 }
+
+/**
+ * Headers object
+ */
+function Headers() {
+
+	this.getHeaderNames = function() {
+		return this.native.getHeaderNames();
+	};
+
+	this.getHeader = function(headerName) {
+		return this.native.getHeader(headerName);
+	}
+};
+


### PR DESCRIPTION
### What does this PR do?
Adds a method to the `HttpUploadFacade` that transforms header names iterator into header names list. Also adds methods to the `upload` js api to get the multipart child requests headers.

### What issues does this PR fix or reference?
This PR is related to an issue from the XSK project SAP/xsk#22

#### Documentation
https://www.dirigible.io/api/http/upload/
