### PR TITLE
Fix getGitRepositories returning projects without git repos

### DIFF
--- a/api/api-facade/api-git/src/main/java/org/eclipse/dirigible/api/v4/git/GitFacade.java
+++ b/api/api-facade/api-git/src/main/java/org/eclipse/dirigible/api/v4/git/GitFacade.java
@@ -92,16 +92,6 @@ public class GitFacade implements IScriptingFacade {
                 }
             }
         }
-        IRepository repository = workspaceObject.getRepository();
-        for (IProject next : workspaceObject.getProjects()) {
-            if (!repository.isLinkedPath(next.getPath())) {
-                ProjectDescriptor project = new ProjectDescriptor();
-                project.setGit(false);
-                project.setName(next.getName());
-                project.setPath(next.getPath());
-                gitRepositories.add(project);
-            }
-        }
         return gitRepositories;
     }
 


### PR DESCRIPTION
GitFacade.getGitRepositories should return only projects with initialized repositories.