### PR TITLE
Increased PROBLEM_EXPECTED size for parser error messages

### DIFF
--- a/modules/core/core-problems/src/main/java/org/eclipse/dirigible/core/problems/model/ProblemsModel.java
+++ b/modules/core/core-problems/src/main/java/org/eclipse/dirigible/core/problems/model/ProblemsModel.java
@@ -45,7 +45,7 @@ public class ProblemsModel {
     @Column(name = "PROBLEM_CAUSE", columnDefinition = "VARCHAR", nullable = false, length = 255)
     private String cause;
 
-    @Column(name = "PROBLEM_EXPECTED", columnDefinition = "VARCHAR", nullable = false, length = 96)
+    @Column(name = "PROBLEM_EXPECTED", columnDefinition = "VARCHAR", nullable = false, length = 255)
     private String expected;
 
     @Column(name = "PROBLEM_CREATED_AT", columnDefinition = "TIMESTAMP", nullable = false)


### PR DESCRIPTION
The column size needs to be increased since parser error messages could be longer than expected.