### PR TITLE
Javascript http client option to put params in body only

### DIFF
--- a/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/extensions/http.d.ts
+++ b/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/extensions/http.d.ts
@@ -1232,5 +1232,9 @@ declare module "@dirigible/http" {
          * The SSL trust all enabled parameter
          */
         sslTrustAllEnabled?: boolean;
+        /**
+         * Whether to put params in the body. If not set or set to false, params are put in the URL
+         */
+        paramsInBody?: boolean;
     }
 }

--- a/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
+++ b/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
@@ -93,8 +93,8 @@ exports.trace = function(_url, options) {
 };
 
 function buildUrl(url, options) {
-    let noParams = options === undefined || options === null || options.params === undefined || options.params === null || options.params.length === 0;
-    let paramsInBody = options.paramsInBody !== undefined && options.paramsInBody == true;
+	let noParams = options === undefined || options === null || options.params === undefined || options.params === null || options.params.length === 0;
+	let paramsInBody = options.paramsInBody !== undefined && options.paramsInBody == true;
 	if (noParams || paramsInBody) {
 		return url;
 	}

--- a/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
+++ b/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
@@ -94,7 +94,7 @@ exports.trace = function(_url, options) {
 
 function buildUrl(url, options) {
 	let noParams = options === undefined || options === null || options.params === undefined || options.params === null || options.params.length === 0;
-	let paramsInBody = options.paramsInBody !== undefined && options.paramsInBody == true;
+	let paramsInBody = options !== undefined && options.paramsInBody !== undefined && options.paramsInBody == true;
 	if (noParams || paramsInBody) {
 		return url;
 	}

--- a/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
+++ b/api/api-javascript/api-http/src/main/resources/META-INF/dirigible/http/v4/client.js
@@ -93,7 +93,9 @@ exports.trace = function(_url, options) {
 };
 
 function buildUrl(url, options) {
-	if (options === undefined || options === null || options.params === undefined || options.params === null || options.params.length === 0) {
+    let noParams = options === undefined || options === null || options.params === undefined || options.params === null || options.params.length === 0;
+    let paramsInBody = options.paramsInBody !== undefined && options.paramsInBody == true;
+	if (noParams || paramsInBody) {
 		return url;
 	}
 	for (let i = 0; i < options.params.length; i ++) {


### PR DESCRIPTION
Allow setting params only in body instead of in path when making requests 

related to https://github.com/SAP/xsk/issues/1228