### PR TITLE
feat: keep parent stack objects in new stacks

### DIFF
--- a/modules/commons/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
+++ b/modules/commons/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
@@ -27,32 +27,32 @@ public class ThreadContextFacade {
 
 	private static final Logger logger = LoggerFactory.getLogger(ThreadContextFacade.class);
 
-	private static final ThreadLocal<Map<String, Map<String, Object>>> STACKED_CONTEXT = new ThreadLocal<Map<String, Map<String, Object>>>();
+	private static final ThreadLocal<Map<Integer, Map<String, Object>>> STACKED_CONTEXT = new ThreadLocal<>();
 
-	private static final ThreadLocal<Map<String, Map<String, AutoCloseable>>> STACKED_CLOSEABLES = new ThreadLocal<Map<String, Map<String, AutoCloseable>>>();
+	private static final ThreadLocal<Map<Integer, Map<String, AutoCloseable>>> STACKED_CLOSEABLES = new ThreadLocal<>();
 
 	private static final AtomicLong UUID_GENERATOR = new AtomicLong(Long.MIN_VALUE);
 	
-	private static final ThreadLocal<Integer> STACK_ID = new ThreadLocal<Integer>();
+	private static final ThreadLocal<Integer> STACK_ID = new ThreadLocal<>();
 	
 	/**
 	 * Initializes the context. This has to be called at the very first (as possible) place at the service entry point
 	 *
 	 */
-	public static final void setUp() {
+	public static void setUp() {
 		if (STACKED_CONTEXT.get() == null || STACKED_CONTEXT.get().size() == 0) {
-			STACKED_CONTEXT.set(new HashMap<String, Map<String, Object>>());
+			STACKED_CONTEXT.set(new HashMap<>());
 		}
 		if (STACKED_CLOSEABLES.get() == null || STACKED_CLOSEABLES.get().size() == 0) {
-			STACKED_CLOSEABLES.set(new HashMap<String, Map<String, AutoCloseable>>());
+			STACKED_CLOSEABLES.set(new HashMap<>());
 		}
 		if (STACK_ID.get() == null) {
 			STACK_ID.set(0);
 		} else {
 			STACK_ID.set(STACK_ID.get() + 1);
 		}
-		STACKED_CONTEXT.get().put(STACK_ID.get() + "", new HashMap<String, Object>());
-		STACKED_CLOSEABLES.get().put(STACK_ID.get() + "", new HashMap<String, AutoCloseable>());
+		STACKED_CONTEXT.get().put(STACK_ID.get(), new HashMap<>());
+		STACKED_CLOSEABLES.get().put(STACK_ID.get(), new HashMap<>());
 		
 		logger.trace("Scripting context {} has been set up", Thread.currentThread().hashCode());
 	}
@@ -61,16 +61,16 @@ public class ThreadContextFacade {
 	 * IMPORTANT! This have to be added at the finally block to clean up objects after the execution of the service.
 	 *
 	 */
-	public static final void tearDown() {
+	public static void tearDown() {
 		if (STACK_ID.get() == null) {
 			return;
 		}
 		int stackId = STACK_ID.get();
 		if (STACKED_CONTEXT.get() != null && STACKED_CONTEXT.get().size() > 0) {
-			STACKED_CONTEXT.get().get(STACK_ID.get() + "").clear();
+			STACKED_CONTEXT.get().get(STACK_ID.get()).clear();
 		}
 		if (STACKED_CLOSEABLES.get() != null && STACKED_CLOSEABLES.get().size() > 0) {
-			Map<String, AutoCloseable> CLOSEABLES = STACKED_CLOSEABLES.get().get(STACK_ID.get() + "");
+			Map<String, AutoCloseable> CLOSEABLES = STACKED_CLOSEABLES.get().get(STACK_ID.get());
 			for (Entry<String, AutoCloseable> closeable : CLOSEABLES.entrySet()) {
 				try {
 					logger.error("Object of type {} from the context {} has not been closed properly.", closeable.getValue().getClass().getCanonicalName(), Thread.currentThread().hashCode());
@@ -79,7 +79,7 @@ public class ThreadContextFacade {
 					logger.error(e.getMessage(), e);
 				}
 			}
-			STACKED_CLOSEABLES.get().get(STACK_ID.get() + "").clear();
+			STACKED_CLOSEABLES.get().get(STACK_ID.get()).clear();
 		}
 		if (stackId == 0) {
 			STACKED_CONTEXT.remove();
@@ -99,9 +99,11 @@ public class ThreadContextFacade {
 	 * @throws ContextException
 	 *             in case of an error
 	 */
-	public static final Object get(String key) throws ContextException {
+	public static Object get(String key) throws ContextException {
 		checkContext();
-		return STACKED_CONTEXT.get().get(STACK_ID.get() + "").get(key);
+		Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
+		Map<String, Object> currentStack = stackedContext.get(STACK_ID.get());
+		return currentStack.get(key);
 	}
 
 	/**
@@ -113,7 +115,7 @@ public class ThreadContextFacade {
 	 * @throws ContextException
 	 *             in case of an error
 	 */
-	public static final String set(Object value) throws ContextException {
+	public static String set(Object value) throws ContextException {
 		final String uuid = generateObjectId();
 		set(uuid, value);
 		return uuid;
@@ -131,9 +133,9 @@ public class ThreadContextFacade {
 	 * @throws ContextException
 	 *             in case of an error
 	 */
-	public static final void set(String key, Object value) throws ContextException {
+	public static void set(String key, Object value) throws ContextException {
 		checkContext();
-		STACKED_CONTEXT.get().get(STACK_ID.get() + "").put(key, value);
+		STACKED_CONTEXT.get().get(STACK_ID.get()).put(key, value);
 		logger.trace("Context object has been added to {} with key {}", Thread.currentThread().hashCode(), key);
 	}
 
@@ -145,10 +147,10 @@ public class ThreadContextFacade {
 	 * @throws ContextException
 	 *             in case of an error
 	 */
-	public static final void remove(String key) throws ContextException {
+	public static void remove(String key) throws ContextException {
 		checkContext();
-		STACKED_CONTEXT.get().get(STACK_ID.get() + "").remove(key);
-		logger.trace("Context object has been removed - key {}", Thread.currentThread().hashCode(), key);
+		STACKED_CONTEXT.get().get(STACK_ID.get()).remove(key);
+		logger.trace("Context object has been removed - key {}", key);
 	}
 
 	/**
@@ -186,9 +188,9 @@ public class ThreadContextFacade {
 	 * 
 	 * @param closeable the closeable object
 	 */
-	public static final void addCloseable(AutoCloseable closeable) {
+	public static void addCloseable(AutoCloseable closeable) {
 		if (STACKED_CLOSEABLES.get() != null) {
-			STACKED_CLOSEABLES.get().get(STACK_ID.get() + "").put(STACK_ID.get() + "_" + closeable.hashCode(), closeable);
+			STACKED_CLOSEABLES.get().get(STACK_ID.get()).put(STACK_ID.get() + "_" + closeable.hashCode(), closeable);
 			logger.trace("Closeable object has been added to {} with hash {}", Thread.currentThread().hashCode(), closeable.hashCode());
 		}
 	}
@@ -198,10 +200,10 @@ public class ThreadContextFacade {
 	 *
 	 * @param closeable the closeable object
 	 */
-	public static final void removeCloseable(AutoCloseable closeable) {
+	public static void removeCloseable(AutoCloseable closeable) {
 		if (STACKED_CLOSEABLES.get() != null) {
-			STACKED_CLOSEABLES.get().get(STACK_ID.get() + "").remove(STACK_ID.get() + "_" + closeable.hashCode());
-			logger.trace("Closeable object has been removed - hash {}", Thread.currentThread().hashCode(), closeable.hashCode());
+			STACKED_CLOSEABLES.get().get(STACK_ID.get()).remove(STACK_ID.get() + "_" + closeable.hashCode());
+			logger.trace("Closeable object has been removed - hash {}", closeable.hashCode());
 		}
 	}
 }

--- a/modules/commons/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
+++ b/modules/commons/commons-api/src/main/java/org/eclipse/dirigible/commons/api/context/ThreadContextFacade.java
@@ -27,213 +27,203 @@ import org.slf4j.LoggerFactory;
  */
 public class ThreadContextFacade {
 
-	private static final Logger logger = LoggerFactory.getLogger(ThreadContextFacade.class);
+    private static final Logger logger = LoggerFactory.getLogger(ThreadContextFacade.class);
 
-	private static final ThreadLocal<Map<Integer, Map<String, Object>>> STACKED_CONTEXT = new ThreadLocal<>();
+    private static final ThreadLocal<Map<Integer, Map<String, Object>>> STACKED_CONTEXT = new ThreadLocal<>();
 
-	private static final ThreadLocal<Map<Integer, Map<String, AutoCloseable>>> STACKED_CLOSEABLES = new ThreadLocal<>();
+    private static final ThreadLocal<Map<Integer, Map<String, AutoCloseable>>> STACKED_CLOSEABLES = new ThreadLocal<>();
 
-	private static final AtomicLong UUID_GENERATOR = new AtomicLong(Long.MIN_VALUE);
-	
-	private static final ThreadLocal<Integer> STACK_ID = new ThreadLocal<>();
-	
-	/**
-	 * Initializes the context. This has to be called at the very first (as possible) place at the service entry point
-	 *
-	 */
-	public static void setUp() {
-		if (stackedContextIsEmpty()) {
-			STACKED_CONTEXT.set(new HashMap<>());
-		}
-		if (stackedCloseablesIsEmpty()) {
-			STACKED_CLOSEABLES.set(new HashMap<>());
-		}
+    private static final AtomicLong UUID_GENERATOR = new AtomicLong(Long.MIN_VALUE);
 
-		Integer currentStackId = STACK_ID.get();
-		if (currentStackId == null) {
-			STACK_ID.set(0);
-		} else {
-			STACK_ID.set(currentStackId + 1);
+    private static final ThreadLocal<Integer> STACK_ID = new ThreadLocal<>();
 
-		}
+    /**
+     * Initializes the context. This has to be called at the very first (as possible) place at the service entry point
+     */
+    public static void setUp() {
+        if (stackedContextIsEmpty()) {
+            STACKED_CONTEXT.set(new HashMap<>());
+        }
+        if (stackedCloseablesIsEmpty()) {
+            STACKED_CLOSEABLES.set(new HashMap<>());
+        }
 
-		STACKED_CONTEXT.get().put(STACK_ID.get(), collectParentObjects());
-		STACKED_CLOSEABLES.get().put(STACK_ID.get(), new HashMap<>());
-		
-		logger.trace("Scripting context {} has been set up", Thread.currentThread().hashCode());
-	}
+        Integer currentStackId = STACK_ID.get();
+        if (currentStackId == null) {
+            STACK_ID.set(0);
+        } else {
+            STACK_ID.set(currentStackId + 1);
 
-	private static Map<String, Object> collectParentObjects() {
-		Map<String, Object> allParentObjects = new HashMap<>();
+        }
 
-		for (int parentStackId = STACK_ID.get() - 1; parentStackId >= 0; parentStackId -= 1) {
-			Map<String, Object> parentStackObjects = STACKED_CONTEXT.get().get(parentStackId);
-			allParentObjects.putAll(parentStackObjects);
-		}
+        STACKED_CONTEXT.get().put(STACK_ID.get(), collectParentObjects());
+        STACKED_CLOSEABLES.get().put(STACK_ID.get(), new HashMap<>());
 
-		return allParentObjects;
-	}
+        logger.trace("Scripting context {} has been set up", Thread.currentThread().hashCode());
+    }
 
-	/**
-	 * IMPORTANT! This have to be added at the finally block to clean up objects after the execution of the service.
-	 *
-	 */
-	public static void tearDown() {
+    private static Map<String, Object> collectParentObjects() {
+        Map<String, Object> allParentObjects = new HashMap<>();
+
+        for (int parentStackId = STACK_ID.get() - 1; parentStackId >= 0; parentStackId -= 1) {
+            Map<String, Object> parentStackObjects = STACKED_CONTEXT.get().get(parentStackId);
+            allParentObjects.putAll(parentStackObjects);
+        }
+
+        return allParentObjects;
+    }
+
+    /**
+     * IMPORTANT! This have to be added at the finally block to clean up objects after the execution of the service.
+     */
+    public static void tearDown() {
         Integer stackId = STACK_ID.get();
-		if (stackId == null) {
+        if (stackId == null) {
             return;
         }
 
-		if (stackedContextIsNotEmpty()) {
-			STACKED_CONTEXT.get().get(stackId).clear();
-		}
+        if (stackedContextIsNotEmpty()) {
+            STACKED_CONTEXT.get().get(stackId).clear();
+        }
 
-		if (stackedCloseablesIsNotEmpty()) {
-			Map<String, AutoCloseable> CLOSEABLES = STACKED_CLOSEABLES.get().get(stackId);
-			for (Entry<String, AutoCloseable> closeable : CLOSEABLES.entrySet()) {
-				try {
-					logger.error("Object of type {} from the context {} has not been closed properly.", closeable.getValue().getClass().getCanonicalName(), Thread.currentThread().hashCode());
-					closeable.getValue().close();
-				} catch (Exception e) {
-					logger.error(e.getMessage(), e);
-				}
-			}
-			STACKED_CLOSEABLES.get().get(stackId).clear();
-		}
+        if (stackedCloseablesIsNotEmpty()) {
+            Map<String, AutoCloseable> CLOSEABLES = STACKED_CLOSEABLES.get().get(stackId);
+            for (Entry<String, AutoCloseable> closeable : CLOSEABLES.entrySet()) {
+                try {
+                    logger.error("Object of type {} from the context {} has not been closed properly.", closeable.getValue().getClass().getCanonicalName(), Thread.currentThread().hashCode());
+                    closeable.getValue().close();
+                } catch (Exception e) {
+                    logger.error(e.getMessage(), e);
+                }
+            }
+            STACKED_CLOSEABLES.get().get(stackId).clear();
+        }
 
-		if (stackId == 0) {
-			STACKED_CONTEXT.remove();
-			STACKED_CLOSEABLES.remove();
-		}
-		STACK_ID.set(stackId - 1);
-		
-		logger.trace("Scripting context {} has been torn down", Thread.currentThread().hashCode());
-	}
+        if (stackId == 0) {
+            STACKED_CONTEXT.remove();
+            STACKED_CLOSEABLES.remove();
+        }
+        STACK_ID.set(stackId - 1);
 
-	/**
-	 * Get a context scripting object.
-	 *
-	 * @param key
-	 *            the key
-	 * @return the value by this key
-	 * @throws ContextException
-	 *             in case of an error
-	 */
-	public static Object get(String key) throws ContextException {
-		checkContext();
-		Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
-		Map<String, Object> currentStack = stackedContext.get(STACK_ID.get());
-		return currentStack.get(key);
-	}
+        logger.trace("Scripting context {} has been torn down", Thread.currentThread().hashCode());
+    }
 
-	/**
-	 * Set a context scripting object.
-	 *
-	 * @param value
-	 *            the value
-	 * @return the UUID of the object
-	 * @throws ContextException
-	 *             in case of an error
-	 */
-	public static String set(Object value) throws ContextException {
-		final String uuid = generateObjectId();
-		set(uuid, value);
-		return uuid;
-	}
+    /**
+     * Get a context scripting object.
+     *
+     * @param key the key
+     * @return the value by this key
+     * @throws ContextException in case of an error
+     */
+    public static Object get(String key) throws ContextException {
+        checkContext();
+        Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
+        Map<String, Object> currentStack = stackedContext.get(STACK_ID.get());
+        return currentStack.get(key);
+    }
 
-	/**
-	 * Set a context scripting object. If object with
-	 * with this key exists, it will be replaced with
-	 * the new object
-	 *
-	 * @param key
-	 *            the key
-	 * @param value
-	 *            the value
-	 * @throws ContextException
-	 *             in case of an error
-	 */
-	public static void set(String key, Object value) throws ContextException {
-		checkContext();
-		STACKED_CONTEXT.get().get(STACK_ID.get()).put(key, value);
-		logger.trace("Context object has been added to {} with key {}", Thread.currentThread().hashCode(), key);
-	}
+    /**
+     * Set a context scripting object.
+     *
+     * @param value the value
+     * @return the UUID of the object
+     * @throws ContextException in case of an error
+     */
+    public static String set(Object value) throws ContextException {
+        final String uuid = generateObjectId();
+        set(uuid, value);
+        return uuid;
+    }
 
-	/**
-	 * Remove a context scripting object.
-	 *
-	 * @param key the key
-	 * @throws ContextException in case of an error
-	 */
-	public static void remove(String key) throws ContextException {
-		checkContext();
-		STACKED_CONTEXT.get().get(STACK_ID.get()).remove(key);
-		logger.trace("Context object has been removed - key {}", key);
-	}
+    /**
+     * Set a context scripting object. If object with
+     * with this key exists, it will be replaced with
+     * the new object
+     *
+     * @param key   the key
+     * @param value the value
+     * @throws ContextException in case of an error
+     */
+    public static void set(String key, Object value) throws ContextException {
+        checkContext();
+        STACKED_CONTEXT.get().get(STACK_ID.get()).put(key, value);
+        logger.trace("Context object has been added to {} with key {}", Thread.currentThread().hashCode(), key);
+    }
+
+    /**
+     * Remove a context scripting object.
+     *
+     * @param key the key
+     * @throws ContextException in case of an error
+     */
+    public static void remove(String key) throws ContextException {
+        checkContext();
+        STACKED_CONTEXT.get().get(STACK_ID.get()).remove(key);
+        logger.trace("Context object has been removed - key {}", key);
+    }
 
 
-	/**
-	 * Check context.
-	 *
-	 * @throws ContextException
-	 *             the context exception
-	 */
-	private static void checkContext() throws ContextException {
-		if (STACKED_CONTEXT.get() == null) {
-			throw new ContextException("Context has not been initialized");
-		}
-	}
+    /**
+     * Check context.
+     *
+     * @throws ContextException the context exception
+     */
+    private static void checkContext() throws ContextException {
+        if (STACKED_CONTEXT.get() == null) {
+            throw new ContextException("Context has not been initialized");
+        }
+    }
 
-	/**
-	 * Check whether the facade is valid.
-	 *
-	 * @return yes, if it is valid
-	 */
-	public static boolean isValid() {
-		return (STACKED_CONTEXT.get() != null);
-	}
-	
-	/**
-	 * Generate object id.
-	 *
-	 * @return the string
-	 */
-	private static String generateObjectId() {
-		return Long.toString(UUID_GENERATOR.incrementAndGet(), Character.MAX_RADIX);
-	}
-	
-	/**
-	 * Add a closeable object to the map
-	 * 
-	 * @param closeable the closeable object
-	 */
-	public static void addCloseable(AutoCloseable closeable) {
-		if (STACKED_CLOSEABLES.get() != null) {
-			STACKED_CLOSEABLES.get().get(STACK_ID.get()).put(STACK_ID.get() + "_" + closeable.hashCode(), closeable);
-			logger.trace("Closeable object has been added to {} with hash {}", Thread.currentThread().hashCode(), closeable.hashCode());
-		}
-	}
-	
-	/**
-	 * Remove a closeable object.
-	 *
-	 * @param closeable the closeable object
-	 */
-	public static void removeCloseable(AutoCloseable closeable) {
-		if (STACKED_CLOSEABLES.get() != null) {
-			STACKED_CLOSEABLES.get().get(STACK_ID.get()).remove(STACK_ID.get() + "_" + closeable.hashCode());
-			logger.trace("Closeable object has been removed - hash {}", closeable.hashCode());
-		}
-	}
+    /**
+     * Check whether the facade is valid.
+     *
+     * @return yes, if it is valid
+     */
+    public static boolean isValid() {
+        return (STACKED_CONTEXT.get() != null);
+    }
+
+    /**
+     * Generate object id.
+     *
+     * @return the string
+     */
+    private static String generateObjectId() {
+        return Long.toString(UUID_GENERATOR.incrementAndGet(), Character.MAX_RADIX);
+    }
+
+    /**
+     * Add a closeable object to the map
+     *
+     * @param closeable the closeable object
+     */
+    public static void addCloseable(AutoCloseable closeable) {
+        if (STACKED_CLOSEABLES.get() != null) {
+            STACKED_CLOSEABLES.get().get(STACK_ID.get()).put(STACK_ID.get() + "_" + closeable.hashCode(), closeable);
+            logger.trace("Closeable object has been added to {} with hash {}", Thread.currentThread().hashCode(), closeable.hashCode());
+        }
+    }
+
+    /**
+     * Remove a closeable object.
+     *
+     * @param closeable the closeable object
+     */
+    public static void removeCloseable(AutoCloseable closeable) {
+        if (STACKED_CLOSEABLES.get() != null) {
+            STACKED_CLOSEABLES.get().get(STACK_ID.get()).remove(STACK_ID.get() + "_" + closeable.hashCode());
+            logger.trace("Closeable object has been removed - hash {}", closeable.hashCode());
+        }
+    }
 
     private static boolean stackedContextIsEmpty() {
         Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
         return stackedContext == null || stackedContext.isEmpty();
     }
 
-	private static boolean stackedContextIsNotEmpty() {
-	    Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
-	    return stackedContext != null && !stackedContext.isEmpty();
+    private static boolean stackedContextIsNotEmpty() {
+        Map<Integer, Map<String, Object>> stackedContext = STACKED_CONTEXT.get();
+        return stackedContext != null && !stackedContext.isEmpty();
     }
 
     private static boolean stackedCloseablesIsEmpty() {


### PR DESCRIPTION
Fixes: https://github.com/eclipse/dirigible/issues/1439

This PR sets newly created stacks to have their parent's stack as their own one in order for the `get` methods to have access to their parent's objects. 

Although this could be implemented by modifying the `get` method to lookup into parent stacks and use a bit less memory, it would be computationally heavier as the `get` methods are called often.