### PR TITLE
feat: support importing zips into a given path

### DIFF
--- a/modules/repository/repository-zip/src/main/java/org/eclipse/dirigible/repository/zip/RepositoryZipImporter.java
+++ b/modules/repository/repository-zip/src/main/java/org/eclipse/dirigible/repository/zip/RepositoryZipImporter.java
@@ -154,13 +154,12 @@ public class RepositoryZipImporter {
 								String extension = ContentTypeHelper.getExtension(name);
 								String mimeType = ContentTypeHelper.getContentType(extension);
 								boolean isBinary = ContentTypeHelper.isBinary(mimeType);
+								logger.debug("importZip creating resource: " + outpath);
 								if (mimeType != null) {
-									logger.debug("importZip creating resource: " + outpath);
 									logger.debug("importZip creating resource is binary?: " + isBinary);
 									repository.createResource(outpath, content, isBinary, mimeType, override);
 
 								} else {
-									logger.debug("importZip creating resource: " + outpath);
 									repository.createResource(outpath, content, true, ContentTypeHelper.APPLICATION_OCTET_STREAM,
 											override);
 								}

--- a/modules/services/service-transport/src/main/java/org/eclipse/dirigible/runtime/transport/processor/TransportProcessor.java
+++ b/modules/services/service-transport/src/main/java/org/eclipse/dirigible/runtime/transport/processor/TransportProcessor.java
@@ -15,6 +15,7 @@ import org.eclipse.dirigible.commons.config.StaticObjects;
 import org.eclipse.dirigible.core.workspace.api.IProject;
 import org.eclipse.dirigible.core.workspace.api.IWorkspace;
 import org.eclipse.dirigible.core.workspace.service.WorkspacesCoreService;
+import org.eclipse.dirigible.repository.api.ICollection;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 
@@ -30,12 +31,34 @@ public class TransportProcessor {
 	/**
 	 * Import project.
 	 *
-	 * @param workspace the workspace
+	 * @param workspaceName the workspace name
 	 * @param content the content
 	 */
-	public void importProject(String workspace, byte[] content) {
-		IWorkspace workspaceApi = getWorkspace(workspace);
-		repository.importZip(content, workspaceApi.getPath(), true, false, null);
+	public void importProjectInWorkspace(String workspaceName, byte[] content) {
+		IWorkspace workspace = getWorkspace(workspaceName);
+		String workspacePath = workspace.getPath();
+		importProject(workspacePath, content);
+	}
+
+	public void importProjectInPath(String path, byte[] content) {
+		ICollection importedZipFolder = getOrCreateCollection(path);
+		String importedZipFolderPath = importedZipFolder.getPath();
+		importProject(importedZipFolderPath, content);
+	}
+
+	private void importProject(String path, byte[] content) {
+		repository.importZip(content, path, true, false, null);
+	}
+
+	private ICollection getOrCreateCollection(String path) {
+		ICollection repositoryRootCollection = repository.getRoot();
+		ICollection importedZipFolder = repositoryRootCollection.getCollection(path);
+
+		if (!importedZipFolder.exists()) {
+			importedZipFolder = repositoryRootCollection.createCollection(path);
+		}
+
+		return importedZipFolder;
 	}
 
 	/**


### PR DESCRIPTION
Fixes: https://github.com/eclipse/dirigible/issues/1483

This PR adds support for importing zips into a given path which would be treated as relative to the Repository root path.
The new endpoint is a POST to `/project?path=/some/path/relative/to/the/repository/root`