### PR TITLE
overloading applyArtefactState required by XSK

### DIFF
--- a/modules/core/core-scheduler/src/main/java/org/eclipse/dirigible/core/scheduler/api/AbstractSynchronizer.java
+++ b/modules/core/core-scheduler/src/main/java/org/eclipse/dirigible/core/scheduler/api/AbstractSynchronizer.java
@@ -11,12 +11,6 @@
  */
 package org.eclipse.dirigible.core.scheduler.api;
 
-import static java.text.MessageFormat.format;
-
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.eclipse.dirigible.commons.api.artefacts.IArtefactDefinition;
 import org.eclipse.dirigible.commons.config.Configuration;
 import org.eclipse.dirigible.commons.config.StaticObjects;
@@ -28,6 +22,12 @@ import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.text.MessageFormat.format;
 
 /**
  * The AbstractSynchronizer.
@@ -248,15 +248,30 @@ public abstract class AbstractSynchronizer implements ISynchronizer {
 			String artefactType = type.getId();
 			String artefactState = state.getValue();
 			String artefactStateMessage = type.getStateMessage(state, message);
-			try {
-				if (synchronizerCoreService.existsSynchronizerStateArtefact(artefactName, artefactLocation)) {
-					synchronizerCoreService.updateSynchronizerStateArtefact(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
-				} else {
-					synchronizerCoreService.createSynchronizerStateArtefact(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
-				}
-			} catch (SchedulerException e) {
-				logger.error(e.getMessage(), e);
+			checkSynchronizerStateArtefactCurrentState(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
+		} else {
+			logger.error("Can't apply artefact state to \"null\" artefact object.");
+		}
+	}
+
+	private void checkSynchronizerStateArtefactCurrentState(String artefactName, String artefactLocation, String artefactType, String artefactState, String artefactStateMessage) {
+		try {
+			if (synchronizerCoreService.existsSynchronizerStateArtefact(artefactName, artefactLocation)) {
+				synchronizerCoreService.updateSynchronizerStateArtefact(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
+			} else {
+				synchronizerCoreService.createSynchronizerStateArtefact(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
 			}
+		} catch (SchedulerException e) {
+			logger.error(e.getMessage(), e);
+		}
+	}
+
+	public void applyArtefactState(String artefactName, String artefactLocation, AbstractSynchronizationArtefactType type, ISynchronizerArtefactType.ArtefactState state, String message) {
+		if (artefactName != null && artefactLocation != null && type != null && state != null) {
+			String artefactType = type.getId();
+			String artefactState = state.getValue();
+			String artefactStateMessage = type.getStateMessage(state, message);
+			checkSynchronizerStateArtefactCurrentState(artefactName, artefactLocation, artefactType, artefactState, artefactStateMessage);
 		} else {
 			logger.error("Can't apply artefact state to \"null\" artefact object.");
 		}

--- a/modules/database/database-data-structures/src/main/java/org/eclipse/dirigible/database/ds/artefacts/SchemaSynchronizationArtefactType.java
+++ b/modules/database/database-data-structures/src/main/java/org/eclipse/dirigible/database/ds/artefacts/SchemaSynchronizationArtefactType.java
@@ -32,7 +32,7 @@ public class SchemaSynchronizationArtefactType extends AbstractSynchronizationAr
 		case SUCCESSFUL_CREATE:
 			return "Processing for create database schema layout was successful";
 		case SUCCESSFUL_CREATE_UPDATE:
-			return "Processing Create or update table was successful";
+			return "Processing Create or update database schema layout was successful";
 		case SUCCESSFUL_UPDATE:
 			return "Processing for update database schema layout was successful";
 		default:


### PR DESCRIPTION
Signed-off-by: LiliyaLazarova <liliya.nikolaeva.lazarova@gmail.com>

<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?
Method "applyArtefactState" overloading in AbstractSynchronizer class

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Documentation
<!-- Please add a matching PR to [the docs repo](https://github.com/dirigible-io/dirigible-io.github.io) and link that PR to this issue.
Both will be merged at the same time. -->
