### PR TITLE
feat: add new process executor and change ExecFacade implementation

### DIFF
--- a/api/api-facade/api-core/src/test/java/org/eclipse/dirigible/api/v3/core/test/ExecFacadeTest.java
+++ b/api/api-facade/api-core/src/test/java/org/eclipse/dirigible/api/v3/core/test/ExecFacadeTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import org.eclipse.dirigible.api.v3.core.ExecFacade;
 import org.eclipse.dirigible.commons.config.Configuration;
@@ -27,7 +28,7 @@ import org.junit.Test;
 public class ExecFacadeTest extends AbstractDirigibleTest {
 
     @Test
-    public void execTest() {
+    public void execTest() throws ExecutionException, InterruptedException {
         String commandLine = null;
         String expectedUnsetValue = null;
         if (Configuration.isOSUNIX() || Configuration.isOSMac()) {

--- a/modules/commons/commons-process/pom.xml
+++ b/modules/commons/commons-process/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-exec</artifactId>
-			<version>1.3</version>
+			<version>${commons.exec}</version>
 		</dependency>
 
 	</dependencies>

--- a/modules/commons/commons-process/pom.xml
+++ b/modules/commons/commons-process/pom.xml
@@ -41,7 +41,13 @@
 			<artifactId>dirigible-commons-config</artifactId>
 			<version>7.0.0-SNAPSHOT</version>
     	</dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-exec</artifactId>
+			<version>1.3</version>
+		</dependency>
+
+	</dependencies>
 
 	<properties>
 		<license.header.location>../../../licensing-header.txt</license.header.location>

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/DefaultProcessExecutor.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/DefaultProcessExecutor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.PumpStreamHandler;
+import org.eclipse.dirigible.commons.process.execution.output.OutputsPair;
+import org.eclipse.dirigible.commons.process.execution.output.ProcessResult;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public final class DefaultProcessExecutor extends ProcessExecutor<OutputsPair> {
+
+    @Override
+    public Future<ProcessResult<OutputsPair>> executeProcess(CommandLine commandLine, DefaultExecutor executor, Map<String, String> environmentVariables) throws IOException {
+        ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+        ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+        PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(stdOut, stdErr);
+        executor.setStreamHandler(pumpStreamHandler);
+
+        ProcessExecutionFuture processExecutionFuture = execute(executor, commandLine, environmentVariables);
+
+        return processExecutionFuture.thenApply(exitCode -> {
+            String output = stdOut.toString(StandardCharsets.UTF_8);
+            String errorOutput = stdErr.toString(StandardCharsets.UTF_8);
+            OutputsPair outputsPair = new OutputsPair(output, errorOutput);
+            return new ProcessResult<>(exitCode, outputsPair);
+        });
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ErrorsRedirectProcessExecutor.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ErrorsRedirectProcessExecutor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution;
+
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.exec.PumpStreamHandler;
+import org.eclipse.dirigible.commons.process.execution.output.ProcessResult;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public final class ErrorsRedirectProcessExecutor extends ProcessExecutor<String> {
+
+    @Override
+    public Future<ProcessResult<String>> executeProcess(CommandLine commandLine, DefaultExecutor executor, Map<String, String> environmentVariables) throws IOException {
+        ByteArrayOutputStream stdOutAndErr = new ByteArrayOutputStream();
+        PumpStreamHandler pumpStreamHandler = new PumpStreamHandler(stdOutAndErr);
+        executor.setStreamHandler(pumpStreamHandler);
+        ProcessExecutionFuture processExecutionFuture = execute(executor, commandLine, environmentVariables);
+
+        return processExecutionFuture.thenApply(exitCode -> {
+            String outAndErr = stdOutAndErr.toString(StandardCharsets.UTF_8);
+            return new ProcessResult<>(exitCode, outAndErr);
+        });
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionException.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution;
+
+public class ProcessExecutionException extends RuntimeException{
+    public ProcessExecutionException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution;
+
+import org.apache.commons.exec.ExecuteException;
+import org.apache.commons.exec.ExecuteResultHandler;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ProcessExecutionFuture extends CompletableFuture<Integer> implements ExecuteResultHandler {
+
+    @Override
+    public void onProcessComplete(int i) {
+        complete(i);
+    }
+
+    @Override
+    public void onProcessFailed(ExecuteException e) {
+        completeExceptionally(e);
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutor.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution;
+
+import org.apache.commons.exec.*;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.dirigible.commons.process.Commandline;
+import org.eclipse.dirigible.commons.process.execution.output.OutputsPair;
+import org.eclipse.dirigible.commons.process.execution.output.ProcessResult;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.Future;
+
+public abstract class ProcessExecutor<TOut> {
+
+    public static ProcessExecutor<String> createWithErrorsRedirect() {
+        return new ErrorsRedirectProcessExecutor();
+    }
+
+    public static ProcessExecutor<OutputsPair> create() {
+        return new DefaultProcessExecutor();
+    }
+
+    public Future<ProcessResult<TOut>> executeProcess(String path, Map<String, String> environmentVariables) {
+        try {
+            Pair<String, String[]> executableAndArgs = toExecutableAndArgs(path);
+            CommandLine commandLine = new CommandLine(executableAndArgs.getLeft());
+            commandLine.addArguments(executableAndArgs.getRight(), false);
+            DefaultExecutor executor = new DefaultExecutor();
+            return executeProcess(commandLine, executor, environmentVariables);
+        } catch (Throwable t) {
+            throw new ProcessExecutionException(t);
+        }
+    }
+
+    private static Pair<String, String[]> toExecutableAndArgs(String path) {
+        String[] parts = Commandline.translateCommandline(path);
+        String executable = parts[0];
+        String[] arguments = parts.length > 1 ? Arrays.copyOfRange(parts, 1, parts.length) : new String[]{};
+        return Pair.of(executable, arguments);
+    }
+
+    public abstract Future<ProcessResult<TOut>> executeProcess(CommandLine commandLine, DefaultExecutor executor, Map<String, String> environmentVariables) throws IOException;
+
+    protected ProcessExecutionFuture execute(DefaultExecutor executor, CommandLine commandLine, Map<String, String> environmentVariables) throws IOException {
+        ProcessExecutionFuture processExecutionFuture = new ProcessExecutionFuture();
+        executor.execute(commandLine, environmentVariables, processExecutionFuture);
+        return processExecutionFuture;
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/output/OutputsPair.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/output/OutputsPair.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution.output;
+
+public class OutputsPair {
+
+    private final String standardOutput;
+    private final String errorOutput;
+
+    public OutputsPair(String standardOutput, String errorOutput) {
+        this.standardOutput = standardOutput;
+        this.errorOutput = errorOutput;
+    }
+
+    public String getStandardOutput() {
+        return standardOutput;
+    }
+
+    public String getErrorOutput() {
+        return errorOutput;
+    }
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/output/ProcessResult.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/output/ProcessResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.execution.output;
+
+public class ProcessResult<TOut> {
+
+    private final int exitCode;
+    private final TOut output;
+
+    public ProcessResult(int exitCode, TOut output) {
+        this.exitCode = exitCode;
+        this.output = output;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public TOut getProcessOutputs() {
+        return output;
+    }
+}

--- a/modules/engines/engine-command/src/main/java/org/eclipse/dirigible/engine/command/processor/CommandEngineExecutor.java
+++ b/modules/engines/engine-command/src/main/java/org/eclipse/dirigible/engine/command/processor/CommandEngineExecutor.java
@@ -11,12 +11,12 @@
  */
 package org.eclipse.dirigible.engine.command.processor;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.eclipse.dirigible.api.v3.http.HttpRequestFacade;
 import org.eclipse.dirigible.api.v3.http.HttpResponseFacade;
@@ -222,7 +222,7 @@ public class CommandEngineExecutor extends AbstractScriptExecutor implements ISc
 			logger.error(e.getMessage(), e);
 			throw new ScriptingException(e);
 		}
-		result = new String(out.toByteArray());
+		result = out.toString(StandardCharsets.UTF_8);
 		return result;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -680,6 +680,7 @@
 		<commons.io>2.11.0</commons.io>
 		<commons.codec>1.15</commons.codec>
 		<commons.lang3>3.12.0</commons.lang3>
+		<commons.exec>1.3</commons.exec>
 		<cxf.version>3.5.0</cxf.version>
 		<gson.version>2.8.5</gson.version>
 		<mockito.version>2.23.0</mockito.version>


### PR DESCRIPTION
Related to: https://github.com/eclipse/dirigible/issues/1491 and https://github.com/SAP/xsk/issues/1120

Currently, the ExecFacade uses a process executor that combines the error and out streams. This is not desired in some cases. The current process executor API is not easily extendable and would need some refactoring to support this. 

This PR proposes a new API for executing command-line programs with the idea of extending it over time for our needs. An advantage of this API is that it returns a Future. This would allow us at a later point to support the `async/await` style in JS if we want to. 

One current disadvantage of it is that it doesn't support timeouts. This could easily be supported as the Apache Exec has the notion of watchdogs that could do the work.