### PR TITLE
Remove encapsulate generated sequence name

### DIFF
--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2NextValueSequenceBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/h2/H2NextValueSequenceBuilder.java
@@ -41,7 +41,7 @@ public class H2NextValueSequenceBuilder extends NextValueSequenceBuilder {
 	 */
 	@Override
 	public String generate() {
-		String sequenceName = (isCaseSensitive()) ? encapsulate(this.getSequence()) : this.getSequence();
+		String sequenceName = this.getSequence();
 		String sql = format(PATTERN_SELECT_NEXT_VAL_SEQUENCE, sequenceName);
 		return sql;
 	}


### PR DESCRIPTION
This PR fixes NextValueSequenceBuilder for the H2 database by removing encapsulate on generated sequence id name.
Resolves #1312 
