### PR TITLE
[OData] Improve skip/offset logic

### DIFF
--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderComplexTypeTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderComplexTypeTest.java
@@ -69,7 +69,7 @@ public class SQLSelectBuilderComplexTypeTest {
         String expected = "SELECT T0.ID AS \"ID_T0\", T0.DESCRIPTION AS \"DESCRIPTION_T0\", T1.CT_ID AS \"CT_ID_T1\", T1.CT_DETAIL AS \"CT_DETAIL_T1\" " +
                 "FROM ENTITY3_TABLE AS T0 " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T1 ON T1.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -86,7 +86,7 @@ public class SQLSelectBuilderComplexTypeTest {
         String expected = "SELECT T0.ID AS \"ID_T0\", T0.DESCRIPTION AS \"DESCRIPTION_T0\", T1.CT_ID AS \"CT_ID_T1\", T1.CT_DETAIL AS \"CT_DETAIL_T1\" " +
                 "FROM ENTITY3_TABLE AS T0 " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T1 ON T1.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
-                "WHERE T1.CT_ID = ? FETCH FIRST 1000 ROWS ONLY";
+                "WHERE T1.CT_ID = ? ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -104,7 +104,7 @@ public class SQLSelectBuilderComplexTypeTest {
                 "FROM ENTITY3_TABLE AS T0 " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T1 ON T1.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
                 "WHERE T1.CT_ID = ? AND T0.ID = ? " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -122,7 +122,7 @@ public class SQLSelectBuilderComplexTypeTest {
                 "FROM ENTITY3_TABLE AS T0 " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T1 ON T1.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
                 "WHERE (T1.CT_ID = ? OR T0.ID = ?) AND T0.ID = ? " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -139,7 +139,7 @@ public class SQLSelectBuilderComplexTypeTest {
         String expected = "SELECT T1.CT_ID AS \"CT_ID_T1\", T1.CT_DETAIL AS \"CT_DETAIL_T1\", T0.ID AS \"ID_T0\" " +
                 "FROM ENTITY3_TABLE AS T0 " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T1 ON T1.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 

--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderExpandTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderExpandTest.java
@@ -71,7 +71,7 @@ public class SQLSelectBuilderExpandTest {
                 "T1.NAME AS \"NAME_T1\", T1.VALUE AS \"VALUE_T1\" " +
                 "FROM MPLHEADER AS T0 " +
                 "LEFT JOIN ITOP_MPLUSERDEFINEDATTRIBUTE AS T1 ON T1.HEADER_ID = T0.ID " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.MESSAGEGUID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -89,7 +89,7 @@ public class SQLSelectBuilderExpandTest {
                 "T1.FK_ID4_1 AS \"FK_ID4_1_T1\", T1.FK_ID4_2 AS \"FK_ID4_2_T1\" " +
                 "FROM ENTITY4_TABLE AS T0 " +
                 "LEFT JOIN ENTITY5_TABLE AS T1 ON T1.FK_ID4_1 = T0.ID4_1 AND T1.FK_ID4_2 = T0.ID4_2 " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID4_1 ASC, T0.ID4_2 ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -109,7 +109,7 @@ public class SQLSelectBuilderExpandTest {
                 "T1.ID4_3 AS \"ID4_3_T1\" " +
                 "FROM ENTITY5_TABLE AS T0 " +
                 "LEFT JOIN ENTITY4_TABLE AS T1 ON T1.ID4_1 = T0.FK_ID4_1 AND T1.ID4_2 = T0.FK_ID4_2 " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID5 ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -127,7 +127,7 @@ public class SQLSelectBuilderExpandTest {
         String expected = "SELECT T0.ID AS \"ID_T0\", T0.NAME AS \"NAME_T0\", T0.VALUE AS \"VALUE_T0\", T1.MESSAGEGUID AS \"MESSAGEGUID_T1\", T1.LOGSTART AS \"LOGSTART_T1\", T1.LOGEND AS \"LOGEND_T1\", T1.SENDER AS \"SENDER_T1\", T1.RECEIVER AS \"RECEIVER_T1\", T1.STATUS AS \"STATUS_T1\", T1.MESSAGEGUID AS \"MESSAGEGUID_T1\" " +
                 "FROM ITOP_MPLUSERDEFINEDATTRIBUTE AS T0 " +
                 "LEFT JOIN MPLHEADER AS T1 ON T1.ID = T0.HEADER_ID " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -146,7 +146,7 @@ public class SQLSelectBuilderExpandTest {
                 "FROM ITOP_MPLUSERDEFINEDATTRIBUTE AS T0 " +
                 "LEFT JOIN MPLHEADER AS T1 ON T1.ID = T0.HEADER_ID " +
                 "WHERE T1.MESSAGEGUID = ? " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 
@@ -167,7 +167,7 @@ public class SQLSelectBuilderExpandTest {
                 "FROM ENTITY5_TABLE AS T0 " +
                 "LEFT JOIN ENTITY4_TABLE AS T1 ON T1.ID4_1 = T0.FK_ID4_1 AND T1.ID4_2 = T0.FK_ID4_2 " +
                 "WHERE T1.ID4_1 = ? AND T1.ID4_2 = ? " +
-                "FETCH FIRST 1000 ROWS ONLY";
+                "ORDER BY T0.ID5 ASC FETCH FIRST 1000 ROWS ONLY";
         assertEquals(expected, q.buildSelect(context));
     }
 

--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderNavigationPropertiesTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLSelectBuilderNavigationPropertiesTest.java
@@ -72,7 +72,7 @@ public class SQLSelectBuilderNavigationPropertiesTest {
         assertEquals("SELECT T0.ID AS \"ID_T0\", T0.NAME AS \"NAME_T0\", T0.VALUE AS \"VALUE_T0\" " +
                 "FROM ITOP_MPLUSERDEFINEDATTRIBUTE AS T0 " +
                 "LEFT JOIN MPLHEADER AS T1 ON T1.ID = T0.HEADER_ID WHERE T1.STATUS = ? " +
-                "AND T0.VALUE = ?" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
+                "AND T0.VALUE = ? ORDER BY T0.ID ASC" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
     }
 
     //    @Test
@@ -137,7 +137,7 @@ public class SQLSelectBuilderNavigationPropertiesTest {
                 "FROM ENTITY3_TABLE AS T0 LEFT JOIN ITOP_MPLUSERDEFINEDATTRIBUTE AS T3 ON T3.ID = T0.ID_OF_ENTITY2 " +
                 "LEFT JOIN MPLHEADER AS T1 ON T1.ID = T3.HEADER_ID " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T2 ON T2.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
-                "WHERE T1.STATUS = ? AND T0.DESCRIPTION = ?" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
+                "WHERE T1.STATUS = ? AND T0.DESCRIPTION = ? ORDER BY T0.ID ASC" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class SQLSelectBuilderNavigationPropertiesTest {
                 "LEFT JOIN ITOP_MPLUSERDEFINEDATTRIBUTE AS T3 ON T3.ID = T0.ID_OF_ENTITY2 " +
                 "LEFT JOIN MPLHEADER AS T1 ON T1.ID = T3.HEADER_ID " +
                 "LEFT JOIN COMPLEX_TYPE_ENTITY_TABLE AS T2 ON T2.CT_ID = T0.COMPLEX_TYPE_JOIN_COLUMN " +
-                "WHERE T1.STATUS = ? AND T2.CT_DETAIL = ?" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
+                "WHERE T1.STATUS = ? AND T2.CT_DETAIL = ? ORDER BY T0.ID ASC" + SERVER_SIDE_PAGING_DEFAULT_SUFFIX, q.buildSelect(context));
     }
 
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLQueryBuilder.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLQueryBuilder.java
@@ -85,9 +85,6 @@ public class SQLQueryBuilder {
 
         final Integer effectiveSkip = calculateEffectiveSkip(uri);
 
-        if (effectiveSkip != null && effectiveTop != null) {
-            effectiveTop += effectiveSkip;
-        }
         if (readIdsForExpand == null || readIdsForExpand.isEmpty()) {
             //no expand, we filter as usual
             q.select(uri.getSelect(), uri.getExpand()).top(effectiveTop).skip(effectiveSkip).from(target);
@@ -226,13 +223,7 @@ public class SQLQueryBuilder {
 
     private boolean calculateNeedsServersidePaging(UriInfo uri) throws EdmException {
         final Integer top = uri.getTop();
-        boolean needsServersidePaging;
-        if (top == null || top > getEntityPagingSize(uri.getTargetEntitySet().getEntityType())) {
-            needsServersidePaging = true;
-        } else {
-            needsServersidePaging = false;
-        }
-        return needsServersidePaging;
+        return top == null || top > getEntityPagingSize(uri.getTargetEntitySet().getEntityType());
     }
 
     /**
@@ -262,7 +253,7 @@ public class SQLQueryBuilder {
             effectiveSkip = skipToken + skip;
         } else if (skipToken == null && skip != null) {
             effectiveSkip = skip;
-        } else if (skipToken != null && skip == null) {
+        } else if (skipToken != null) {
             effectiveSkip = skipToken;
         } else {
             effectiveSkip = null;

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -128,23 +128,8 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 			throws SQLException, ODataException {
 		String sql = selectQuery.buildSelect(createSQLContext(connection));
 		LOG.info(sql);
-		PreparedStatement preparedStatement;
-		if (selectQuery.getSelectExpression().getSkip() != SQLSelectClause.NOT_SET) {
-			preparedStatement = connection.prepareStatement(sql, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
-			/*
-			 * Restrict fetch size to prevent OutOfMemoryErrors for huge page sizes. If no
-			 * fetch size is specified, jConnect will fetch all records up to the requested
-			 * page (in case of the last page, this would be the entire result set).
-			 * 
-			 * Internal Incident:
-			 * https://support.wdf.sap.corp/sap/support/message/1780258655
-			 */
+		PreparedStatement preparedStatement = connection.prepareStatement(sql);
 
-			preparedStatement.setFetchSize(SQLQueryBuilder.DEFAULT_SERVER_PAGING_SIZE);
-
-		} else {
-			preparedStatement = connection.prepareStatement(sql);
-		}
 		setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
 		return preparedStatement;
 	}
@@ -165,8 +150,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 		try (Connection connection = getDataSource().getConnection()){
 			try (PreparedStatement statement = createSelectStatement(query, connection)){
 				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
+					while (resultSet.next()) {
 
 						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
 							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
@@ -217,7 +201,6 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 
 			try (PreparedStatement statement = createSelectStatement(query, connection)) {
 				try (ResultSet resultSet = statement.executeQuery()) {
-					query.setOffset(resultSet);
 					OData2ResultSetEntity currentResultSetEntity = null;
 
 					// we iterate the ResultSet rows here
@@ -226,7 +209,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 					// next target instance.
 					// Otherwise that row has only navigation properties, then in that iteration
 					// only the navigation properties are set
-					while (query.next(resultSet)) {// TODO remove the duplication here
+					while (resultSet.next()) {// TODO remove the duplication here
 
 						Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
 						OData2ResultSetEntity nextResultSetEntity = new OData2ResultSetEntity(data);
@@ -281,8 +264,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 			SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
 			try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
 				try (ResultSet resultSet = statement.executeQuery()) {
-					queryForIdsInExpand.setOffset(resultSet);
-					while (queryForIdsInExpand.next(resultSet)) {// TODO remove the duplication here
+					while (resultSet.next()) {// TODO remove the duplication here
 						// we select only the ids here (we assume that only one key property is in the
 						// ID)
 						// Override this method if this is not the case
@@ -325,8 +307,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 		try (Connection connection = getDataSource().getConnection()){
 			try (PreparedStatement statement = createSelectStatement(query, connection)){
 				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
+					while (resultSet.next()) {
 						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
 							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
 							resultEntity = new OData2ResultSetEntity(data);
@@ -354,8 +335,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 		try (Connection connection = getDataSource().getConnection()){
 			try(PreparedStatement statement = createSelectStatement(query, connection)){
 				try (ResultSet resultSet = statement.executeQuery()){
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
+					while (resultSet.next()) {
 						if (resultEntity == null) {// TODO remove the duplication here with the readEntitySet
 							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
 							resultEntity = new OData2ResultSetEntity(data);
@@ -478,8 +458,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 				try (Connection connection = getDataSource().getConnection()){
 					try (PreparedStatement statement = createSelectStatement(query, connection)){
 						try (ResultSet resultSet = statement.executeQuery()){
-							query.setOffset(resultSet);
-							while (query.next(resultSet)) {
+							while (resultSet.next()) {
 								if (resultEntity == null) {
 									Map<String, Object> data = readResultSet(query, entityType, properties, resultSet);
 									resultEntity = new OData2ResultSetEntity(data);
@@ -579,8 +558,7 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 		try (Connection connection = getDataSource().getConnection()) {
 			try (PreparedStatement statement = createSelectStatement(query, connection)) {
 				try (ResultSet resultSet = statement.executeQuery()) {
-					query.setOffset(resultSet);
-					while (query.next(resultSet)) {
+					while (resultSet.next()) {
 						if (resultEntity == null) {
 							Map<String, Object> data = readResultSet(query, targetEntityType, properties, resultSet);
 							resultEntity = new OData2ResultSetEntity(data);


### PR DESCRIPTION
Fix for #1555 

Change log:
1. **$skip** is now implemented with OFFSET for all DBs
2. **$top** is now implemented with LIMIT for all DBs
3. remove requirement for support of ResultSet **TYPE_SCROLL_INSENSITIVE** by the DB drivers