### PR TITLE
[DO NOT MERGE] Synonym target objects search now works only with a given schema

### DIFF
--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DBMetadataUtil.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DBMetadataUtil.java
@@ -248,12 +248,13 @@ public class DBMetadataUtil {
         }
     }
 
-    public HashMap<String, String> getSynonymTargetObjectMetadata(String synonymName) throws SQLException {
+    public HashMap<String, String> getSynonymTargetObjectMetadata(String synonymName, String schemaName) throws SQLException {
         HashMap<String, String> targetObjectMetadata = new HashMap<>();
 
         try (Connection connection = dataSource.getConnection()) {
-            PreparedStatement prepareStatement = connection.prepareStatement("SELECT * FROM \"SYS\".\"SYNONYMS\" WHERE \"SYNONYM_NAME\" = ?");
+            PreparedStatement prepareStatement = connection.prepareStatement("SELECT * FROM \"SYS\".\"SYNONYMS\" WHERE \"SYNONYM_NAME\" = ? AND \"SCHEMA_NAME\" = ?");
             prepareStatement.setString(1, synonymName);
+            prepareStatement.setString(2, schemaName);
 
             try (ResultSet resultSet = prepareStatement.executeQuery()) {
                 if (resultSet.next()) {

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
@@ -53,7 +53,7 @@ public class OData2ODataXTransformer {
             PersistenceTableModel tableMetadata = dbMetadataUtil.getTableMetadata(entity.getTable(), dbMetadataUtil.getOdataArtifactTypeSchema(entity.getTable()));
 
             if (ISqlKeywords.METADATA_SYNONYM.equals(tableMetadata.getTableType())) {
-                HashMap<String, String> targetObjectMetadata = dbMetadataUtil.getSynonymTargetObjectMetadata(tableMetadata.getTableName());
+                HashMap<String, String> targetObjectMetadata = dbMetadataUtil.getSynonymTargetObjectMetadata(tableMetadata.getTableName(), tableMetadata.getSchemaName());
 
                 if (targetObjectMetadata.isEmpty()) {
                     logger.error("Failed to get details for synonym - " + tableMetadata.getTableName());

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformerTest.java
@@ -403,7 +403,7 @@ public class OData2ODataXTransformerTest extends AbstractDirigibleTest {
 
         when(dbMetadataUtil.getTableMetadata("EMPLOYEES", null)).thenReturn(viewModel);
         when(dbMetadataUtil.getTableMetadata("EmployeesView", null)).thenReturn(synonymModel);
-        when(dbMetadataUtil.getSynonymTargetObjectMetadata(synonymModel.getTableName())).thenReturn(synonymTargetObjectMetadata);
+        when(dbMetadataUtil.getSynonymTargetObjectMetadata(synonymModel.getTableName(), null)).thenReturn(synonymTargetObjectMetadata);
 
         String entitySchema = "<Schema Namespace=\"np\"\n" +
                 "\txmlns=\"http://schemas.microsoft.com/ado/2008/09/edm\">\n" +


### PR DESCRIPTION
Resolves #1296 

Changelog:
getSynonymTargetObjectMetadata inside DBMetadataUtil will search by synonym name and schema name