### PR TITLE
fix: add modules.json and add test for sibling imports with dirigible imports

### DIFF
--- a/api/api-javascript/api-bpm/src/main/resources/META-INF/dirigible/bpm/extensions/bpm.d.ts
+++ b/api/api-javascript/api-bpm/src/main/resources/META-INF/dirigible/bpm/extensions/bpm.d.ts
@@ -1,0 +1,8 @@
+declare module "@dirigible/bpm" {
+    module deployer {
+    }
+    module process {
+    }
+    module tasks {
+    }
+}

--- a/api/api-javascript/api-bpm/src/main/resources/META-INF/dirigible/bpm/extensions/modules.json
+++ b/api/api-javascript/api-bpm/src/main/resources/META-INF/dirigible/bpm/extensions/modules.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "@dirigible/bpm",
+    "description": "Dirigible BPM Module",
+    "isPackageDescription": true,
+    "dtsPath": "bpm/extensions/bpm.d.ts"
+  },
+  {
+    "name": "bpm/v4/deployer",
+    "description": "BPM Deployer API",
+    "api": "deployer",
+    "versionedPaths": [
+      "bpm/v4/deployer",
+      "bpm/v4/deployer"
+    ],
+    "pathDefault": "bpm/v4/deployer"
+  },
+  {
+    "name": "bpm/v4/process",
+    "description": "BPM Process API",
+    "api": "process",
+    "versionedPaths": [
+      "bpm/v4/process",
+      "bpm/v3/process"
+    ],
+    "pathDefault": "bpm/v4/process"
+  },
+  {
+    "name": "bpm/v4/tasks",
+    "description": "BPM Tasks API",
+    "api": "tasks",
+    "versionedPaths": [
+      "bpm/v4/tasks",
+      "bpm/v3/tasks"
+    ],
+    "pathDefault": "bpm/v4/tasks"
+  }
+]

--- a/api/api-javascript/api-core/src/main/resources/META-INF/dirigible/core/extensions/core.d.ts
+++ b/api/api-javascript/api-core/src/main/resources/META-INF/dirigible/core/extensions/core.d.ts
@@ -1,5 +1,5 @@
 declare module "@dirigible/core" {
-    module configuration {
+    module configurations {
         /**
          * Returns the value for the specified key, or the default value
          * @param key

--- a/api/api-javascript/api-core/src/main/resources/META-INF/dirigible/core/extensions/modules.json
+++ b/api/api-javascript/api-core/src/main/resources/META-INF/dirigible/core/extensions/modules.json
@@ -8,7 +8,7 @@
   {
     "name": "core/v4/configurations",
     "description": "Configurations API",
-    "api": "configuration",
+    "api": "configurations",
     "versionedPaths": [
       "core/v4/configurations",
       "core/v3/configurations"

--- a/modules/engines/engine-javascript-graalvm/src/test/resources/META-INF/dirigible/graalvm/ecmascript/relativeImports/l11/l11_with_dirigible_import.mjs
+++ b/modules/engines/engine-javascript-graalvm/src/test/resources/META-INF/dirigible/graalvm/ecmascript/relativeImports/l11/l11_with_dirigible_import.mjs
@@ -1,0 +1,6 @@
+import { bytes } from "@dirigible/io"
+
+export const expectedTestData = "test123";
+
+const testDataBytes = bytes.textToByteArray(expectedTestData);
+export const actualTestData = bytes.byteArrayToText(testDataBytes);

--- a/modules/engines/engine-javascript-graalvm/src/test/resources/META-INF/dirigible/graalvm/ecmascript/relativeImports/l12/l12.mjs
+++ b/modules/engines/engine-javascript-graalvm/src/test/resources/META-INF/dirigible/graalvm/ecmascript/relativeImports/l12/l12.mjs
@@ -1,7 +1,9 @@
 import { root } from '../root.mjs';
 import { l11, exported } from '../l11/l11.mjs';
+import { expectedTestData, actualTestData } from '../l11/l11_with_dirigible_import.mjs'
 
 var assertEquals = require('utils/assert').assertEquals;
 assertEquals(root, 'root', "root import failed");
 assertEquals(l11, 'l11', "l11 import failed");
 assertEquals(exported, 'l12', "exported import failed");
+assertEquals(expectedTestData, expectedTestData, "import of @dirigible/io or the encoding failed in l11_with_dirigible_import.mjs");


### PR DESCRIPTION
Fixes: https://github.com/eclipse/dirigible/issues/1447

This PR adds:
- Test for the case of import of a file from a sibling folder that has a `@dirigible` import inside of it
- Add `modules.json` for the `api-bpm` module
- Add empty `bpm.d.ts` file for the `api-bpm` module (this and other `d.ts` files would be updated at a later point)