### PR TITLE
fix: change how we clone projects without a specified branch

### DIFF
--- a/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/GitConnectorFactory.java
+++ b/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/GitConnectorFactory.java
@@ -43,7 +43,7 @@ public class GitConnectorFactory {
 	 *            the path to an existing Git Repository
 	 * @return a newly created {@link IGitConnector} object
 	 * @throws GitConnectorException
-	 *             Git Connector Exception 
+	 *             Git Connector Exception
 	 */
 	public static IGitConnector getConnector(String repositoryDirectory) throws GitConnectorException {
 		try {
@@ -82,6 +82,7 @@ public class GitConnectorFactory {
 	public static IGitConnector cloneRepository(String repositoryDirectory, String repositoryUri, String username, String password, String branch)
 			throws InvalidRemoteException, TransportException, GitAPIException {
 		try {
+			branch = branchOrNull(branch);
 
 			CloneCommand cloneCommand = Git.cloneRepository();
 			cloneCommand.setURI(repositoryUri);
@@ -96,6 +97,10 @@ public class GitConnectorFactory {
 		} catch (Exception e) {
 			throw new TransportException(e.getMessage());
 		}
+	}
+
+	private static String branchOrNull(String branch) {
+		return (branch != null && !branch.isEmpty()) ? branch : null;
 	}
 
 	public static void initRepository(String repositoryDirectory, Boolean isBare) throws TransportException, GitAPIException {

--- a/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/command/CloneCommand.java
+++ b/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/command/CloneCommand.java
@@ -149,10 +149,6 @@ public class CloneCommand {
 	protected void cloneProject(final String user, final String repositoryURI, String repositoryBranch, final String username, final String password,
 			File gitDirectory, IWorkspace workspace, Set<String> clonedProjects, String optionalProjectName) throws GitConnectorException {
 		try {
-			if (repositoryBranch == null || repositoryBranch.isEmpty()) {
-				repositoryBranch = getDefaultBranch(repositoryURI);
-			}
-			
 			logger.debug(String.format("Cloning repository %s, with username %s for branch %s in the directory %s ...", repositoryURI, username,
 					repositoryBranch, gitDirectory.getCanonicalPath()));
 			GitConnectorFactory.cloneRepository(gitDirectory.getCanonicalPath(), repositoryURI, username, password, repositoryBranch);
@@ -285,8 +281,6 @@ public class CloneCommand {
 	/**
 	 * Generate workspace path.
 	 *
-	 * @param user
-	 *            the user
 	 * @param workspace
 	 *            the workspace
 	 * @return the string builder
@@ -295,41 +289,6 @@ public class CloneCommand {
 		StringBuilder relativePath = new StringBuilder(IRepositoryStructure.PATH_USERS).append(IRepositoryStructure.SEPARATOR).append(UserFacade.getName())
 				.append(IRepositoryStructure.SEPARATOR).append(workspace);
 		return relativePath.toString();
-	}
-	
-	private String getDefaultBranch(String gitUrl) throws InvalidRemoteException, TransportException, GitAPIException {
-		
-		String result = "refs/heads/master";
-		String defaultId = "";
-		
-		Ref head = Git.lsRemoteRepository()
-				.setRemote(gitUrl)
-				.callAsMap()
-				.get("HEAD");
-		
-		if (head != null) {
-		   if(head.isSymbolic()) {
-		      Ref b = head.getTarget();
-		      defaultId = b.getName();
-		   } else {
-			   AnyObjectId id = head.getObjectId();
-			   defaultId = id.getName();
-		   }
-		}
-		
-		Map<String, Ref> refMap = Git.lsRemoteRepository()
-			    .setRemote(gitUrl)
-			    .setHeads(true)
-			    .setTags(true)
-			    .callAsMap();
-		
-		for (Map.Entry<String, Ref> entry : refMap.entrySet()) {
-			if (entry.getValue().getObjectId().getName().equals(defaultId)) {
-				result = entry.getKey();
-			}
-		}
-		
-		return result.substring(result.lastIndexOf('/') + 1);
 	}
 
 }

--- a/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/command/ShareCommand.java
+++ b/modules/core/core-git/src/main/java/org/eclipse/dirigible/core/git/command/ShareCommand.java
@@ -91,8 +91,6 @@ public class ShareCommand {
 	private void shareToGitRepository(final String user, final IWorkspace workspace, final IProject project, final String commitMessage, final String username,
 			final String email, final String password, final String gitRepositoryURI, final String gitRepositoryBranch) throws GitConnectorException {
 		String errorMessage = String.format("Error occurred while sharing project [%s].", project.getName());
-		
-		String branch = gitRepositoryBranch != null ? gitRepositoryBranch : ProjectMetadataManager.BRANCH_MASTER;
 
 		projectMetadataManager.ensureProjectMetadata(workspace, project.getName());
 
@@ -107,12 +105,12 @@ public class ShareCommand {
 
 			if (!isExistingGitRepository) {
 				logger.debug(String.format("Cloning repository %s, with username %s for branch %s in the directory %s ...", gitRepositoryURI, username,
-						branch, tempGitDirectory.getCanonicalPath()));
-				GitConnectorFactory.cloneRepository(tempGitDirectory.getCanonicalPath(), gitRepositoryURI, username, password, branch);
+						gitRepositoryBranch, tempGitDirectory.getCanonicalPath()));
+				GitConnectorFactory.cloneRepository(tempGitDirectory.getCanonicalPath(), gitRepositoryURI, username, password, gitRepositoryBranch);
 				logger.debug(String.format("Cloning repository %s finished.", gitRepositoryURI));
 			} else {
 				logger.debug(String.format("Sharing to existing git repository %s, with username %s for branch %s in the directory %s ...", gitRepositoryURI, username,
-						branch, tempGitDirectory.getCanonicalPath()));
+						gitRepositoryBranch, tempGitDirectory.getCanonicalPath()));
 			}
 
 			IGitConnector gitConnector = GitConnectorFactory.getConnector(tempGitDirectory.getCanonicalPath());


### PR DESCRIPTION
Fixes: https://github.com/eclipse/dirigible/issues/1457

Currently, we get the default repository branch by checking the HEAD. This is not necessary as stated in the JGit docs: https://archive.eclipse.org/jgit/site/4.5.0.201609210915-r/apidocs/org/eclipse/jgit/api/CloneCommand.html#setBranch-java.lang.String-