### PR TITLE
Reduce RabbitMQ's image version to 3.8.19 for testcontainers compatib…

### DIFF
--- a/ext/ext-api/api-rabbitmq/src/test/java/org/eclipse/dirigible/api/rabbitmq/RabbitMQFacadeTest.java
+++ b/ext/ext-api/api-rabbitmq/src/test/java/org/eclipse/dirigible/api/rabbitmq/RabbitMQFacadeTest.java
@@ -30,7 +30,7 @@ public class RabbitMQFacadeTest {
 	
 	@Before
 	public void setUp() {
-		RabbitMQContainer rabbit = new RabbitMQContainer("rabbitmq:alpine");
+		RabbitMQContainer rabbit = new RabbitMQContainer("rabbitmq:3.8.19-alpine");
 		rabbit.start();
 		
 		String host = rabbit.getHost();


### PR DESCRIPTION
### What does this PR do?
RabbitMQ's official image on docker hub introduces changes that break the compatibility with testcontainers.
Therefore the docker image version is hardcoded to 3.8.19.

### What issues does this PR fix or reference?
Resolves #1013 
