### PR TITLE
fix: reconfigure logback.xml file appenders path

### DIFF
--- a/releng/anonymous-all/src/main/resources/logback.xml
+++ b/releng/anonymous-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/anonymous-runtime/src/main/resources/logback.xml
+++ b/releng/anonymous-runtime/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/desktop-all/src/main/resources/logback.xml
+++ b/releng/desktop-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/openshift-all/src/main/resources/logback.xml
+++ b/releng/openshift-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-all-ephemeral/src/main/resources/logback.xml
+++ b/releng/sap-all-ephemeral/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-all/src/main/resources/logback.xml
+++ b/releng/sap-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-cf-base/src/main/resources/logback.xml
+++ b/releng/sap-cf-base/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-cms/src/main/resources/logback.xml
+++ b/releng/sap-cms/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-kyma-base/src/main/resources/logback.xml
+++ b/releng/sap-kyma-base/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/sap-runtime-ephemeral/src/main/resources/logback.xml
+++ b/releng/sap-runtime-ephemeral/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-all/src/main/resources/logback.xml
+++ b/releng/server-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-keycloak-all/src/main/resources/logback.xml
+++ b/releng/server-keycloak-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-minimal/src/main/resources/logback.xml
+++ b/releng/server-minimal/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-oauth/src/main/resources/logback.xml
+++ b/releng/server-oauth/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-runtime-keycloak/src/main/resources/logback.xml
+++ b/releng/server-runtime-keycloak/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/server-runtime/src/main/resources/logback.xml
+++ b/releng/server-runtime/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>

--- a/releng/trial-all/src/main/resources/logback.xml
+++ b/releng/trial-all/src/main/resources/logback.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration packagingData="true">
 
+	<!-- 
+		Try to set LOGS_DIR for the file appenders to the environment variables 
+		"DIRIGIBLE_LOGS_DIR -> CATALINA_BASE ->  CATALINA_HOME" in this order 
+		or use ".." if none of the environment variables exist
+	-->
+	<property name="LOGS_DIR" value="${DIRIGIBLE_LOGS_DIR:-${CATALINA_BASE:-${CATALINA_HOME:-..}}}" />
+
 	<contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
 		<resetJUL>true</resetJUL>
 	</contextListener>
@@ -17,21 +24,21 @@
 	</appender>
 	
 	<appender name="FILE_CORE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-core-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-core-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_APPS" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-apps-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-apps-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>
 	</appender>
 	
 	<appender name="FILE_BASE" class="ch.qos.logback.core.FileAppender">
-	    <file>../logs/dirigible-base-${date}.log</file>
+	    <file>${LOGS_DIR}/logs/dirigible-base-${date}.log</file>
 	    <encoder>
 	      <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
 	    </encoder>


### PR DESCRIPTION
Fixes: https://github.com/eclipse/dirigible/issues/651

This PR configures the logback.xml files to use the following environment variables for logs output:

1. DIRIGIBLE_LOGS_DIR
2. CATALINA_BASE
3. CATALINA_HOME

The variable to be used, if several of those exist, would be the first one found in the same order as in the list above.
If none of those variables exist, logs would be output the same way as before this PR - relative to the folder where the tomcat was started.