### PR TITLE
ci: run nightly build on windows and linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,10 @@ on:
   - cron: "0 22 * * *"
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -14,5 +17,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 13
-    - name: Maven Build
+    - name: Maven Build if Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: mvn clean install
+    - name: Maven Build if not Windows
+      if: ${{ matrix.os != 'windows-latest' }}
       run: mvn clean install -Drabbitmq-test -Dredis-test -Delastic-test -Detcd-test


### PR DESCRIPTION
Currently, we run the nightly build only on Ubuntu. This PR adds a step to build on Windows but without the Dirigible tests using TestContainers as there is not Docker on the Windows VM.