### PR TITLE
feat: support bpmn mjs class and method execution

### DIFF
--- a/modules/bpm/bpm-flowable/src/main/java/org/eclipse/dirigible/bpm/flowable/DirigibleCallDelegate.java
+++ b/modules/bpm/bpm-flowable/src/main/java/org/eclipse/dirigible/bpm/flowable/DirigibleCallDelegate.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import org.eclipse.dirigible.bpm.flowable.dto.ExecutionData;
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
 import org.eclipse.dirigible.commons.api.scripting.ScriptingException;
+import org.eclipse.dirigible.engine.api.resource.ResourcePath;
+import org.eclipse.dirigible.engine.api.script.AbstractScriptExecutor;
 import org.eclipse.dirigible.engine.api.script.ScriptEngineExecutorsManager;
 import org.eclipse.dirigible.engine.js.api.IJavascriptEngineExecutor;
 import org.flowable.engine.delegate.BpmnError;
@@ -26,61 +28,96 @@ import org.flowable.engine.impl.el.FixedValue;
 import org.springframework.beans.BeanUtils;
 
 public class DirigibleCallDelegate implements JavaDelegate {
-	
-	private FixedValue handler;
-	
-	private FixedValue type;
-	
-	/**
-	 * Getter for the handler attribute
-	 * @return the handler
-	 */
-	public FixedValue getHandler() {
-		return handler;
-	}
-	
-	/**
-	 * Setter of the handler attribute
-	 * @param handler the handler
-	 */
-	public void setHandler(FixedValue handler) {
-		this.handler = handler;
-	}
-	
-	/**
-	 * Getter for the engine attribute
-	 * @return the type
-	 */
-	public FixedValue getType() {
-		return type;
-	}
-	
-	/**
-	 * Setter of the engine attribute
-	 * @param type the type
-	 */
-	public void setType(FixedValue type) {
-		this.type = type;
-	}
-	
-	@Override
-	public void execute(DelegateExecution execution) {
-		
-		try {
-			Map<Object, Object> context = new HashMap<>();
-			ExecutionData executionData = new ExecutionData();
-			BeanUtils.copyProperties(execution, executionData);
-			context.put("execution", GsonHelper.GSON.toJson(executionData));
-			if (type == null) {
-				type = new FixedValue(IJavascriptEngineExecutor.JAVASCRIPT_TYPE_DEFAULT);
-			}
-			if (handler == null) {
-				throw new BpmnError("Handler cannot be null at the call delegate.");
-			}
-			ScriptEngineExecutorsManager.executeServiceModule(this.type.getExpressionText(), this.handler.getExpressionText(), context);
-		} catch (ScriptingException e) {
-			throw new BpmnError(e.getMessage());
-		}		
-	}
+
+    private FixedValue handler;
+
+    private FixedValue type;
+
+    /**
+     * Getter for the handler attribute
+     *
+     * @return the handler
+     */
+    public FixedValue getHandler() {
+        return handler;
+    }
+
+    /**
+     * Setter of the handler attribute
+     *
+     * @param handler the handler
+     */
+    public void setHandler(FixedValue handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * Getter for the engine attribute
+     *
+     * @return the type
+     */
+    public FixedValue getType() {
+        return type;
+    }
+
+    /**
+     * Setter of the engine attribute
+     *
+     * @param type the type
+     */
+    public void setType(FixedValue type) {
+        this.type = type;
+    }
+
+    @Override
+    public void execute(DelegateExecution execution) {
+
+        try {
+            Map<Object, Object> context = new HashMap<>();
+            ExecutionData executionData = new ExecutionData();
+            BeanUtils.copyProperties(execution, executionData);
+            context.put("execution", GsonHelper.GSON.toJson(executionData));
+            if (type == null) {
+                type = new FixedValue(IJavascriptEngineExecutor.JAVASCRIPT_TYPE_DEFAULT);
+            }
+            if (handler == null) {
+                throw new BpmnError("Handler cannot be null at the call delegate.");
+            }
+
+            executeJSHandler(context);
+
+        } catch (ScriptingException e) {
+            throw new BpmnError(e.getMessage());
+        }
+    }
+
+    private Object executeJSHandler(Map<Object, Object> context) {
+        ResourcePath resourcePath = AbstractScriptExecutor.generateResourcePath(handler.getExpressionText(), new String[]{".mjs/", ".js/"});
+
+        if (resourcePath.getModule().endsWith(".js")) {
+            return ScriptEngineExecutorsManager.executeServiceModule(type.getExpressionText(), handler.getExpressionText(), context);
+        }
+
+        return executeES6ModuleMethod(resourcePath, context);
+    }
+
+    private Object executeES6ModuleMethod(ResourcePath resourcePath, Map<Object, Object> context) {
+        String module = resourcePath.getModule();
+        String member = resourcePath.getPath();
+
+        String memberClass;
+        String memberMethod;
+
+        if (member.contains("/")) {
+            String[] splits = member.split("/");
+            memberClass = splits[0];
+            memberMethod = splits[1];
+        } else {
+            memberClass = null;
+            memberMethod = member;
+        }
+
+        return ScriptEngineExecutorsManager.executeMethodFromModule(type.getExpressionText(), module, memberClass, memberMethod, context);
+    }
 
 }

--- a/modules/engines/engine-api/src/main/java/org/eclipse/dirigible/engine/api/script/IScriptEngineExecutor.java
+++ b/modules/engines/engine-api/src/main/java/org/eclipse/dirigible/engine/api/script/IScriptEngineExecutor.java
@@ -108,4 +108,6 @@ public interface IScriptEngineExecutor extends IEngineExecutor {
 
 	public Object evalModule(String module, Map<Object, Object> executionContext) throws ScriptingException;
 
+	public Object executeMethodFromModule(String module, String memberClass, String memberClassMethod, Map<Object, Object> executionContext);
+
 }

--- a/modules/engines/engine-api/src/main/java/org/eclipse/dirigible/engine/api/script/ScriptEngineExecutorsManager.java
+++ b/modules/engines/engine-api/src/main/java/org/eclipse/dirigible/engine/api/script/ScriptEngineExecutorsManager.java
@@ -25,104 +25,112 @@ import org.eclipse.dirigible.commons.api.scripting.ScriptingException;
  */
 public class ScriptEngineExecutorsManager {
 
-	/**
-	 * Execute service module.
-	 *
-	 * @param engineType
-	 *            the engine type
-	 * @param module
-	 *            the module
-	 * @param executionContext
-	 *            the execution context
-	 * @return the object
-	 * @throws ScriptingException
-	 *             the scripting exception
-	 */
-	public static Object executeServiceModule(String engineType, String module, Map<Object, Object> executionContext) throws ScriptingException {
-		IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor(engineType);
-		if (scriptEngineExecutor != null) {
-			try {
-				ThreadContextFacade.setUp();
-				
-				return scriptEngineExecutor.executeServiceModule(module, executionContext);
-			} finally {
-				ThreadContextFacade.tearDown();
-			}
-		}
+    /**
+     * Execute service module.
+     *
+     * @param engineType       the engine type
+     * @param module           the module
+     * @param executionContext the execution context
+     * @return the object
+     * @throws ScriptingException the scripting exception
+     */
+    public static Object executeServiceModule(String engineType, String module, Map<Object, Object> executionContext) throws ScriptingException {
+        IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor(engineType);
+        if (scriptEngineExecutor != null) {
+            try {
+                ThreadContextFacade.setUp();
 
-		throw new ScriptingException(
-				format("Script Executor of Type [{0}] does not exist, hence the Module [{1}] cannot be processed", engineType, module));
-	}
+                return scriptEngineExecutor.executeServiceModule(module, executionContext);
+            } finally {
+                ThreadContextFacade.tearDown();
+            }
+        }
 
-	/**
-	 * Evaluate a code snippet
-	 * 
-	 * @param code the code snippet
-	 * @param executionContext the execution context 
-	 * @return the result object
-	 * @throws ScriptingException in case of exception
-	 */
-	public static Object evalModule(String code, Map<Object, Object> executionContext) throws ScriptingException {
-		IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor("javascript");
-		if (scriptEngineExecutor != null) {
-			try {
-				ThreadContextFacade.setUp();
-				
-				return scriptEngineExecutor.evalModule(code, executionContext);
-			} finally {
-				ThreadContextFacade.tearDown();
-			}
-		}
+        throw new ScriptingException(
+                format("Script Executor of Type [{0}] does not exist, hence the Module [{1}] cannot be processed", engineType, module));
+    }
 
-		throw new ScriptingException(
-				format("Script Executor of Type [{0}] does not exist, hence the Script [{1}] cannot be processed", "javascript", code));
-	}
+    /**
+     * Evaluate a code snippet
+     *
+     * @param code             the code snippet
+     * @param executionContext the execution context
+     * @return the result object
+     * @throws ScriptingException in case of exception
+     */
+    public static Object evalModule(String code, Map<Object, Object> executionContext) throws ScriptingException {
+        IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor("javascript");
+        if (scriptEngineExecutor != null) {
+            try {
+                ThreadContextFacade.setUp();
 
-	/**
-	 * Execute service code.
-	 *
-	 * @param engineType
-	 *            the engine type
-	 * @param code
-	 *            the code
-	 * @param executionContext
-	 *            the execution context
-	 * @return the object
-	 * @throws ScriptingException
-	 *             the scripting exception
-	 */
-	public static Object executeServiceCode(String engineType, String code, Map<Object, Object> executionContext) throws ScriptingException {
-		IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor(engineType);
-		if (scriptEngineExecutor != null) {
-			try {
-				ThreadContextFacade.setUp();
-				
-				return scriptEngineExecutor.evalCode(code, executionContext);
-			} finally {
-				ThreadContextFacade.tearDown();
-			}
-		}
+                return scriptEngineExecutor.evalModule(code, executionContext);
+            } finally {
+                ThreadContextFacade.tearDown();
+            }
+        }
 
-		throw new ScriptingException(
-				format("Script Executor of Type [{0}] does not exist, hence the code [{1}] cannot be processed", engineType, code));
-	}
-	
-	/**
-	 * Returns all the registered engine types
-	 * 
-	 * @return engine types
-	 */
-	public static Set<String> getEngineTypes() {
-		return ScriptEngineExecutorFactory.getEnginesTypes();
-	}
-	
-	/**
-	 * Returns all the registered engine types as JSON
-	 * 
-	 * @return engine types as JSON
-	 */
-	public static String getEngineTypesAsJson() {
-		return GsonHelper.GSON.toJson(getEngineTypes());
-	}
+        throw new ScriptingException(
+                format("Script Executor of Type [{0}] does not exist, hence the Script [{1}] cannot be processed", "javascript", code));
+    }
+
+    /**
+     * Execute service code.
+     *
+     * @param engineType       the engine type
+     * @param code             the code
+     * @param executionContext the execution context
+     * @return the object
+     * @throws ScriptingException the scripting exception
+     */
+    public static Object executeServiceCode(String engineType, String code, Map<Object, Object> executionContext) throws ScriptingException {
+        IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor(engineType);
+        if (scriptEngineExecutor != null) {
+            try {
+                ThreadContextFacade.setUp();
+
+                return scriptEngineExecutor.evalCode(code, executionContext);
+            } finally {
+                ThreadContextFacade.tearDown();
+            }
+        }
+
+        throw new ScriptingException(
+                format("Script Executor of Type [{0}] does not exist, hence the code [{1}] cannot be processed", engineType, code));
+    }
+
+    public static Object executeMethodFromModule(String engineType, String module, String memberClass, String memberMethod, Map<Object, Object> executionContext) throws ScriptingException {
+        IScriptEngineExecutor scriptEngineExecutor = ScriptEngineExecutorFactory.getScriptEngineExecutor(engineType);
+        if (scriptEngineExecutor != null) {
+            try {
+                ThreadContextFacade.setUp();
+
+                return scriptEngineExecutor.executeMethodFromModule(module, memberClass, memberMethod, executionContext);
+            } finally {
+                ThreadContextFacade.tearDown();
+            }
+        }
+
+        throw new ScriptingException(
+                format("Script Executor of Type [{0}] does not exist, hence the Module [{1}] cannot be processed", engineType, module));
+    }
+
+    /**
+     * Returns all the registered engine types
+     *
+     * @return engine types
+     */
+    public static Set<String> getEngineTypes() {
+        return ScriptEngineExecutorFactory.getEnginesTypes();
+    }
+
+    /**
+     * Returns all the registered engine types as JSON
+     *
+     * @return engine types as JSON
+     */
+    public static String getEngineTypesAsJson() {
+        return GsonHelper.GSON.toJson(getEngineTypes());
+    }
 
 }

--- a/modules/engines/engine-command/src/main/java/org/eclipse/dirigible/engine/command/processor/CommandEngineExecutor.java
+++ b/modules/engines/engine-command/src/main/java/org/eclipse/dirigible/engine/command/processor/CommandEngineExecutor.java
@@ -106,6 +106,11 @@ public class CommandEngineExecutor extends AbstractScriptExecutor implements ISc
 		return executeService(module, executionContext, true);
 	}
 
+	@Override
+	public Object executeMethodFromModule(String module, String memberClass, String memberClassMethod, Map<Object, Object> executionContext) {
+		throw new RuntimeException(this.getClass().getSimpleName() + " does not support executing ES6 modules!");
+	}
+
 	/**
 	 * Execute service.
 	 *

--- a/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/GraalVMJavaScriptContextBuilder.java
+++ b/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/processor/GraalVMJavaScriptContextBuilder.java
@@ -53,6 +53,7 @@ class GraalVMJavaScriptContextBuilder {
             String project = StringUtils.substringBeforeLast(moduleOrCode, "/");
             RegistryTruffleFileSystem registryTruffleFileSystem = truffleFileSystemProvider.apply(project);
             contextBuilder.fileSystem(registryTruffleFileSystem);
+            contextBuilder.option("js.esm-eval-returns-exports", "true");
         }
 
 

--- a/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/processor/DefaultJavascriptEngineExecutor.java
+++ b/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/processor/DefaultJavascriptEngineExecutor.java
@@ -114,4 +114,10 @@ public class DefaultJavascriptEngineExecutor extends AbstractJavascriptExecutor 
 		logger.error(format("Default Javascript Engine Executor not found."));
 		return null;
 	}
+
+	@Override
+	public Object executeMethodFromModule(String module, String memberClass, String memberClassMethod, Map<Object, Object> executionContext) {
+		IJavascriptEngineExecutor engine = getJavascriptEngine();
+		return engine.executeMethodFromModule(module, memberClass, memberClassMethod, executionContext);
+	}
 }


### PR DESCRIPTION
Currently, the BPMN engine in Dirigible supports only executing scripts. This PR enables execution of ES6 modules with a provided `className/methodName` pair or a `methodName`.