### PR TITLE
Initial support for OData batching

### DIFF
--- a/modules/odata/odata-core-test/src/main/java/org/eclipse/dirigible/engine/odata2/sql/AbstractSQLProcessorTest.java
+++ b/modules/odata/odata-core-test/src/main/java/org/eclipse/dirigible/engine/odata2/sql/AbstractSQLProcessorTest.java
@@ -11,7 +11,9 @@
  */
 package org.eclipse.dirigible.engine.odata2.sql;
 
+import static org.apache.olingo.odata2.api.commons.ODataHttpMethod.GET;
 import static org.easymock.EasyMock.expect;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -21,6 +23,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Map;
 
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
@@ -195,5 +198,16 @@ public abstract class AbstractSQLProcessorTest {
     protected ODataEntry retrieveODataEntry(final Response response, final String entitySetName) throws IOException, ODataException {
         EdmEntitySet entitySet = new EdmImplProv(edm).getDefaultEntityContainer().getEntitySet(entitySetName);
         return OData2TestUtils.retrieveODataEntryFromResponse(response, entitySet);
+    }
+
+    public void assertCarHasPrice(String segment, double expectedPrice) throws IOException, ODataException {
+        Response existingCar = OData2RequestBuilder.createRequest(sf) //
+                .segments(segment) //
+                .accept("application/json").executeRequest(GET);
+
+        assertEquals(200, existingCar.getStatus());
+        ODataEntry resultEntry  = retrieveODataEntry(existingCar, "Cars");
+        Map<String, Object> properties  = resultEntry.getProperties();
+        assertEquals(expectedPrice, properties.get("Price"));
     }
 }

--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/ODataSQLProcessorTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/ODataSQLProcessorTest.java
@@ -12,14 +12,14 @@
 package org.eclipse.dirigible.engine.odata2.sql;
 
 import com.google.gson.Gson;
-
-import liquibase.resource.AbstractResourceAccessor;
-import liquibase.resource.ClassLoaderResourceAccessor;
-
 import org.apache.cxf.helpers.IOUtils;
+import org.apache.olingo.odata2.api.client.batch.*;
+import org.apache.olingo.odata2.api.commons.ODataHttpMethod;
 import org.apache.olingo.odata2.api.ep.entry.ODataEntry;
 import org.apache.olingo.odata2.api.ep.feed.ODataFeed;
 import org.apache.olingo.odata2.api.exception.ODataException;
+import org.apache.olingo.odata2.api.processor.ODataResponse;
+import org.apache.olingo.odata2.core.batch.v2.BatchParser;
 import org.apache.olingo.odata2.core.ep.feed.ODataDeltaFeedImpl;
 import org.eclipse.dirigible.engine.odata2.sql.entities.Address;
 import org.eclipse.dirigible.engine.odata2.sql.entities.Car;
@@ -38,20 +38,17 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.apache.olingo.odata2.api.commons.ODataHttpMethod.*;
 import static org.junit.Assert.*;
 
 public class ODataSQLProcessorTest extends AbstractSQLProcessorTest {
 
-	@Override
-	protected Class<?>[] getODataEntities() {
-		Class<?> [] classes = {Car.class, Driver.class, Owner.class, Address.class};
-		return classes;
-	}
+    @Override
+    protected Class<?>[] getODataEntities() {
+        return new Class<?>[]{Car.class, Driver.class, Owner.class, Address.class};
+    }
 
     @Test
     public void testSQLProcessor() throws Exception {
@@ -760,6 +757,7 @@ public class ODataSQLProcessorTest extends AbstractSQLProcessorTest {
         assertEquals(500, response.getStatus()); //TODO refine the error codes, here it should be a bad request
     }
 
+
     @Test
     public void testOrderByExpandedEntityProperty() throws Exception {
         Response response = OData2RequestBuilder.createRequest(sf) //
@@ -824,6 +822,197 @@ public class ODataSQLProcessorTest extends AbstractSQLProcessorTest {
         assertEquals(1, drivers.size());
         Map<String, Object> firstDriverProperties = drivers.get(0).getProperties();
         assertEquals("Zahari", firstDriverProperties.get("FirstName"));
+
+    }
+
+
+    private String getBoundary(String body) {
+        return body.split("\r\n")[0].substring(2);
+    }
+
+    @Test
+    public void testExecuteMetadataRequestInBatch() throws Exception {
+        List<BatchPart> batch = new ArrayList<>();
+        BatchPart request = BatchQueryPart.method(ODataHttpMethod.GET.name()).uri("$metadata").build();
+        batch.add(request);
+        ODataResponse res = OData2RequestBuilder.createRequest(sf).executeBatchRequest(batch);
+        assertEquals(202, res.getStatus().getStatusCode()); //Accepted
+        String responseEntity = IOUtils.toString(res.getEntityAsStream());
+        String boundary = getBoundary(responseEntity);
+
+        BatchParser parser = new BatchParser("multipart/mixed;boundary=" + boundary, true);
+        List<BatchSingleResponse> responses = parser.parseBatchResponse(new ByteArrayInputStream(responseEntity.getBytes()));
+        for (BatchSingleResponse response : responses) {
+            assertEquals("200", response.getStatusCode());
+            assertEquals("OK", response.getStatusInfo());
+            assertTrue(response.getBody().startsWith("<?xml version='1.0' encoding='UTF-8'?><edmx:Edmx xmlns:edmx=\"http://schemas.microsoft.com/ado/2007/06/edmx\" Version=\"1.0\"><edmx:DataServices"));
+        }
+    }
+
+
+    @Test
+    public void testExecuteMetadataRequestBatchChangeSetTwoUpdates() throws Exception {
+        String content = "{" //
+                + "  \"d\": {" //
+                + "    \"__metadata\": {" //
+                + "      \"type\": \"org.eclipse.dirigible.engine.odata2.sql.entities.Car\"" //
+                + "    }," //
+                + "    \"Id\": \"XXXXXXXXX\"," //
+                + "    \"Price\": 123456789.0" //
+                + " }" + "}";
+
+        List<BatchPart> batch = new ArrayList<>();
+
+        Map<String, String> changeSetHeaders = new HashMap<>();
+        changeSetHeaders.put("content-type", "application/json");
+        changeSetHeaders.put("Accept", "application/json");
+        String body = "/9j/4AAQSkZJRgABAQEBLAEsAAD/4RM0RXhpZgAATU0AKgAAAAgABwESAAMAAAABAAEA";
+        BatchChangeSetPart changeRequest = BatchChangeSetPart.method(PUT.toString())
+                .uri("Cars('639cac17-4cfd-4d94-b5d0-111fd5488423')")
+                .body(content.replaceAll("XXXXXXXXX", "639cac17-4cfd-4d94-b5d0-111fd5488423"))
+                .headers(changeSetHeaders)
+                .contentId("1")
+                .build();
+        BatchChangeSet changeSet = BatchChangeSet.newBuilder().build();
+        changeSet.add(changeRequest);
+
+        changeSetHeaders = new HashMap<>();
+        changeSetHeaders.put("content-type", "application/json;odata=verbose");
+        changeSetHeaders.put("Accept", "application/json");
+        BatchChangeSetPart changeRequest2 = BatchChangeSetPart.method(PUT.toString())
+                .uri("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')")
+                .body(content.replaceAll("XXXXXXXXX", "3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5"))
+                .headers(changeSetHeaders)
+                .contentId("2")
+                .build();
+        changeSet.add(changeRequest2);
+        batch.add(changeSet);
+
+
+        ODataResponse res = OData2RequestBuilder.createRequest(sf).executeBatchRequest(batch);
+        assertEquals(202, res.getStatus().getStatusCode()); //Accepted
+        String responseEntity = IOUtils.toString(res.getEntityAsStream());
+        String boundary = getBoundary(responseEntity);
+
+        BatchParser parser = new BatchParser("multipart/mixed;boundary=" + boundary, true);
+        List<BatchSingleResponse> responses = parser.parseBatchResponse(new ByteArrayInputStream(responseEntity.getBytes()));
+        assertEquals(2, responses.size());
+        for (BatchSingleResponse response : responses) {
+            assertEquals("204", response.getStatusCode());
+            assertEquals("No Content", response.getStatusInfo());
+        }
+        assertCarHasPrice("Cars('639cac17-4cfd-4d94-b5d0-111fd5488423')", 123456789.0d);
+        assertCarHasPrice("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')", 123456789.0d);
+    }
+
+    @Test
+    public void testExecuteMetadataRequestBatchChangeSetRollback() throws Exception {
+        String content = "{" //
+                + "  \"d\": {" //
+                + "    \"__metadata\": {" //
+                + "      \"type\": \"org.eclipse.dirigible.engine.odata2.sql.entities.Car\"" //
+                + "    }," //
+                + "    \"Id\": \"XXXXXXXXX\"," //
+                + "    \"Price\": 123456789.0" //
+                + " }" + "}";
+
+        List<BatchPart> batch = new ArrayList<>();
+
+        Map<String, String> changeSetHeaders = new HashMap<>();
+        changeSetHeaders.put("content-type", "application/json");
+        changeSetHeaders.put("Accept", "application/json");
+        String body = "/9j/4AAQSkZJRgABAQEBLAEsAAD/4RM0RXhpZgAATU0AKgAAAAgABwESAAMAAAABAAEA";
+        BatchChangeSetPart changeRequest = BatchChangeSetPart.method(PUT.toString())
+                .uri("Cars('639cac17-4cfd-4d94-b5d0-111fd5488423')")
+                .body(content.replaceAll("XXXXXXXXX", "639cac17-4cfd-4d94-b5d0-111fd5488423"))
+                .headers(changeSetHeaders)
+                .contentId("1")
+                .build();
+        BatchChangeSet changeSet = BatchChangeSet.newBuilder().build();
+        changeSet.add(changeRequest);
+
+        changeSetHeaders = new HashMap<>();
+        changeSetHeaders.put("content-type", "application/json;odata=verbose");
+        changeSetHeaders.put("Accept", "application/json");
+        BatchChangeSetPart invalidPriceChangeSet = BatchChangeSetPart.method(PUT.toString())
+                .uri("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')")
+                .body(content.replaceAll("123456789.0", "BOOM")//Simulate error by setting invalid price
+                        .replaceAll("XXXXXXXXX", "3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5"))
+                .headers(changeSetHeaders)
+                .contentId("2")
+                .build();
+        changeSet.add(invalidPriceChangeSet);
+        batch.add(changeSet);
+
+
+        ODataResponse res = OData2RequestBuilder.createRequest(sf).executeBatchRequest(batch);
+        assertEquals(202, res.getStatus().getStatusCode()); //Accepted
+        String responseEntity = IOUtils.toString(res.getEntityAsStream());
+        String boundary = getBoundary(responseEntity);
+
+        BatchParser parser = new BatchParser("multipart/mixed;boundary=" + boundary, true);
+        List<BatchSingleResponse> responses = parser.parseBatchResponse(new ByteArrayInputStream(responseEntity.getBytes()));
+        assertEquals(1, responses.size());
+        for (BatchSingleResponse response : responses) {
+            assertEquals("400", response.getStatusCode());
+            assertEquals("Bad Request", response.getStatusInfo());
+        }
+
+        assertCarHasPrice("Cars('639cac17-4cfd-4d94-b5d0-111fd5488423')", 67000.0);
+        assertCarHasPrice("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')", 7000.0);
+    }
+
+    @Test
+    public void testExecuteMetadataRequestBatchChangeSetRollbackAndPut() throws Exception {
+        String content = "{" //
+                + "  \"d\": {" //
+                + "    \"__metadata\": {" //
+                + "      \"type\": \"org.eclipse.dirigible.engine.odata2.sql.entities.Car\"" //
+                + "    }," //
+                + "    \"Id\": \"3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5\"," //
+                + "    \"Price\": 123456789.0" //
+                + " }" + "}";
+
+        List<BatchPart> batch = new ArrayList<>();
+
+        BatchChangeSet changeSet = BatchChangeSet.newBuilder().build();
+
+        Map<String, String> changeSetHeaders = new HashMap<>();
+        changeSetHeaders.put("content-type", "application/json;odata=verbose");
+        changeSetHeaders.put("Accept", "application/json");
+        BatchChangeSetPart invalidPriceChangeSet = BatchChangeSetPart.method(PUT.toString())
+                .uri("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')")
+                .body(content.replaceAll("123456789.0", "BOOM"))//Simulate error by setting invalid price
+                .headers(changeSetHeaders)
+                .contentId("1")
+                .build();
+        changeSet.add(invalidPriceChangeSet);
+        batch.add(changeSet);
+
+
+        ODataResponse res = OData2RequestBuilder.createRequest(sf).executeBatchRequest(batch);
+        assertEquals(202, res.getStatus().getStatusCode()); //Accepted
+        String responseEntity = IOUtils.toString(res.getEntityAsStream());
+        String boundary = getBoundary(responseEntity);
+
+        BatchParser parser = new BatchParser("multipart/mixed;boundary=" + boundary, true);
+        List<BatchSingleResponse> responses = parser.parseBatchResponse(new ByteArrayInputStream(responseEntity.getBytes()));
+        assertEquals(1, responses.size());
+        for (BatchSingleResponse response : responses) {
+            assertEquals("400", response.getStatusCode());
+            assertEquals("Bad Request", response.getStatusInfo());
+        }
+        assertCarHasPrice("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')", 7000.0);
+
+        Response response = modifyingRequestBuilder(sf, content)//
+                .segments("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')") //
+                .accept("application/json")//
+                .content(content)//
+                .param("content-type", "application/json")//
+                .contentSize(content.length()).executeRequest(PUT);
+
+        assertCarHasPrice("Cars('3b1ea3aa-e18a-434b-9d6b-a1044ba8c7e5')", 123456789.0);
+
 
     }
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -11,10 +11,14 @@
  */
 package org.eclipse.dirigible.engine.odata2.sql.processor;
 
+import org.apache.olingo.odata2.api.batch.BatchHandler;
+import org.apache.olingo.odata2.api.batch.BatchRequestPart;
+import org.apache.olingo.odata2.api.batch.BatchResponsePart;
 import org.apache.olingo.odata2.api.commons.HttpStatusCodes;
 import org.apache.olingo.odata2.api.commons.InlineCount;
 import org.apache.olingo.odata2.api.edm.*;
 import org.apache.olingo.odata2.api.ep.EntityProvider;
+import org.apache.olingo.odata2.api.ep.EntityProviderBatchProperties;
 import org.apache.olingo.odata2.api.ep.EntityProviderReadProperties;
 import org.apache.olingo.odata2.api.ep.EntityProviderWriteProperties;
 import org.apache.olingo.odata2.api.ep.entry.ODataEntry;
@@ -23,23 +27,29 @@ import org.apache.olingo.odata2.api.exception.ODataException;
 import org.apache.olingo.odata2.api.exception.ODataNotFoundException;
 import org.apache.olingo.odata2.api.exception.ODataNotImplementedException;
 import org.apache.olingo.odata2.api.processor.ODataContext;
+import org.apache.olingo.odata2.api.processor.ODataRequest;
 import org.apache.olingo.odata2.api.processor.ODataResponse;
 import org.apache.olingo.odata2.api.processor.ODataSingleProcessor;
 import org.apache.olingo.odata2.api.uri.KeyPredicate;
 import org.apache.olingo.odata2.api.uri.NavigationPropertySegment;
+import org.apache.olingo.odata2.api.uri.PathInfo;
 import org.apache.olingo.odata2.api.uri.UriInfo;
 import org.apache.olingo.odata2.api.uri.info.*;
 import org.apache.olingo.odata2.core.uri.KeyPredicateImpl;
 import org.apache.olingo.odata2.core.uri.UriInfoImpl;
-import org.eclipse.dirigible.engine.odata2.sql.api.*;
+import org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler;
+import org.eclipse.dirigible.engine.odata2.sql.api.SQLProcessor;
+import org.eclipse.dirigible.engine.odata2.sql.api.SQLStatement;
+import org.eclipse.dirigible.engine.odata2.sql.api.SQLStatementParam;
 import org.eclipse.dirigible.engine.odata2.sql.builder.*;
 import org.eclipse.dirigible.engine.odata2.sql.clause.SQLSelectClause;
-import org.eclipse.dirigible.engine.odata2.sql.builder.SQLUtils;
 import org.eclipse.dirigible.engine.odata2.sql.utils.OData2ResultSetEntity;
 import org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils;
+import org.eclipse.dirigible.engine.odata2.sql.utils.SingleConnectionDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.sql.DataSource;
 import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -53,586 +63,681 @@ import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.hasExpan
 
 public abstract class AbstractSQLProcessor extends ODataSingleProcessor implements SQLProcessor {
 
-	private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
-	
-	private final OData2EventHandler odata2EventHandler;
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
 
-	public AbstractSQLProcessor() {
-		this.odata2EventHandler = new DummyOData2EventHandler();
-	}
-	
-	public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
-		this.odata2EventHandler = odata2EventHandler;
-	}
+    private final OData2EventHandler odata2EventHandler;
 
-	@Override
-	public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
-		return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
-	}
+    private DataSource dataSource;
 
-	@Override
-	public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
-			throw new ODataNotImplementedException();
-		}
-		try {
-			SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+    public AbstractSQLProcessor() {
+        this.odata2EventHandler = new DummyOData2EventHandler();
+    }
 
-			try (Connection connection = getDataSource().getConnection()) {
-				int count = doCountEntitySet(sqlQuery, connection);
-				return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
-			}
-		} catch (SQLException e) {
-			throw new ODataException(e);
-		}
-	}
+    public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
+        this.odata2EventHandler = odata2EventHandler;
+    }
 
-	@Override
-	public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		LOG.error("readEntityComplexProperty not implemented: {}",uriInfo.toString());
-		throw new ODataException("Not Implemented");
-	}
+    private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
+        Map<String, Object> keyMap = new HashMap<>();
+        for (final KeyPredicate key : keys) {
+            final EdmProperty property = key.getProperty();
+            final EdmSimpleType type = (EdmSimpleType) property.getType();
+            keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
+                    property.getFacets(), type.getDefaultType()));
+        }
+        return keyMap;
+    }
 
-	protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
-		// TODO cache the metadata, because it fires a DB query every time
-		// TODO do we really need to select the entities?
-		String sql = sqlQuery.buildSelect(createSQLContext(connection));
-		try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-			LOG.info(sql);
-			setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				// TODO do we need to assert that resultSet.next() == true and subsequently
-				// resultSet.next() == false here?
-				resultSet.next();
-				return resultSet.getInt(1);
-			}
-		}
-	}
+    @Override
+    public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
+        return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
+    }
 
-	protected SQLContext createSQLContext(final Connection connection) throws SQLException {
-		return new SQLContext(connection.getMetaData(), this.getContext());
-	}
+    @Override
+    public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
+            throw new ODataNotImplementedException();
+        }
+        try {
+            SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
 
-	protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
-			throws SQLException, ODataException {
-		String sql = selectQuery.buildSelect(createSQLContext(connection));
-		LOG.info(sql);
-		PreparedStatement preparedStatement;
-		if (selectQuery.getSelectExpression().getSkip() != SQLSelectClause.NOT_SET) {
-			preparedStatement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-			/*
-			 * Restrict fetch size to prevent OutOfMemoryErrors for huge page sizes. If no
-			 * fetch size is specified, jConnect will fetch all records up to the requested
-			 * page (in case of the last page, this would be the entire result set).
-			 * 
-			 * Internal Incident:
-			 * https://support.wdf.sap.corp/sap/support/message/1780258655
-			 */
+            try (Connection connection = getDataSource().getConnection()) {
+                int count = doCountEntitySet(sqlQuery, connection);
+                return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
+            }
+        } catch (SQLException e) {
+            throw new ODataException(e);
+        }
+    }
 
-			preparedStatement.setFetchSize(SQLQueryBuilder.DEFAULT_SERVER_PAGING_SIZE);
+    @Override
+    public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        LOG.error("readEntityComplexProperty not implemented: {}", uriInfo.toString());
+        throw new ODataException("Not Implemented");
+    }
 
-		} else {
-			preparedStatement = connection.prepareStatement(sql);
-		}
-		setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
-		return preparedStatement;
-	}
+    protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
+        // TODO cache the metadata, because it fires a DB query every time
+        // TODO do we really need to select the entities?
+        String sql = sqlQuery.buildSelect(createSQLContext(connection));
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            LOG.info(sql);
+            setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                // TODO do we need to assert that resultSet.next() == true and subsequently
+                // resultSet.next() == false here?
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
+
+    protected SQLContext createSQLContext(final Connection connection) throws SQLException {
+        return new SQLContext(connection.getMetaData(), this.getContext());
+    }
+
+    protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
+            throws SQLException, ODataException {
+        String sql = selectQuery.buildSelect(createSQLContext(connection));
+        LOG.info(sql);
+        PreparedStatement preparedStatement;
+        if (selectQuery.getSelectExpression().getSkip() != SQLSelectClause.NOT_SET) {
+            preparedStatement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+            /*
+             * Restrict fetch size to prevent OutOfMemoryErrors for huge page sizes. If no
+             * fetch size is specified, jConnect will fetch all records up to the requested
+             * page (in case of the last page, this would be the entire result set).
+             *
+             * Internal Incident:
+             * https://support.wdf.sap.corp/sap/support/message/1780258655
+             */
+
+            preparedStatement.setFetchSize(SQLQueryBuilder.DEFAULT_SERVER_PAGING_SIZE);
+
+        } else {
+            preparedStatement = connection.prepareStatement(sql);
+        }
+        setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
+        return preparedStatement;
+    }
+
+    // TODO add unit tests for the expand functionality
+    @Override
+    public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
+
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        OData2ResultSetEntity resultEntity = null;
+        // TODO change logic to read columns from ResultSet? (key has to be read even if
+        // it is now requested via $select)
+        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    query.setOffset(resultSet);
+                    while (query.next(resultSet)) {
+
+                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+                            resultEntity = new OData2ResultSetEntity(data);
+                        }
+                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+                        if (hasExpand(expandEntities)) {
+                            processExpand(targetEntityType, query, resultSet, resultEntity, expandEntities);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
+    }
+
+    // TODO add unit tests for the expand functionality
+    @Override
+    public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        final InlineCount inlineCountType = uriInfo.getInlineCount();
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+        List<OData2ResultSetEntity> targetEntitiesResult = new ArrayList<>();
+
+        Integer count;
+        String nextLink;
+        try (Connection connection = getDataSource().getConnection()) {
+            if (inlineCountType == InlineCount.ALLPAGES) {
+                SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+                count = doCountEntitySet(countEntitySet, connection); // does not close the connection
+            } else {
+                count = null;
+            }
+            SQLSelectBuilder query;
+            List<String> readIdsForExpand = new ArrayList<>();
+            if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
+                LOG.info("Reading the ids that will be used for $expand");
+                readIdsForExpand = readIdsForExpand(uriInfo);
+                LOG.info("Using IDs for $expand: {}", readIdsForExpand);
+            }
+            query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
+
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    query.setOffset(resultSet);
+                    OData2ResultSetEntity currentResultSetEntity = null;
+
+                    // we iterate the ResultSet rows here
+                    // for every row, we create one target entity instance and compare it with the
+                    // previous one. If the key property values are different, then we move to the
+                    // next target instance.
+                    // Otherwise that row has only navigation properties, then in that iteration
+                    // only the navigation properties are set
+                    while (query.next(resultSet)) {// TODO remove the duplication here
+
+                        Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+                        OData2ResultSetEntity nextResultSetEntity = new OData2ResultSetEntity(data);
+
+                        LOG.info("Current object is " + nextResultSetEntity);
+                        if (OData2Utils.isEmpty(targetEntityType, nextResultSetEntity)) {
+                            continue;
+                        }
+                        if (!OData2Utils.isSameInstance(targetEntityType, currentResultSetEntity,
+                                nextResultSetEntity)) {
+                            // now the result set has a new entity
+                            currentResultSetEntity = nextResultSetEntity;
+                            targetEntitiesResult.add(currentResultSetEntity);
+                        }
+                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+                        if (hasExpand(expandEntities)) {
+                            processExpand(targetEntityType, query, resultSet, currentResultSetEntity, expandEntities);
+                        }
+                    }
+                    boolean needsNextLink = query.isServersidePaging() && targetEntitiesResult.size() == this
+                            .getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+                    nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return OData2Utils.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, targetEntitiesResult, contentType,
+                count, nextLink);
+    }
+
+    private void processExpand(EdmEntityType targetEntityType, SQLSelectBuilder query, ResultSet resultSet, OData2ResultSetEntity currentResultSetEntity,
+                               List<ArrayList<NavigationPropertySegment>> expandEntities) throws SQLException, ODataException {
+        for (List<NavigationPropertySegment> expandContents : expandEntities) {
+            for (NavigationPropertySegment expandContent : expandContents) {
+                EdmEntityType expandType = expandContent.getTargetEntitySet().getEntityType();
+                Map<String, Object> expandData = readResultSet(query, expandType, EdmUtils.getProperties(expandType), resultSet);
+                if (OData2Utils.isEmpty(expandType, expandData)) {
+                    // nothing there, we need to find the next one
+                    continue;
+                }
+                Map<String, Object> customizedExpandData = onCustomizeExpandedNavigatonProperty(targetEntityType, expandType, expandData);
+                currentResultSetEntity.addExpandedEntityProperties(expandType, customizedExpandData);
+            }
+        }
+    }
+
+    public List<String> readIdsForExpand(final GetEntitySetUriInfo uriInfo) throws ODataException {
+        List<String> idsOfLeadingEntities = new ArrayList<>();
+        try (Connection connection = getDataSource().getConnection()) {
+            SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
+            try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    queryForIdsInExpand.setOffset(resultSet);
+                    while (queryForIdsInExpand.next(resultSet)) {// TODO remove the duplication here
+                        // we select only the ids here (we assume that only one key property is in the
+                        // ID)
+                        // Override this method if this is not the case
+                        idsOfLeadingEntities.add(resultSet.getString(1));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new ODataException(e);
+        }
+        return idsOfLeadingEntities;
+    }
+
+    /**
+     * Generates the next link for server-side paging. The next-link is based on the
+     * URI of the current request, except that {@code $skip} or {@code $skiptoken}
+     * will be removed.
+     *
+     * @param query            the query
+     * @param targetEntityType the target entity type
+     * @return the link
+     * @throws ODataException in case of an error
+     */
+    protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
+        int top = query.getSelectExpression().getTop();
+        int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+        return OData2Utils.generateNextLink(getContext(), top, pagingSize);
+    }
+
+    @Override
+    public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        OData2ResultSetEntity resultEntity = null;
+        Collection<EdmProperty> properties = uriInfo.getPropertyPath();
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    query.setOffset(resultSet);
+                    while (query.next(resultSet)) {
+                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+                            resultEntity = new OData2ResultSetEntity(data);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return OData2Utils.writeEntryPropertyValue(getContext(), uriInfo.getPropertyPath().iterator().next(),
+                (UriInfo) uriInfo, resultEntity, contentType);
+    }
+
+    @Override
+    public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        OData2ResultSetEntity resultEntity = null;
+        Collection<EdmProperty> properties = uriInfo.getPropertyPath();
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    query.setOffset(resultSet);
+                    while (query.next(resultSet)) {
+                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+                            resultEntity = new OData2ResultSetEntity(data);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return OData2Utils.writeEntryProperty(getContext(), uriInfo.getPropertyPath().iterator().next(),
+                (UriInfo) uriInfo, resultEntity, contentType);
+    }
+
+    @Override
+    public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        throw new ODataNotImplementedException();
+    }
+
+    @Override
+    public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        throw new ODataNotImplementedException();
+    }
+
+    protected Map<String, Object> readResultSet(SQLSelectBuilder selectEntityQuery, final EdmStructuralType entityType,
+                                                Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException {
+        Map<String, Object> result = new HashMap<>();
+        for (EdmProperty property : properties) {
+            result.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
+        }
+        return result;
+    }
+
+    protected Object readProperty(EdmStructuralType entityType, EdmProperty property, SQLSelectBuilder selectEntityQuery,
+                                  ResultSet resultSet) throws SQLException, ODataException {
+        Object propertyDbValue;
+        if (property.isSimple()) {
+            if (!selectEntityQuery.isTransientType(entityType, property)) {
+                final String columnName = selectEntityQuery.getSQLTableColumnAlias(entityType, property);
+                if ("Binary".equals(property.getType().getName())) {
+                    propertyDbValue = resultSet.getBytes(columnName);
+                } else {
+                    propertyDbValue = resultSet.getObject(columnName);
+                    propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
+                }
+                return propertyDbValue;
+            } else {
+                return null;
+            }
+        } else {
+            EdmStructuralType complexProperty = (EdmStructuralType) property.getType();
+            Map<String, Object> complexPropertyData = new HashMap<>();
+            for (String pn : complexProperty.getPropertyNames()) {
+                EdmProperty prop = (EdmProperty) complexProperty.getProperty(pn);
+                final String columnName = selectEntityQuery.getSQLTableColumnAlias(complexProperty, prop);
+                propertyDbValue = resultSet.getObject(columnName);
+                propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
+                complexPropertyData.put(pn, propertyDbValue);
+            }
+            return complexPropertyData;
+        }
+    }
+
+    @Override
+    public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
+                                      final String requestContentType, final String contentType) throws ODataException {
+
+        if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
+            throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
+                    OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+
+        if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
+            return this.odata2EventHandler.onCreateEntity(uriInfo, content,
+                    requestContentType, contentType);
+        }
+
+        final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType entityType = entitySet.getEntityType();
+        ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
+        this.odata2EventHandler.beforeCreateEntity(uriInfo,
+                requestContentType, contentType, entry);
+
+        SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
+
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)) {
+                statement.executeUpdate();
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+
+        try {
+            List<EdmProperty> keyProperties = entityType.getKeyProperties();
+            List<KeyPredicate> keyPredicates = new ArrayList<>();
+            if (!keyProperties.isEmpty()) {
+                for (EdmProperty keyProperty : keyProperties) {
+                    if (entry.getProperties().get(keyProperty.getName()) != null) {
+                        keyPredicates.add(new KeyPredicateImpl(
+                                entry.getProperties().get(keyProperty.getName()).toString(),
+                                keyProperty));
+                    } else {
+                        String msg = "Cannot create entity without key(s)";
+                        LOG.error(msg);
+                        throw new ODataException(msg);
+                    }
+                }
+
+                ((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
+
+                // Re-read the inserted entity to get the auto-generated properties
+                SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+                OData2ResultSetEntity resultEntity = null;
+                Collection<EdmProperty> properties = getProperties(entityType);
+                try (Connection connection = getDataSource().getConnection()) {
+                    try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                        try (ResultSet resultSet = statement.executeQuery()) {
+                            query.setOffset(resultSet);
+                            while (query.next(resultSet)) {
+                                if (resultEntity == null) {
+                                    Map<String, Object> data = readResultSet(query, entityType, properties, resultSet);
+                                    resultEntity = new OData2ResultSetEntity(data);
+                                }
+                            }
+                        }
+                    }
+                    ODataResponse response = OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
+                    this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
+                    return response;
+                } catch (Exception e) {
+                    LOG.error("Unable to serve request", e);
+                    throw new ODataException(e);
+                }
+            }
+        } catch (Throwable t) {
+            LOG.error("Unable to get back the created entity", t);
+        }
+
+        ODataContext context = getContext();
+        EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
+                .serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
+                .build();
+        final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
+        this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
+        return response;
+    }
+
+    public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
+                                       final String requestContentType, final boolean merge) throws ODataBadRequestException {
+        ODataEntry entryValues;
+        try {
+            EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
+                    .mergeSemantic(merge).build();
+            entryValues = EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
+        } catch (Exception e) {
+            throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
+        }
+        return entryValues;
+    }
+
+    @Override
+    public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
+        if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
+            throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+        if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
+            return this.odata2EventHandler.onDeleteEntity(uriInfo, contentType);
+        }
+        this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType);
+
+        SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
+
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
+                statement.executeUpdate();
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+
+        ODataResponse response = ODataResponse.newBuilder().build();
+        this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType);
+        return response;
+    }
+
+    @Override
+    public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
+                                      final String requestContentType, final boolean merge, final String contentType) throws ODataException {
+        if (uriInfo.getFilter() != null) {
+            throw new ODataException("Update operation is not allowed with $filter.");
+        }
+        if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+            throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+
+        if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+            return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType);
+        }
+
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        OData2ResultSetEntity resultEntity = null;
+        Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    query.setOffset(resultSet);
+                    while (query.next(resultSet)) {
+                        if (resultEntity == null) {
+                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+                            resultEntity = new OData2ResultSetEntity(data);
+                        }
+                    }
+                    if (resultEntity == null) {
+                        throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+
+        ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
+        this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
+
+        SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
+                mapKeys(uriInfo.getKeyPredicates()), getContext());
+
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)) {
+                statement.executeUpdate();
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
+        this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
+        return response;
+    }
+
+    @Override
+    public ODataResponse executeBatch(final BatchHandler handler, final String contentType, final InputStream content) throws ODataException {
+        try {
+            ODataResponse batchResponse;
+            PathInfo pathInfo = getContext().getPathInfo();
+            EntityProviderBatchProperties batchProperties = EntityProviderBatchProperties.init().pathInfo(pathInfo).build();
+            List<BatchRequestPart> batchParts = EntityProvider.parseBatchRequest(contentType, content, batchProperties);
+            List<BatchResponsePart> parts = new ArrayList<>();
+            for (BatchRequestPart batchPart : batchParts) {
+                parts.add(handler.handleBatchPart(batchPart));
+            }
+            batchResponse = EntityProvider.writeBatchResponse(parts);
+            return batchResponse;
+        } catch (ODataException e) {
+            LOG.error("Problem during batch processing", e);
+            throw e;
+        } catch (Exception e) {
+            throw new ODataException("Problem during batch processing", e);
+        }
+    }
+
+    @Override
+    public BatchResponsePart executeChangeSet(final BatchHandler handler, final List<ODataRequest> requests) throws ODataException {
+        DataSource originalDataSource = this.getDataSource();
+        try (Connection connection = getDataSource().getConnection()) {
+            SingleConnectionDataSource singleConnectionDataSource = new SingleConnectionDataSource(connection);
+            boolean originalAutoCommit = connection.getAutoCommit();
+            try {
+                //override the setDataSource so that all requests in a change set run in the same connection
+                this.setDataSource(singleConnectionDataSource);
+                BatchResponsePart result = doExecuteChangeSet(handler, requests);
+                return result;
+            } finally {
+                connection.setAutoCommit(originalAutoCommit);
+            }
+        } catch (ODataException e) {
+            LOG.error("Unable to execute chnange set", e);
+            throw e;
+        } catch (Exception e) {
+            LOG.error("Unable to execute chnange set", e);
+            throw new ODataException("Unable to execute the change set ", e);
+        } finally {
+            //restore the original data source
+            this.setDataSource(originalDataSource);
+        }
+    }
+
+    public BatchResponsePart doExecuteChangeSet(final BatchHandler handler, final List<ODataRequest> requests) throws ODataException, SQLException {
+        boolean changeSetFailed = false;
+        try (Connection nonClosableConnectionUsedForChangeSet = this.getDataSource().getConnection()) { //
+            try {
+                if (nonClosableConnectionUsedForChangeSet.getAutoCommit()) {
+                    nonClosableConnectionUsedForChangeSet.setAutoCommit(false);
+                }
+                List<ODataResponse> responses = new ArrayList<>();
+                for (ODataRequest request : requests) {
+                    ODataResponse response = handler.handleRequest(request);
+                    //erroneous requests are >= 400 (BAD_REQUEST)
+                    if (response.getStatus().getStatusCode() >= HttpStatusCodes.BAD_REQUEST.getStatusCode()) {
+                        List<ODataResponse> errorResponses = new ArrayList<>();
+                        errorResponses.add(response);
+                        changeSetFailed = true;
+                        return BatchResponsePart.responses(errorResponses).changeSet(false).build();
+                    }
+                    responses.add(response);
+                }
+                return BatchResponsePart.responses(responses).changeSet(true).build();
+            } catch (ODataException e) {
+                changeSetFailed = true;
+                throw e;
+            } catch (RuntimeException e) {
+                changeSetFailed = true;
+                throw new ODataException("Unable to process change set", e);
+            } finally {
+                if (!nonClosableConnectionUsedForChangeSet.getAutoCommit()) {
+                    if (changeSetFailed) {
+                        nonClosableConnectionUsedForChangeSet.rollback();
+                    } else {
+                        nonClosableConnectionUsedForChangeSet.commit();
+                    }
+                } else {
+                    throw new IllegalStateException("Invalid implementation - the OData operations must not unset the auto commit to false on the connection!");
+                }
+            }
+        }
+    }
+
+    protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
+
+    protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
+
+    protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
 
 
-	// TODO add unit tests for the expand functionality
-	@Override
-	public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
-		
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+    protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
+        String sql = statement.sql();
+        LOG.info("SQL Statement: {}", sql);
 
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		OData2ResultSetEntity resultEntity = null;
-		// TODO change logic to read columns from ResultSet? (key has to be read even if
-		// it is now requested via $select)
-		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createSelectStatement(query, connection)){
-				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        setParamsOnStatement(preparedStatement, statement.getStatementParams());
+        return preparedStatement;
+    }
 
-						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-							resultEntity = new OData2ResultSetEntity(data);
-						}
-						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-						if (hasExpand(expandEntities)) {
-							processExpand(targetEntityType, query, resultSet, resultEntity, expandEntities);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
-	}
+    public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws SQLException {
+        LOG.debug("SQL Params: {}", params);
+        SQLUtils.setParamsOnStatement(preparedStatement, params);
+    }
 
-	// TODO add unit tests for the expand functionality
-	@Override
-	public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		final InlineCount inlineCountType = uriInfo.getInlineCount();
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+    @Override
+    public DataSource getDataSource() {
+        return dataSource;
+    }
 
-		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-		List<OData2ResultSetEntity> targetEntitiesResult = new ArrayList<>();
-
-		Integer count;
-		String nextLink;
-		try (Connection connection = getDataSource().getConnection()) {
-			if (inlineCountType == InlineCount.ALLPAGES) {
-				SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
-				count = doCountEntitySet(countEntitySet, connection); // does not close the connection
-			} else {
-				count = null;
-			}
-			SQLSelectBuilder query;
-			List<String> readIdsForExpand = new ArrayList<>();
-			if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
-				LOG.info("Reading the ids that will be used for $expand");
-				readIdsForExpand = readIdsForExpand(uriInfo);
-				LOG.info("Using IDs for $expand: {}", readIdsForExpand);
-			}
-			query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
-
-			try (PreparedStatement statement = createSelectStatement(query, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					query.setOffset(resultSet);
-					OData2ResultSetEntity currentResultSetEntity = null;
-
-					// we iterate the ResultSet rows here
-					// for every row, we create one target entity instance and compare it with the
-					// previous one. If the key property values are different, then we move to the
-					// next target instance.
-					// Otherwise that row has only navigation properties, then in that iteration
-					// only the navigation properties are set
-					while (query.next(resultSet)) {// TODO remove the duplication here
-
-						Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-						OData2ResultSetEntity nextResultSetEntity = new OData2ResultSetEntity(data);
-
-						LOG.info("Current object is " + nextResultSetEntity);
-						if (OData2Utils.isEmpty(targetEntityType, nextResultSetEntity)) {
-							continue;
-						}
-						if (!OData2Utils.isSameInstance(targetEntityType, currentResultSetEntity,
-								nextResultSetEntity)) {
-							// now the result set has a new entity
-							currentResultSetEntity = nextResultSetEntity;
-							targetEntitiesResult.add(currentResultSetEntity);
-						}
-						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-						if (hasExpand(expandEntities)) {
-							processExpand(targetEntityType, query, resultSet, currentResultSetEntity, expandEntities);
-						}
-					}
-					boolean needsNextLink = query.isServersidePaging() && targetEntitiesResult.size() == this
-							.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-					nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return OData2Utils.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, targetEntitiesResult, contentType,
-				count, nextLink);
-	}
-
-	private void processExpand(EdmEntityType targetEntityType, SQLSelectBuilder query, ResultSet resultSet, OData2ResultSetEntity currentResultSetEntity,
-							   List<ArrayList<NavigationPropertySegment>> expandEntities) throws SQLException, ODataException {
-		for (List<NavigationPropertySegment> expandContents : expandEntities) {
-			for (NavigationPropertySegment expandContent : expandContents) {
-				EdmEntityType expandType = expandContent.getTargetEntitySet().getEntityType();
-				Map<String, Object> expandData = readResultSet(query, expandType, EdmUtils.getProperties(expandType), resultSet);
-				if (OData2Utils.isEmpty(expandType, expandData)) {
-					// nothing there, we need to find the next one
-					continue;
-				}
-				Map<String, Object> customizedExpandData = onCustomizeExpandedNavigatonProperty(targetEntityType, expandType, expandData);
-				currentResultSetEntity.addExpandedEntityProperties(expandType, customizedExpandData);
-			}
-		}
-	}
-
-	public List<String> readIdsForExpand (final GetEntitySetUriInfo uriInfo) throws ODataException {
-		List<String> idsOfLeadingEntities = new ArrayList<>();
-		try (Connection connection = getDataSource().getConnection()) {
-			SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
-			try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					queryForIdsInExpand.setOffset(resultSet);
-					while (queryForIdsInExpand.next(resultSet)) {// TODO remove the duplication here
-						// we select only the ids here (we assume that only one key property is in the
-						// ID)
-						// Override this method if this is not the case
-						idsOfLeadingEntities.add(resultSet.getString(1));
-					}
-				}
-			}
-		} catch (Exception e) {
-			throw new ODataException(e);
-		}
-		return idsOfLeadingEntities;
-	}
-
-	
-	/**
-	 * Generates the next link for server-side paging. The next-link is based on the
-	 * URI of the current request, except that {@code $skip} or {@code $skiptoken}
-	 * will be removed.
-	 * 
-	 * @param query the query
-	 * @param targetEntityType the target entity type
-	 * @return the link
-	 * @throws ODataException in case of an error
-	 */
-	protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
-		int top = query.getSelectExpression().getTop();
-		int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-		return OData2Utils.generateNextLink(getContext(), top, pagingSize);
-	}
-
-	@Override
-	public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		OData2ResultSetEntity resultEntity = null;
-		Collection<EdmProperty> properties = uriInfo.getPropertyPath();
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createSelectStatement(query, connection)){
-				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
-						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-							resultEntity = new OData2ResultSetEntity(data);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return OData2Utils.writeEntryPropertyValue(getContext(), uriInfo.getPropertyPath().iterator().next(),
-				(UriInfo) uriInfo, resultEntity, contentType);
-	}
-
-	@Override
-	public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		OData2ResultSetEntity resultEntity = null;
-		Collection<EdmProperty> properties = uriInfo.getPropertyPath();
-		try (Connection connection = getDataSource().getConnection()){
-			try(PreparedStatement statement = createSelectStatement(query, connection)){
-				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
-						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-							resultEntity = new OData2ResultSetEntity(data);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return OData2Utils.writeEntryProperty(getContext(), uriInfo.getPropertyPath().iterator().next(),
-				(UriInfo) uriInfo, resultEntity, contentType);
-	}
-
-	@Override
-	public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		throw new ODataNotImplementedException();
-	}
-
-	@Override
-	public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		throw new ODataNotImplementedException();
-	}
-
-	protected Map<String, Object> readResultSet(SQLSelectBuilder selectEntityQuery, final EdmStructuralType entityType,
-												Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException {
-		Map<String, Object> result = new HashMap<>();
-		for (EdmProperty property : properties) {
-			result.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
-		}
-		return result;
-	}
-
-	protected Object readProperty(EdmStructuralType entityType, EdmProperty property, SQLSelectBuilder selectEntityQuery,
-			ResultSet resultSet) throws SQLException, ODataException {
-		Object propertyDbValue;
-		if (property.isSimple()) {
-			if (!selectEntityQuery.isTransientType(entityType, property)) {
-				final String columnName = selectEntityQuery.getSQLTableColumnAlias(entityType, property);
-				if ("Binary".equals(property.getType().getName())) {
-					propertyDbValue = resultSet.getBytes(columnName);
-				} else {
-					propertyDbValue = resultSet.getObject(columnName);
-					propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
-				}
-				return propertyDbValue;
-			} else {
-				return null;
-			}
-		} else {
-			EdmStructuralType complexProperty = (EdmStructuralType) property.getType();
-			Map<String, Object> complexPropertyData = new HashMap<>();
-			for (String pn : complexProperty.getPropertyNames()) {
-				EdmProperty prop = (EdmProperty) complexProperty.getProperty(pn);
-				final String columnName = selectEntityQuery.getSQLTableColumnAlias(complexProperty, prop);
-				propertyDbValue = resultSet.getObject(columnName);
-				propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
-				complexPropertyData.put(pn, propertyDbValue);
-			}
-			return complexPropertyData;
-		}
-	}
-
-	@Override
-	public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final String contentType) throws ODataException {
-		
-		if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
-			throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
-					OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-		
-		if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
-			return this.odata2EventHandler.onCreateEntity(uriInfo, content,
-					requestContentType, contentType);
-		}
-
-		final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType entityType = entitySet.getEntityType();
-		ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
-		this.odata2EventHandler.beforeCreateEntity(uriInfo,
-				requestContentType, contentType, entry);
-
-		SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
-
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)){
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		
-		try {
-			List<EdmProperty> keyProperties = entityType.getKeyProperties();
-			List<KeyPredicate> keyPredicates = new ArrayList<>();
-			if (!keyProperties.isEmpty()) {
-				for (EdmProperty keyProperty : keyProperties) {
-					if (entry.getProperties().get(keyProperty.getName()) != null) {
-						keyPredicates.add(new KeyPredicateImpl(
-								entry.getProperties().get(keyProperty.getName()).toString(),
-								keyProperty));
-					} else {
-						String msg = "Cannot create entity without key(s)";
-						LOG.error(msg);
-						throw new ODataException(msg);
-					}
-				}
-				
-				((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
-				
-				// Re-read the inserted entity to get the auto-generated properties
-				SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-				OData2ResultSetEntity resultEntity = null;
-				Collection<EdmProperty> properties = getProperties(entityType);
-				try (Connection connection = getDataSource().getConnection()){
-					try (PreparedStatement statement = createSelectStatement(query, connection)){
-						try (ResultSet resultSet = statement.executeQuery()){
-							query.setOffset(resultSet);
-							while (query.next(resultSet)) {
-								if (resultEntity == null) {
-									Map<String, Object> data = readResultSet(query, entityType, properties, resultSet);
-									resultEntity = new OData2ResultSetEntity(data);
-								}
-							}
-						}
-					}
-					ODataResponse response = OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
-					this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-					return response;
-				} catch (Exception e) {
-					LOG.error("Unable to serve request", e);
-					throw new ODataException(e);
-				}
-			}
-		} catch (Throwable t) {
-			LOG.error("Unable to get back the created entity", t);
-		}
-		
-		ODataContext context = getContext();
-		EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
-				.serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
-				.build();
-		final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
-		this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-		return response;
-	}
-
-	public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
-			final String requestContentType, final boolean merge) throws ODataBadRequestException {
-		ODataEntry entryValues;
-		try {
-			EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
-					.mergeSemantic(merge).build();
-			entryValues = EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
-		} catch (Exception e) {
-			throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
-		}
-		return entryValues;
-	}
-
-	@Override
-	public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
-		if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
-			throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-		if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
-			return this.odata2EventHandler.onDeleteEntity(uriInfo, contentType);
-		}
-		this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType);
-
-		SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-		try (Connection connection = getDataSource().getConnection()) {
-			try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-
-		ODataResponse response = ODataResponse.newBuilder().build();
-		this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType);
-		return response;
-	}
-
-	private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
-		Map<String, Object> keyMap = new HashMap<>();
-		for (final KeyPredicate key : keys) {
-			final EdmProperty property = key.getProperty();
-			final EdmSimpleType type = (EdmSimpleType) property.getType();
-			keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
-					property.getFacets(), type.getDefaultType()));
-		}
-		return keyMap;
-	}
-
-	@Override
-	public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final boolean merge, final String contentType) throws ODataException {
-		if (uriInfo.getFilter() != null) {
-			throw new ODataException("Update operation is not allowed with $filter.");
-		}
-		if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-			throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-
-		if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-			return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType);
-		}
-		
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		OData2ResultSetEntity resultEntity = null;
-		Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
-		try (Connection connection = getDataSource().getConnection()) {
-			try (PreparedStatement statement = createSelectStatement(query, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
-						if (resultEntity == null) {
-							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-							resultEntity = new OData2ResultSetEntity(data);
-						}
-					}
-					if (resultEntity == null) {
-						throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-
-		ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
-		this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-
-		SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
-				mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-		try(Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)){
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
-		this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-		return response;
-	}
-
-
-	protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
-
-	protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
-
-	protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
-
-
-	protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
-		String sql = statement.sql();
-		LOG.info("SQL Statement: {}", sql);
-
-		PreparedStatement preparedStatement = connection.prepareStatement(sql);
-		setParamsOnStatement(preparedStatement, statement.getStatementParams());
-		return preparedStatement;
-	}
-
-	public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws EdmException, SQLException {
-		LOG.debug("SQL Params: {}", params);
-		SQLUtils.setParamsOnStatement(preparedStatement, params);
-	}
+    void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -37,12 +37,10 @@ import org.apache.olingo.odata2.api.uri.UriInfo;
 import org.apache.olingo.odata2.api.uri.info.*;
 import org.apache.olingo.odata2.core.uri.KeyPredicateImpl;
 import org.apache.olingo.odata2.core.uri.UriInfoImpl;
-import org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler;
-import org.eclipse.dirigible.engine.odata2.sql.api.SQLProcessor;
-import org.eclipse.dirigible.engine.odata2.sql.api.SQLStatement;
-import org.eclipse.dirigible.engine.odata2.sql.api.SQLStatementParam;
+import org.eclipse.dirigible.engine.odata2.sql.api.*;
 import org.eclipse.dirigible.engine.odata2.sql.builder.*;
 import org.eclipse.dirigible.engine.odata2.sql.clause.SQLSelectClause;
+import org.eclipse.dirigible.engine.odata2.sql.builder.SQLUtils;
 import org.eclipse.dirigible.engine.odata2.sql.utils.OData2ResultSetEntity;
 import org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils;
 import org.eclipse.dirigible.engine.odata2.sql.utils.SingleConnectionDataSource;
@@ -63,559 +61,597 @@ import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.hasExpan
 
 public abstract class AbstractSQLProcessor extends ODataSingleProcessor implements SQLProcessor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
-
-    private final OData2EventHandler odata2EventHandler;
-
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
+	
+	private final OData2EventHandler odata2EventHandler;
     private DataSource dataSource;
 
-    public AbstractSQLProcessor() {
-        this.odata2EventHandler = new DummyOData2EventHandler();
-    }
+	public AbstractSQLProcessor() {
+		this.odata2EventHandler = new DummyOData2EventHandler();
+	}
+	
+	public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
+		this.odata2EventHandler = odata2EventHandler;
+	}
 
-    public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
-        this.odata2EventHandler = odata2EventHandler;
-    }
+	@Override
+	public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
+		return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
+	}
 
-    private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
-        Map<String, Object> keyMap = new HashMap<>();
-        for (final KeyPredicate key : keys) {
-            final EdmProperty property = key.getProperty();
-            final EdmSimpleType type = (EdmSimpleType) property.getType();
-            keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
-                    property.getFacets(), type.getDefaultType()));
-        }
-        return keyMap;
-    }
+	@Override
+	public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
+			throw new ODataNotImplementedException();
+		}
+		try {
+			SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+
+			try (Connection connection = getDataSource().getConnection()) {
+				int count = doCountEntitySet(sqlQuery, connection);
+				return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
+			}
+		} catch (SQLException e) {
+			throw new ODataException(e);
+		}
+	}
+
+	@Override
+	public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		LOG.error("readEntityComplexProperty not implemented: {}",uriInfo.toString());
+		throw new ODataException("Not Implemented");
+	}
+
+	protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
+		// TODO cache the metadata, because it fires a DB query every time
+		// TODO do we really need to select the entities?
+		String sql = sqlQuery.buildSelect(createSQLContext(connection));
+		try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+			LOG.info(sql);
+			setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				// TODO do we need to assert that resultSet.next() == true and subsequently
+				// resultSet.next() == false here?
+				resultSet.next();
+				return resultSet.getInt(1);
+			}
+		}
+	}
+
+	protected SQLContext createSQLContext(final Connection connection) throws SQLException {
+		return new SQLContext(connection.getMetaData(), this.getContext());
+	}
+
+	protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
+			throws SQLException, ODataException {
+		String sql = selectQuery.buildSelect(createSQLContext(connection));
+		LOG.info(sql);
+		PreparedStatement preparedStatement;
+		if (selectQuery.getSelectExpression().getSkip() != SQLSelectClause.NOT_SET) {
+			preparedStatement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			/*
+			 * Restrict fetch size to prevent OutOfMemoryErrors for huge page sizes. If no
+			 * fetch size is specified, jConnect will fetch all records up to the requested
+			 * page (in case of the last page, this would be the entire result set).
+			 * 
+			 * Internal Incident:
+			 * https://support.wdf.sap.corp/sap/support/message/1780258655
+			 */
+
+			preparedStatement.setFetchSize(SQLQueryBuilder.DEFAULT_SERVER_PAGING_SIZE);
+
+		} else {
+			preparedStatement = connection.prepareStatement(sql);
+		}
+		setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
+		return preparedStatement;
+	}
+
+
+	// TODO add unit tests for the expand functionality
+	@Override
+	public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
+		
+		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+		OData2ResultSetEntity resultEntity = null;
+		// TODO change logic to read columns from ResultSet? (key has to be read even if
+		// it is now requested via $select)
+		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+		try (Connection connection = getDataSource().getConnection()){
+			try (PreparedStatement statement = createSelectStatement(query, connection)){
+				try (ResultSet resultSet = statement.executeQuery()){
+					query.setOffset(resultSet);
+					while (query.next(resultSet)) {
+
+						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+							resultEntity = new OData2ResultSetEntity(data);
+						}
+						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+						if (hasExpand(expandEntities)) {
+							processExpand(targetEntityType, query, resultSet, resultEntity, expandEntities);
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		return OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
+	}
+
+	// TODO add unit tests for the expand functionality
+	@Override
+	public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		final InlineCount inlineCountType = uriInfo.getInlineCount();
+		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+		List<OData2ResultSetEntity> targetEntitiesResult = new ArrayList<>();
+
+		Integer count;
+		String nextLink;
+		try (Connection connection = getDataSource().getConnection()) {
+			if (inlineCountType == InlineCount.ALLPAGES) {
+				SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+				count = doCountEntitySet(countEntitySet, connection); // does not close the connection
+			} else {
+				count = null;
+			}
+			SQLSelectBuilder query;
+			List<String> readIdsForExpand = new ArrayList<>();
+			if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
+				LOG.info("Reading the ids that will be used for $expand");
+				readIdsForExpand = readIdsForExpand(uriInfo);
+				LOG.info("Using IDs for $expand: {}", readIdsForExpand);
+			}
+			query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
+
+			try (PreparedStatement statement = createSelectStatement(query, connection)) {
+				try (ResultSet resultSet = statement.executeQuery()) {
+					query.setOffset(resultSet);
+					OData2ResultSetEntity currentResultSetEntity = null;
+
+					// we iterate the ResultSet rows here
+					// for every row, we create one target entity instance and compare it with the
+					// previous one. If the key property values are different, then we move to the
+					// next target instance.
+					// Otherwise that row has only navigation properties, then in that iteration
+					// only the navigation properties are set
+					while (query.next(resultSet)) {// TODO remove the duplication here
+
+						Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+						OData2ResultSetEntity nextResultSetEntity = new OData2ResultSetEntity(data);
+
+						LOG.info("Current object is " + nextResultSetEntity);
+						if (OData2Utils.isEmpty(targetEntityType, nextResultSetEntity)) {
+							continue;
+						}
+						if (!OData2Utils.isSameInstance(targetEntityType, currentResultSetEntity,
+								nextResultSetEntity)) {
+							// now the result set has a new entity
+							currentResultSetEntity = nextResultSetEntity;
+							targetEntitiesResult.add(currentResultSetEntity);
+						}
+						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+						if (hasExpand(expandEntities)) {
+							processExpand(targetEntityType, query, resultSet, currentResultSetEntity, expandEntities);
+						}
+					}
+					boolean needsNextLink = query.isServersidePaging() && targetEntitiesResult.size() == this
+							.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+					nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		return OData2Utils.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, targetEntitiesResult, contentType,
+				count, nextLink);
+	}
+
+	private void processExpand(EdmEntityType targetEntityType, SQLSelectBuilder query, ResultSet resultSet, OData2ResultSetEntity currentResultSetEntity,
+							   List<ArrayList<NavigationPropertySegment>> expandEntities) throws SQLException, ODataException {
+		for (List<NavigationPropertySegment> expandContents : expandEntities) {
+			for (NavigationPropertySegment expandContent : expandContents) {
+				EdmEntityType expandType = expandContent.getTargetEntitySet().getEntityType();
+				Map<String, Object> expandData = readResultSet(query, expandType, EdmUtils.getProperties(expandType), resultSet);
+				if (OData2Utils.isEmpty(expandType, expandData)) {
+					// nothing there, we need to find the next one
+					continue;
+				}
+				Map<String, Object> customizedExpandData = onCustomizeExpandedNavigatonProperty(targetEntityType, expandType, expandData);
+				currentResultSetEntity.addExpandedEntityProperties(expandType, customizedExpandData);
+			}
+		}
+	}
+
+	public List<String> readIdsForExpand (final GetEntitySetUriInfo uriInfo) throws ODataException {
+		List<String> idsOfLeadingEntities = new ArrayList<>();
+		try (Connection connection = getDataSource().getConnection()) {
+			SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
+			try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
+				try (ResultSet resultSet = statement.executeQuery()) {
+					queryForIdsInExpand.setOffset(resultSet);
+					while (queryForIdsInExpand.next(resultSet)) {// TODO remove the duplication here
+						// we select only the ids here (we assume that only one key property is in the
+						// ID)
+						// Override this method if this is not the case
+						idsOfLeadingEntities.add(resultSet.getString(1));
+					}
+				}
+			}
+		} catch (Exception e) {
+			throw new ODataException(e);
+		}
+		return idsOfLeadingEntities;
+	}
+
+	
+	/**
+	 * Generates the next link for server-side paging. The next-link is based on the
+	 * URI of the current request, except that {@code $skip} or {@code $skiptoken}
+	 * will be removed.
+	 * 
+	 * @param query the query
+	 * @param targetEntityType the target entity type
+	 * @return the link
+	 * @throws ODataException in case of an error
+	 */
+	protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
+		int top = query.getSelectExpression().getTop();
+		int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+		return OData2Utils.generateNextLink(getContext(), top, pagingSize);
+	}
+
+	@Override
+	public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+		OData2ResultSetEntity resultEntity = null;
+		Collection<EdmProperty> properties = uriInfo.getPropertyPath();
+		try (Connection connection = getDataSource().getConnection()){
+			try (PreparedStatement statement = createSelectStatement(query, connection)){
+				try (ResultSet resultSet = statement.executeQuery()){
+					query.setOffset(resultSet);
+					while (query.next(resultSet)) {
+						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+							resultEntity = new OData2ResultSetEntity(data);
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		return OData2Utils.writeEntryPropertyValue(getContext(), uriInfo.getPropertyPath().iterator().next(),
+				(UriInfo) uriInfo, resultEntity, contentType);
+	}
+
+	@Override
+	public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+		OData2ResultSetEntity resultEntity = null;
+		Collection<EdmProperty> properties = uriInfo.getPropertyPath();
+		try (Connection connection = getDataSource().getConnection()){
+			try(PreparedStatement statement = createSelectStatement(query, connection)){
+				try (ResultSet resultSet = statement.executeQuery()){
+					query.setOffset(resultSet);
+					while (query.next(resultSet)) {
+						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
+							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+							resultEntity = new OData2ResultSetEntity(data);
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		return OData2Utils.writeEntryProperty(getContext(), uriInfo.getPropertyPath().iterator().next(),
+				(UriInfo) uriInfo, resultEntity, contentType);
+	}
+
+	@Override
+	public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		throw new ODataNotImplementedException();
+	}
+
+	@Override
+	public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
+			throws ODataException {
+		throw new ODataNotImplementedException();
+	}
+
+	protected Map<String, Object> readResultSet(SQLSelectBuilder selectEntityQuery, final EdmStructuralType entityType,
+												Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException {
+		Map<String, Object> result = new HashMap<>();
+		for (EdmProperty property : properties) {
+			result.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
+		}
+		return result;
+	}
+
+	protected Object readProperty(EdmStructuralType entityType, EdmProperty property, SQLSelectBuilder selectEntityQuery,
+			ResultSet resultSet) throws SQLException, ODataException {
+		Object propertyDbValue;
+		if (property.isSimple()) {
+			if (!selectEntityQuery.isTransientType(entityType, property)) {
+				final String columnName = selectEntityQuery.getSQLTableColumnAlias(entityType, property);
+				if ("Binary".equals(property.getType().getName())) {
+					propertyDbValue = resultSet.getBytes(columnName);
+				} else {
+					propertyDbValue = resultSet.getObject(columnName);
+					propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
+				}
+				return propertyDbValue;
+			} else {
+				return null;
+			}
+		} else {
+			EdmStructuralType complexProperty = (EdmStructuralType) property.getType();
+			Map<String, Object> complexPropertyData = new HashMap<>();
+			for (String pn : complexProperty.getPropertyNames()) {
+				EdmProperty prop = (EdmProperty) complexProperty.getProperty(pn);
+				final String columnName = selectEntityQuery.getSQLTableColumnAlias(complexProperty, prop);
+				propertyDbValue = resultSet.getObject(columnName);
+				propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
+				complexPropertyData.put(pn, propertyDbValue);
+			}
+			return complexPropertyData;
+		}
+	}
+
+	@Override
+	public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
+			final String requestContentType, final String contentType) throws ODataException {
+		
+		if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
+			throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
+					OData2Utils.fqn(uriInfo.getTargetType())));
+		}
+		
+		if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
+			return this.odata2EventHandler.onCreateEntity(uriInfo, content,
+					requestContentType, contentType);
+		}
+
+		final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType entityType = entitySet.getEntityType();
+		ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
+		this.odata2EventHandler.beforeCreateEntity(uriInfo,
+				requestContentType, contentType, entry);
+
+		SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
+
+		try (Connection connection = getDataSource().getConnection()){
+			try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)){
+				statement.executeUpdate();
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		
+		try {
+			List<EdmProperty> keyProperties = entityType.getKeyProperties();
+			List<KeyPredicate> keyPredicates = new ArrayList<>();
+			if (!keyProperties.isEmpty()) {
+				for (EdmProperty keyProperty : keyProperties) {
+					if (entry.getProperties().get(keyProperty.getName()) != null) {
+						keyPredicates.add(new KeyPredicateImpl(
+								entry.getProperties().get(keyProperty.getName()).toString(),
+								keyProperty));
+					} else {
+						String msg = "Cannot create entity without key(s)";
+						LOG.error(msg);
+						throw new ODataException(msg);
+					}
+				}
+				
+				((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
+				
+				// Re-read the inserted entity to get the auto-generated properties
+				SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+				OData2ResultSetEntity resultEntity = null;
+				Collection<EdmProperty> properties = getProperties(entityType);
+				try (Connection connection = getDataSource().getConnection()){
+					try (PreparedStatement statement = createSelectStatement(query, connection)){
+						try (ResultSet resultSet = statement.executeQuery()){
+							query.setOffset(resultSet);
+							while (query.next(resultSet)) {
+								if (resultEntity == null) {
+									Map<String, Object> data = readResultSet(query, entityType, properties, resultSet);
+									resultEntity = new OData2ResultSetEntity(data);
+								}
+							}
+						}
+					}
+					ODataResponse response = OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
+					this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
+					return response;
+				} catch (Exception e) {
+					LOG.error("Unable to serve request", e);
+					throw new ODataException(e);
+				}
+			}
+		} catch (Throwable t) {
+			LOG.error("Unable to get back the created entity", t);
+		}
+		
+		ODataContext context = getContext();
+		EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
+				.serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
+				.build();
+		final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
+		this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
+		return response;
+	}
+
+	public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
+			final String requestContentType, final boolean merge) throws ODataBadRequestException {
+		ODataEntry entryValues;
+		try {
+			EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
+					.mergeSemantic(merge).build();
+			entryValues = EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
+		} catch (Exception e) {
+			throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
+		}
+		return entryValues;
+	}
+
+	@Override
+	public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
+		if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
+			throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
+		}
+		if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
+			return this.odata2EventHandler.onDeleteEntity(uriInfo, contentType);
+		}
+		this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType);
+
+		SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
+
+		try (Connection connection = getDataSource().getConnection()) {
+			try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
+				statement.executeUpdate();
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+
+		ODataResponse response = ODataResponse.newBuilder().build();
+		this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType);
+		return response;
+	}
+
+	private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
+		Map<String, Object> keyMap = new HashMap<>();
+		for (final KeyPredicate key : keys) {
+			final EdmProperty property = key.getProperty();
+			final EdmSimpleType type = (EdmSimpleType) property.getType();
+			keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
+					property.getFacets(), type.getDefaultType()));
+		}
+		return keyMap;
+	}
+
+	@Override
+	public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
+			final String requestContentType, final boolean merge, final String contentType) throws ODataException {
+		if (uriInfo.getFilter() != null) {
+			throw new ODataException("Update operation is not allowed with $filter.");
+		}
+		if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+			throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
+		}
+
+		if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+			return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType);
+		}
+		
+		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+		OData2ResultSetEntity resultEntity = null;
+		Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
+		try (Connection connection = getDataSource().getConnection()) {
+			try (PreparedStatement statement = createSelectStatement(query, connection)) {
+				try (ResultSet resultSet = statement.executeQuery()) {
+					query.setOffset(resultSet);
+					while (query.next(resultSet)) {
+						if (resultEntity == null) {
+							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
+							resultEntity = new OData2ResultSetEntity(data);
+						}
+					}
+					if (resultEntity == null) {
+						throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
+					}
+				}
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+
+		ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
+		this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
+
+		SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
+				mapKeys(uriInfo.getKeyPredicates()), getContext());
+
+		try(Connection connection = getDataSource().getConnection()){
+			try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)){
+				statement.executeUpdate();
+			}
+		} catch (Exception e) {
+			LOG.error("Unable to serve request", e);
+			throw new ODataException(e);
+		}
+		ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
+		this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
+		return response;
+	}
+
+
+	protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
+		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+	}
+
+	protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
+		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+	}
+
+	protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
+		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+	}
+
+
+	protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
+		String sql = statement.sql();
+		LOG.info("SQL Statement: {}", sql);
+
+		PreparedStatement preparedStatement = connection.prepareStatement(sql);
+		setParamsOnStatement(preparedStatement, statement.getStatementParams());
+		return preparedStatement;
+	}
+
+	public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws EdmException, SQLException {
+		LOG.debug("SQL Params: {}", params);
+		SQLUtils.setParamsOnStatement(preparedStatement, params);
+	}
 
     @Override
-    public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
-        return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
+    public DataSource getDataSource() {
+        return dataSource;
     }
 
-    @Override
-    public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
-            throw new ODataNotImplementedException();
-        }
-        try {
-            SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
-
-            try (Connection connection = getDataSource().getConnection()) {
-                int count = doCountEntitySet(sqlQuery, connection);
-                return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
-            }
-        } catch (SQLException e) {
-            throw new ODataException(e);
-        }
-    }
-
-    @Override
-    public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        LOG.error("readEntityComplexProperty not implemented: {}", uriInfo.toString());
-        throw new ODataException("Not Implemented");
-    }
-
-    protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
-        // TODO cache the metadata, because it fires a DB query every time
-        // TODO do we really need to select the entities?
-        String sql = sqlQuery.buildSelect(createSQLContext(connection));
-        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-            LOG.info(sql);
-            setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                // TODO do we need to assert that resultSet.next() == true and subsequently
-                // resultSet.next() == false here?
-                resultSet.next();
-                return resultSet.getInt(1);
-            }
-        }
-    }
-
-    protected SQLContext createSQLContext(final Connection connection) throws SQLException {
-        return new SQLContext(connection.getMetaData(), this.getContext());
-    }
-
-    protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
-            throws SQLException, ODataException {
-        String sql = selectQuery.buildSelect(createSQLContext(connection));
-        LOG.info(sql);
-        PreparedStatement preparedStatement;
-        if (selectQuery.getSelectExpression().getSkip() != SQLSelectClause.NOT_SET) {
-            preparedStatement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-            /*
-             * Restrict fetch size to prevent OutOfMemoryErrors for huge page sizes. If no
-             * fetch size is specified, jConnect will fetch all records up to the requested
-             * page (in case of the last page, this would be the entire result set).
-             *
-             * Internal Incident:
-             * https://support.wdf.sap.corp/sap/support/message/1780258655
-             */
-
-            preparedStatement.setFetchSize(SQLQueryBuilder.DEFAULT_SERVER_PAGING_SIZE);
-
-        } else {
-            preparedStatement = connection.prepareStatement(sql);
-        }
-        setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
-        return preparedStatement;
-    }
-
-    // TODO add unit tests for the expand functionality
-    @Override
-    public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
-
-        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-        OData2ResultSetEntity resultEntity = null;
-        // TODO change logic to read columns from ResultSet? (key has to be read even if
-        // it is now requested via $select)
-        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    query.setOffset(resultSet);
-                    while (query.next(resultSet)) {
-
-                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-                            resultEntity = new OData2ResultSetEntity(data);
-                        }
-                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-                        if (hasExpand(expandEntities)) {
-                            processExpand(targetEntityType, query, resultSet, resultEntity, expandEntities);
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-        return OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
-    }
-
-    // TODO add unit tests for the expand functionality
-    @Override
-    public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        final InlineCount inlineCountType = uriInfo.getInlineCount();
-        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-        List<OData2ResultSetEntity> targetEntitiesResult = new ArrayList<>();
-
-        Integer count;
-        String nextLink;
-        try (Connection connection = getDataSource().getConnection()) {
-            if (inlineCountType == InlineCount.ALLPAGES) {
-                SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
-                count = doCountEntitySet(countEntitySet, connection); // does not close the connection
-            } else {
-                count = null;
-            }
-            SQLSelectBuilder query;
-            List<String> readIdsForExpand = new ArrayList<>();
-            if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
-                LOG.info("Reading the ids that will be used for $expand");
-                readIdsForExpand = readIdsForExpand(uriInfo);
-                LOG.info("Using IDs for $expand: {}", readIdsForExpand);
-            }
-            query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
-
-            try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    query.setOffset(resultSet);
-                    OData2ResultSetEntity currentResultSetEntity = null;
-
-                    // we iterate the ResultSet rows here
-                    // for every row, we create one target entity instance and compare it with the
-                    // previous one. If the key property values are different, then we move to the
-                    // next target instance.
-                    // Otherwise that row has only navigation properties, then in that iteration
-                    // only the navigation properties are set
-                    while (query.next(resultSet)) {// TODO remove the duplication here
-
-                        Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-                        OData2ResultSetEntity nextResultSetEntity = new OData2ResultSetEntity(data);
-
-                        LOG.info("Current object is " + nextResultSetEntity);
-                        if (OData2Utils.isEmpty(targetEntityType, nextResultSetEntity)) {
-                            continue;
-                        }
-                        if (!OData2Utils.isSameInstance(targetEntityType, currentResultSetEntity,
-                                nextResultSetEntity)) {
-                            // now the result set has a new entity
-                            currentResultSetEntity = nextResultSetEntity;
-                            targetEntitiesResult.add(currentResultSetEntity);
-                        }
-                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-                        if (hasExpand(expandEntities)) {
-                            processExpand(targetEntityType, query, resultSet, currentResultSetEntity, expandEntities);
-                        }
-                    }
-                    boolean needsNextLink = query.isServersidePaging() && targetEntitiesResult.size() == this
-                            .getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-                    nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-        return OData2Utils.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, targetEntitiesResult, contentType,
-                count, nextLink);
-    }
-
-    private void processExpand(EdmEntityType targetEntityType, SQLSelectBuilder query, ResultSet resultSet, OData2ResultSetEntity currentResultSetEntity,
-                               List<ArrayList<NavigationPropertySegment>> expandEntities) throws SQLException, ODataException {
-        for (List<NavigationPropertySegment> expandContents : expandEntities) {
-            for (NavigationPropertySegment expandContent : expandContents) {
-                EdmEntityType expandType = expandContent.getTargetEntitySet().getEntityType();
-                Map<String, Object> expandData = readResultSet(query, expandType, EdmUtils.getProperties(expandType), resultSet);
-                if (OData2Utils.isEmpty(expandType, expandData)) {
-                    // nothing there, we need to find the next one
-                    continue;
-                }
-                Map<String, Object> customizedExpandData = onCustomizeExpandedNavigatonProperty(targetEntityType, expandType, expandData);
-                currentResultSetEntity.addExpandedEntityProperties(expandType, customizedExpandData);
-            }
-        }
-    }
-
-    public List<String> readIdsForExpand(final GetEntitySetUriInfo uriInfo) throws ODataException {
-        List<String> idsOfLeadingEntities = new ArrayList<>();
-        try (Connection connection = getDataSource().getConnection()) {
-            SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
-            try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    queryForIdsInExpand.setOffset(resultSet);
-                    while (queryForIdsInExpand.next(resultSet)) {// TODO remove the duplication here
-                        // we select only the ids here (we assume that only one key property is in the
-                        // ID)
-                        // Override this method if this is not the case
-                        idsOfLeadingEntities.add(resultSet.getString(1));
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new ODataException(e);
-        }
-        return idsOfLeadingEntities;
-    }
-
-    /**
-     * Generates the next link for server-side paging. The next-link is based on the
-     * URI of the current request, except that {@code $skip} or {@code $skiptoken}
-     * will be removed.
-     *
-     * @param query            the query
-     * @param targetEntityType the target entity type
-     * @return the link
-     * @throws ODataException in case of an error
-     */
-    protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
-        int top = query.getSelectExpression().getTop();
-        int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-        return OData2Utils.generateNextLink(getContext(), top, pagingSize);
-    }
-
-    @Override
-    public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-        OData2ResultSetEntity resultEntity = null;
-        Collection<EdmProperty> properties = uriInfo.getPropertyPath();
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    query.setOffset(resultSet);
-                    while (query.next(resultSet)) {
-                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-                            resultEntity = new OData2ResultSetEntity(data);
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-        return OData2Utils.writeEntryPropertyValue(getContext(), uriInfo.getPropertyPath().iterator().next(),
-                (UriInfo) uriInfo, resultEntity, contentType);
-    }
-
-    @Override
-    public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-        OData2ResultSetEntity resultEntity = null;
-        Collection<EdmProperty> properties = uriInfo.getPropertyPath();
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    query.setOffset(resultSet);
-                    while (query.next(resultSet)) {
-                        if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
-                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-                            resultEntity = new OData2ResultSetEntity(data);
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-        return OData2Utils.writeEntryProperty(getContext(), uriInfo.getPropertyPath().iterator().next(),
-                (UriInfo) uriInfo, resultEntity, contentType);
-    }
-
-    @Override
-    public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        throw new ODataNotImplementedException();
-    }
-
-    @Override
-    public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
-            throws ODataException {
-        throw new ODataNotImplementedException();
-    }
-
-    protected Map<String, Object> readResultSet(SQLSelectBuilder selectEntityQuery, final EdmStructuralType entityType,
-                                                Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException {
-        Map<String, Object> result = new HashMap<>();
-        for (EdmProperty property : properties) {
-            result.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
-        }
-        return result;
-    }
-
-    protected Object readProperty(EdmStructuralType entityType, EdmProperty property, SQLSelectBuilder selectEntityQuery,
-                                  ResultSet resultSet) throws SQLException, ODataException {
-        Object propertyDbValue;
-        if (property.isSimple()) {
-            if (!selectEntityQuery.isTransientType(entityType, property)) {
-                final String columnName = selectEntityQuery.getSQLTableColumnAlias(entityType, property);
-                if ("Binary".equals(property.getType().getName())) {
-                    propertyDbValue = resultSet.getBytes(columnName);
-                } else {
-                    propertyDbValue = resultSet.getObject(columnName);
-                    propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
-                }
-                return propertyDbValue;
-            } else {
-                return null;
-            }
-        } else {
-            EdmStructuralType complexProperty = (EdmStructuralType) property.getType();
-            Map<String, Object> complexPropertyData = new HashMap<>();
-            for (String pn : complexProperty.getPropertyNames()) {
-                EdmProperty prop = (EdmProperty) complexProperty.getProperty(pn);
-                final String columnName = selectEntityQuery.getSQLTableColumnAlias(complexProperty, prop);
-                propertyDbValue = resultSet.getObject(columnName);
-                propertyDbValue = onCustomizePropertyValue(entityType, property, entityType, propertyDbValue);
-                complexPropertyData.put(pn, propertyDbValue);
-            }
-            return complexPropertyData;
-        }
-    }
-
-    @Override
-    public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
-                                      final String requestContentType, final String contentType) throws ODataException {
-
-        if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
-            throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
-                    OData2Utils.fqn(uriInfo.getTargetType())));
-        }
-
-        if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
-            return this.odata2EventHandler.onCreateEntity(uriInfo, content,
-                    requestContentType, contentType);
-        }
-
-        final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType entityType = entitySet.getEntityType();
-        ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
-        this.odata2EventHandler.beforeCreateEntity(uriInfo,
-                requestContentType, contentType, entry);
-
-        SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
-
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)) {
-                statement.executeUpdate();
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-
-        try {
-            List<EdmProperty> keyProperties = entityType.getKeyProperties();
-            List<KeyPredicate> keyPredicates = new ArrayList<>();
-            if (!keyProperties.isEmpty()) {
-                for (EdmProperty keyProperty : keyProperties) {
-                    if (entry.getProperties().get(keyProperty.getName()) != null) {
-                        keyPredicates.add(new KeyPredicateImpl(
-                                entry.getProperties().get(keyProperty.getName()).toString(),
-                                keyProperty));
-                    } else {
-                        String msg = "Cannot create entity without key(s)";
-                        LOG.error(msg);
-                        throw new ODataException(msg);
-                    }
-                }
-
-                ((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
-
-                // Re-read the inserted entity to get the auto-generated properties
-                SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-                OData2ResultSetEntity resultEntity = null;
-                Collection<EdmProperty> properties = getProperties(entityType);
-                try (Connection connection = getDataSource().getConnection()) {
-                    try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                        try (ResultSet resultSet = statement.executeQuery()) {
-                            query.setOffset(resultSet);
-                            while (query.next(resultSet)) {
-                                if (resultEntity == null) {
-                                    Map<String, Object> data = readResultSet(query, entityType, properties, resultSet);
-                                    resultEntity = new OData2ResultSetEntity(data);
-                                }
-                            }
-                        }
-                    }
-                    ODataResponse response = OData2Utils.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, resultEntity, contentType);
-                    this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-                    return response;
-                } catch (Exception e) {
-                    LOG.error("Unable to serve request", e);
-                    throw new ODataException(e);
-                }
-            }
-        } catch (Throwable t) {
-            LOG.error("Unable to get back the created entity", t);
-        }
-
-        ODataContext context = getContext();
-        EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
-                .serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
-                .build();
-        final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
-        this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-        return response;
-    }
-
-    public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
-                                       final String requestContentType, final boolean merge) throws ODataBadRequestException {
-        ODataEntry entryValues;
-        try {
-            EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
-                    .mergeSemantic(merge).build();
-            entryValues = EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
-        } catch (Exception e) {
-            throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
-        }
-        return entryValues;
-    }
-
-    @Override
-    public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
-        if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
-            throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
-        }
-        if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
-            return this.odata2EventHandler.onDeleteEntity(uriInfo, contentType);
-        }
-        this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType);
-
-        SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
-                statement.executeUpdate();
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-
-        ODataResponse response = ODataResponse.newBuilder().build();
-        this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType);
-        return response;
-    }
-
-    @Override
-    public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
-                                      final String requestContentType, final boolean merge, final String contentType) throws ODataException {
-        if (uriInfo.getFilter() != null) {
-            throw new ODataException("Update operation is not allowed with $filter.");
-        }
-        if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-            throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
-        }
-
-        if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-            return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType);
-        }
-
-        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-        OData2ResultSetEntity resultEntity = null;
-        Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createSelectStatement(query, connection)) {
-                try (ResultSet resultSet = statement.executeQuery()) {
-                    query.setOffset(resultSet);
-                    while (query.next(resultSet)) {
-                        if (resultEntity == null) {
-                            Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
-                            resultEntity = new OData2ResultSetEntity(data);
-                        }
-                    }
-                    if (resultEntity == null) {
-                        throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-
-        ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
-        this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-
-        SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
-                mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-        try (Connection connection = getDataSource().getConnection()) {
-            try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)) {
-                statement.executeUpdate();
-            }
-        } catch (Exception e) {
-            LOG.error("Unable to serve request", e);
-            throw new ODataException(e);
-        }
-        ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
-        this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-        return response;
+    void setDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
     }
 
     @Override
@@ -703,41 +739,5 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
                 }
             }
         }
-    }
-
-    protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
-        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-    }
-
-    protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
-        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-    }
-
-    protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
-        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-    }
-
-
-    protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
-        String sql = statement.sql();
-        LOG.info("SQL Statement: {}", sql);
-
-        PreparedStatement preparedStatement = connection.prepareStatement(sql);
-        setParamsOnStatement(preparedStatement, statement.getStatementParams());
-        return preparedStatement;
-    }
-
-    public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws SQLException {
-        LOG.debug("SQL Params: {}", params);
-        SQLUtils.setParamsOnStatement(preparedStatement, params);
-    }
-
-    @Override
-    public DataSource getDataSource() {
-        return dataSource;
-    }
-
-    void setDataSource(DataSource dataSource) {
-        this.dataSource = dataSource;
     }
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/DefaultSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/DefaultSQLProcessor.java
@@ -86,7 +86,10 @@ public class DefaultSQLProcessor extends AbstractSQLProcessor {
             }
             context = parent;
         }
-        DataSource ds = (DataSource) context.getParameter(DEFAULT_DATA_SOURCE_CONTEXT_KEY);
+        DataSource ds = super.getDataSource();
+        if (ds == null) {
+            ds = (DataSource) context.getParameter(DEFAULT_DATA_SOURCE_CONTEXT_KEY);
+        }
         if (ds == null) {
             throw new OData2Exception("Unable to get the dataSource from the context. Please provide the datasource.",
                     INTERNAL_SERVER_ERROR);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/utils/SingleConnectionDataSource.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/utils/SingleConnectionDataSource.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.odata2.sql.utils;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.logging.Logger;
+/**
+ * The operations in a OData changeset must be executed within one transaction (connection)
+ * Therefore we create a single and non-closable connection datasource for simplicity
+ */
+public class SingleConnectionDataSource implements DataSource {
+
+
+    private final Connection nonClosableConnection;
+
+    public SingleConnectionDataSource(Connection connection){
+       this.nonClosableConnection = getNonClosableConnection(connection);
+    }
+
+    @Override
+    public Connection getConnection() {
+        return nonClosableConnection;
+    }
+
+    @Override
+    public Connection getConnection(String username, String password){
+        return nonClosableConnection;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter printWriter) {
+        throw new UnsupportedOperationException("Not supported");
+
+    }
+
+    @Override
+    public void setLoginTimeout(int i) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public int getLoginTimeout() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> aClass) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> aClass) {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    Connection getNonClosableConnection(Connection connection) {
+        return (Connection) Proxy.newProxyInstance(
+                this.getClass().getClassLoader(),
+                new Class<?>[] {Connection.class},
+                new NonClosableConnection(connection));
+    }
+
+
+    private static class NonClosableConnection implements InvocationHandler {
+
+        private final Connection delegate;
+
+        public NonClosableConnection(Connection delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+            switch (method.getName()) {
+                case "equals":
+                    return (proxy == args[0]);
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "close":
+                    return null;
+                case "isClosed":
+                    return delegate.isClosed();
+            }
+            try {
+                return method.invoke(this.delegate, args);
+            } catch (InvocationTargetException ex) {
+                throw ex.getTargetException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?
Provides support for transactions and batching #1282 #843 

### What issues does this PR fix or reference?
Closes #1282 
Closes #843

Note: If you want to use transactions for customer operations, you can use a custom data source that uses only one connection, set auto-commit false on the connection perform the requests and then commit the transaction. The class org.eclipse.dirigible.engine.odata2.sql.utils.SingleConnectionDataSource  can be used for that purpose in custom code.
This approach is very similar to how the changesets in the batch support are implemented. 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Support for batching and transactions. Added unit tests.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Documentation
<!-- Please add a matching PR to [the docs repo](https://github.com/dirigible-io/dirigible-io.github.io) and link that PR to this issue.
Both will be merged at the same time. -->
