### PR TITLE
Allow xsodata entity definition use synonym

### DIFF
--- a/modules/engines/engine-odata/src/test/resources/transformers/EmployeeSynonym.odata
+++ b/modules/engines/engine-odata/src/test/resources/transformers/EmployeeSynonym.odata
@@ -1,0 +1,10 @@
+{
+	"namespace": "np",
+	"entities": [
+		{
+			"name": "employee",
+			"alias": "Employees",
+			"table": "EmployeesView"
+		}
+	]
+}


### PR DESCRIPTION
Resolves #1295 

`OData2ODataXTransformer` check if the defined entity is synonym and in case it is uses the target object of the synonym for further processing. 