### PR TITLE
fix: updates jstree due to windows build errors

### DIFF
--- a/ide/ui/ide-database/src/main/resources/ide-database/explorer/explorer.html
+++ b/ide/ui/ide-database/src/main/resources/ide-database/explorer/explorer.html
@@ -31,7 +31,7 @@
 	<script src="/webjars/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 	
 	<link href="../../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Custom IDE Styles -->
 	<link type="text/css" rel="stylesheet" href="../../../../../services/v4/js/theme/resources.js/ide.css" />

--- a/ide/ui/ide-debugger/src/main/resources/ide-debugger/views/debugger/index.html
+++ b/ide/ui/ide-debugger/src/main/resources/ide-debugger/views/debugger/index.html
@@ -20,7 +20,7 @@
 	
 	<!-- jsTree -->
 	<link href="../../../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-git/src/main/resources/ide-git/git/git.html
+++ b/ide/ui/ide-git/src/main/resources/ide-git/git/git.html
@@ -30,7 +30,7 @@
 	
 	<!-- jsTree -->
 	<link href="../../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-git/src/main/resources/ide-git/git/history.html
+++ b/ide/ui/ide-git/src/main/resources/ide-git/git/history.html
@@ -31,7 +31,7 @@
 
 	<!-- jsTree -->
 	<link href="../../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-git/src/main/resources/ide-git/git/staging.html
+++ b/ide/ui/ide-git/src/main/resources/ide-git/git/staging.html
@@ -30,7 +30,7 @@
 	
 	<!-- jsTree -->
 	<link href="../../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-registry/src/main/resources/ide-registry/registry.html
+++ b/ide/ui/ide-registry/src/main/resources/ide-registry/registry.html
@@ -29,7 +29,7 @@
 
 	<!-- jsTree -->
 	<link href="../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-repository/src/main/resources/ide-repository/repository.html
+++ b/ide/ui/ide-repository/src/main/resources/ide-repository/repository.html
@@ -29,7 +29,7 @@
 
 	<!-- jsTree -->
 	<link href="../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-workspace/src/main/resources/ide-workspace/search.html
+++ b/ide/ui/ide-workspace/src/main/resources/ide-workspace/search.html
@@ -30,7 +30,7 @@
 
 	<!-- jsTree -->
 	<link href="../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/ide/ui/ide-workspace/src/main/resources/ide-workspace/workspace.html
+++ b/ide/ui/ide-workspace/src/main/resources/ide-workspace/workspace.html
@@ -30,7 +30,7 @@
 
 	<!-- jsTree -->
 	<link href="../../../../services/v4/js/theme/resources.js/jstree.css" rel="stylesheet">
-	<script src="/webjars/jstree/3.3.4/dist/jstree.min.js"></script>
+	<script src="/webjars/jstree/3.3.5/dist/jstree.min.js"></script>
 	
 	<!-- Twitter Bootstrap with Theme Support -->
 	<link rel="stylesheet" href="../../../../services/v4/js/theme/resources.js/bootstrap.min.css">

--- a/resources/resources-all/pom.xml
+++ b/resources/resources-all/pom.xml
@@ -108,9 +108,9 @@
 		    <version>1.12.1</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.webjars.npm</groupId>
+		    <groupId>org.webjars</groupId>
 		    <artifactId>jstree</artifactId>
-		    <version>3.3.4</version>
+		    <version>3.3.5</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.webjars</groupId>


### PR DESCRIPTION
Currently, with jstree 3.3.4 the build fails on windows with the following error:
```
[ERROR] Failed to execute goal on project dirigible-resources: Could not resolve dependencies for project org.eclipse.dirigible:dirigible-resources:jar:5.12.9: Failed to collect dependencies at org.webjars.npm:jstree:jar:3.3.4 -> org.webjars.npm:jquery:jar:3.3.0 -> org.webjars.npm:npm:jar:4.4.1 -> org.webjars.npm:npm-registry-client:jar:7.4.6 -> org.webjars.npm:semver:jar:2- >=2.2.1,[3,4),[4,5),[5,6): Failed to read artifact descriptor for org.webjars.npm:semver:jar:2- >=2.2.1,[3,4),[4,5),[5,6): Could not transfer artifact org.webjars.npm:semver:pom:2- >=2.2.1,[3,4),[4,5),[5,6) from/to mvnrepository (https://repo1.maven.org/maven2): C:\Users\IVO\.m2\repository\org\webjars\npm\semver\2- >=2.2.1,[3,4),[4,5),[5,6)\semver-2- >=2.2.1,[3,4),[4,5),[5,6).pom.part.lock (The filename, directory name, or volume label syntax is incorrect) -> [Help 1]
```
This is due to an attempt to create a folder name with the symbol '>', which is not valid in windows.