### PR TITLE
Added dirigible editor header for workspace file upload

### DIFF
--- a/ide/ui/ide-workspace/src/main/resources/META-INF/dirigible/ide-workspace/workspace.js
+++ b/ide/ui/ide-workspace/src/main/resources/META-INF/dirigible/ide-workspace/workspace.js
@@ -194,6 +194,7 @@ WorkspaceService.prototype.uploadFile = function (name, path, node) {
         method: 'POST',
         url: url,
         headers: {
+            'Dirigible-Editor': 'Editor',
             'Content-Type': 'application/octet-stream',
             'Content-Transfer-Encoding': 'base64'
         },


### PR DESCRIPTION
Added `Dirigible-Editor: Workspace` header to the file upload of the ide workspace as `.xsodata` artifact couldn't be uploaded.