### PR TITLE
feat: add initial code for watchable typescript compilation

### DIFF
--- a/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/compilation/TypeScriptCompilerFacade.java
+++ b/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/compilation/TypeScriptCompilerFacade.java
@@ -13,38 +13,132 @@ package org.eclipse.dirigible.engine.js.graalvm.processor.compilation;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.dirigible.repository.api.CaffeineRepositoryCache;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toList;
 
 class TypeScriptCompilerFacade {
+    private static final String typescriptPrettyErrorRegex = ":\\d+:\\d+ \\- error TS\\d+: ";
+    private static final String typescriptErrorRegex = "\\(\\d+,\\d+\\): error TS\\d+: ";
+    private static final String compilationCompleteWithErrorRegex = "Found [^0][0-9]* error[s]?\\. Watching for file changes\\.";
+    private static final String compilationCompleteRegex = "(Compilation complete\\. Watching for file changes\\.|Found \\d+ error[s]?\\. Watching for file changes\\.)";
+    private static final String compilationStartedRegex = "(Starting compilation in watch mode\\.\\.\\.|File change detected\\. Starting incremental compilation\\.\\.\\.)";
+    private static final Map<String, Process> TYPESCRIPT_COMPILER_WATCHER_PROCESSES = new HashMap<>();
 
-    void handleTypeScriptFile(String relativeProjectFilePath) throws IOException, InterruptedException {
-        String projectPath = "/Users/xxxxxx/target/dirigible/repository/root/registry/public/";
-        String filePath = projectPath + relativeProjectFilePath;
-        String fileDirectoryPath = StringUtils.substringBeforeLast(filePath, "/");
+    private final ExecutorService executor = Executors.newCachedThreadPool();
 
-        createIndexDtsFile(fileDirectoryPath);
-        compileTypeScriptFile(filePath);
-        invalidateCache(fileDirectoryPath);
+    Future<TypeScriptCompilationState> compileProject(String projectPath) {
+        CompletableFuture<TypeScriptCompilationState> compilationStateFuture = new CompletableFuture<>();
+        Consumer<TypeScriptCompilationState> onCompilationStateChange = compilationStateFuture::complete;
+        compileProject(projectPath, onCompilationStateChange);
+        return compilationStateFuture;
     }
 
-    private void createIndexDtsFile(String fileDirectoryPath) throws IOException {
+    void compileProject(String projectPath, Consumer<TypeScriptCompilationState> onCompilationStateChange) {
+        Runnable r = () -> {
+            try {
+                prepareTypeScriptProject(projectPath);
+                startWatcherIfNotStarted(projectPath, onCompilationStateChange);
+            } catch (IOException e) {
+                e.printStackTrace();
+                onCompilationStateChange.accept(TypeScriptCompilationState.FINISHED_WITH_ERROR);
+            }
+        };
+
+        executor.submit(r);
+    }
+
+    private void prepareTypeScriptProject(String fileDirectoryPath) throws IOException {
+        createIndexDtsFileIfNotCreated(fileDirectoryPath);
+        createTsConfigFileIfNotCreated(fileDirectoryPath);
+    }
+
+    private void startWatcherIfNotStarted(String projectPath, Consumer<TypeScriptCompilationState> onCompilationStateChange) throws IOException {
+        if (TYPESCRIPT_COMPILER_WATCHER_PROCESSES.containsKey(projectPath)) {
+            return;
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder("tsc", "index.d.ts", "-w");
+        processBuilder.redirectErrorStream(true);
+        processBuilder.directory(new File(projectPath));
+
+        Process process = processBuilder.start();
+        TYPESCRIPT_COMPILER_WATCHER_PROCESSES.put(projectPath, process);
+        InputStream stdout = process.getInputStream();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(stdout));
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            InternalTypeScriptCompilationState compilationState = tryExtractCompilationState(line);
+            if (InternalTypeScriptCompilationState.FINISHED_SUCCESSFULLY.equals(compilationState)) {
+                invalidateCache(projectPath);
+                onCompilationStateChange.accept(TypeScriptCompilationState.FINISHED_SUCCESSFULLY);
+            } else if (InternalTypeScriptCompilationState.FINISHED_WITH_ERROR.equals(compilationState)) {
+                onCompilationStateChange.accept(TypeScriptCompilationState.FINISHED_WITH_ERROR);
+            }
+        }
+    }
+
+    private InternalTypeScriptCompilationState tryExtractCompilationState(String input) {
+        boolean compilationStarted = input.matches(compilationStartedRegex);
+
+        boolean compilationError = input.matches(compilationCompleteWithErrorRegex) ||
+                input.matches(typescriptErrorRegex) ||
+                input.matches(typescriptPrettyErrorRegex);
+
+        boolean compilationComplete = input.matches(compilationCompleteRegex);
+
+        if (compilationComplete) {
+            return compilationError ? InternalTypeScriptCompilationState.FINISHED_WITH_ERROR : InternalTypeScriptCompilationState.FINISHED_SUCCESSFULLY;
+        } else if (compilationStarted) {
+            return InternalTypeScriptCompilationState.STARTED;
+        } else {
+            return InternalTypeScriptCompilationState.UNKNOWN;
+        }
+    }
+
+    private void createIndexDtsFileIfNotCreated(String fileDirectoryPath) throws IOException {
         File indexDtsFile = new File(fileDirectoryPath + "/index.d.ts");
-        FileUtils.writeStringToFile(indexDtsFile, "declare const require: any;", StandardCharsets.UTF_8);
+        if (indexDtsFile.exists()) {
+            return;
+        }
+
+        String defaultContent = "declare const require: any;";
+        FileUtils.writeStringToFile(indexDtsFile, defaultContent, StandardCharsets.UTF_8);
     }
 
-    private void compileTypeScriptFile(String filePath) throws InterruptedException, IOException {
-        Runtime runtime = Runtime.getRuntime();
-        String[] command = new String[]{"tsc index.d.ts ", filePath};
-        Process pr = runtime.exec(command);
-        pr.waitFor();
+    private void createTsConfigFileIfNotCreated(String fileDirectoryPath) throws IOException {
+        File tsConfigFile = new File(fileDirectoryPath + "/tsconfig.json");
+        if (tsConfigFile.exists()) {
+            return;
+        }
+
+        String defaultContent = "{\n" +
+                "  \"compilerOptions\": {\n" +
+                "    \"target\": \"ES6\",\n" +
+                "    \"module\": \"ES2020\",\n" +
+                "    \"esModuleInterop\": true,\n" +
+                "    \"forceConsistentCasingInFileNames\": true,\n" +
+                "    \"strict\": true,\n" +
+                "    \"skipLibCheck\": true\n" +
+                "  }\n" +
+                "}\n";
+        FileUtils.writeStringToFile(tsConfigFile, defaultContent, StandardCharsets.UTF_8);
     }
 
     private void invalidateCache(String fileDirectoryPath) {
@@ -54,5 +148,18 @@ class TypeScriptCompilerFacade {
                 .collect(toList());
 
         cache.invalidateAll(keys);
+    }
+
+    enum InternalTypeScriptCompilationState {
+        STARTED,
+        FINISHED_WITH_ERROR,
+        FINISHED_SUCCESSFULLY,
+        COMPILER_EXITED,
+        UNKNOWN
+    }
+
+    enum TypeScriptCompilationState {
+        FINISHED_SUCCESSFULLY,
+        FINISHED_WITH_ERROR
     }
 }


### PR DESCRIPTION
This PR adds initial support for a watchable TypeScript compiler. 
The provided API uses the `tsc` compiler executable and invokes it with the `-w` flag. This flag starts the compiler in watch mode and this gives us the opportunity to incrementally compile users' projects instead of running the `tsc` compiler on each file save. This improves compilation speed a lot.
Although this approach would be great for development purposes, maybe we still need to hook in the publishing synchronizer in order to guarantee the project is cleanly compiled. Some other things that need to be done are keeping better track of spawned `tsc` compilers, their compilation results, improving the generated `index.d.ts` to reuse the Dirigible `.d.ts` files, and also testing if the generated `tsconfig.json` is the most optimal one.