### PR TITLE
fix: handle relative imported scripts from parent folder having dirig…

### DIFF
--- a/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/GraalVMJavascriptEngineExecutor.java
+++ b/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/GraalVMJavascriptEngineExecutor.java
@@ -113,7 +113,7 @@ public class GraalVMJavascriptEngineExecutor extends AbstractJavascriptExecutor 
         }
 
         if (isModule) {
-            ResourcePath resourcePath = getResourcePath(moduleOrCode, MODULE_EXT_JS, MODULE_EXT_GRAALVM);
+            ResourcePath resourcePath = getResourcePath(moduleOrCode, MODULE_EXT_JS, MODULE_EXT_MJS, MODULE_EXT_GRAALVM);
             moduleOrCode = resourcePath.getModule();
             if (HttpRequestFacade.isValid()) {
                 HttpRequestFacade.setAttribute(HttpRequestFacade.ATTRIBUTE_REST_RESOURCE_PATH, resourcePath.getPath());

--- a/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/truffle/StandardPathHandler.java
+++ b/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/truffle/StandardPathHandler.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.dirigible.engine.js.graalvm.processor.truffle;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.dirigible.engine.api.script.IScriptEngineExecutor;
 import org.eclipse.dirigible.engine.api.script.Module;
 
@@ -37,6 +38,11 @@ class StandardPathHandler {
     Path handlePossibleRepositoryPath(Path path) {
         String pathString = path.toString();
         pathString = pathString.replace("\\", "/");
+
+        String maybeDirigibleScope = tryExtractDirigibleScope(pathString);
+        if (maybeDirigibleScope != null) {
+            return Paths.get(maybeDirigibleScope);
+        }
 
         if (pathString.startsWith(Constants.CURRENT_DIRECTORY)
                 || pathString.startsWith(Constants.PARENT_DIRECTORY)) {
@@ -74,5 +80,14 @@ class StandardPathHandler {
 
     private Module getModuleFromRepository(String root, String pathString, IScriptEngineExecutor executor) {
         return executor.retrieveModule(root, pathString, Constants.MJS_EXTENSION);
+    }
+
+    private String tryExtractDirigibleScope(String pathString) {
+        int maybeDirigibleScopeIndex = pathString.indexOf("/@dirigible/");
+        if (maybeDirigibleScopeIndex == -1) {
+            return null;
+        }
+
+        return pathString.substring(maybeDirigibleScopeIndex);
     }
 }

--- a/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/api/AbstractJavascriptExecutor.java
+++ b/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/api/AbstractJavascriptExecutor.java
@@ -22,6 +22,9 @@ public abstract class AbstractJavascriptExecutor extends AbstractScriptExecutor 
 	/** The Constant MODULE_EXT_JS. */
 	public static final String MODULE_EXT_JS = ".js/";
 
+	/** The Constant MODULE_EXT_MJS. */
+	public static final String MODULE_EXT_MJS = ".mjs/";
+
 	/** The Constant MODULE_EXT_RHINO. */
 	public static final String MODULE_EXT_RHINO = ".rhino/";
 


### PR DESCRIPTION
Handle cases when a JS file imports another JS file from a sibling folder and the latter imports a `@dirigible` package.