### PR TITLE
Handle OData default order by when there is no primary keys

### DIFF
--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClauseTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClauseTest.java
@@ -68,16 +68,6 @@ public class SQLOrderByClauseTest {
     }
 
     @Test
-    public void testOrderByWithNoCols() throws Exception {
-        OrderByExpression orderBy = UriParser.parse(edm, new ArrayList<>(), new HashMap<>()).getOrderBy();
-        EdmEntityType type = edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName());
-        SQLSelectBuilder noop = new SQLSelectBuilder(tableMappingProvider);
-        SQLOrderByClause sqlOrderBy = new SQLOrderByClause(noop, type, orderBy);
-
-        assertEquals("T0.MESSAGEGUID ASC", sqlOrderBy.evaluate(null));
-    }
-
-    @Test
     public void testOrderByWithNoOrderBy() throws Exception {
         OrderByExpression orderBy = UriParser.parse(edm, new ArrayList<>(), new HashMap<>()).getOrderBy();
         EdmEntityType type = edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName());

--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClauseTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClauseTest.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.dirigible.engine.odata2.sql.clause;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import org.apache.olingo.odata2.annotation.processor.core.edm.AnnotationEdmProvider;
 import org.apache.olingo.odata2.api.edm.EdmEntityType;
 import org.apache.olingo.odata2.api.uri.UriParser;
@@ -65,10 +67,29 @@ public class SQLOrderByClauseTest {
         assertEquals("T0.STATUS DESC, T0.LOGEND ASC, T0.LOGSTART DESC", sqlOrderBy.evaluate(null));
     }
 
+    @Test
+    public void testOrderByWithNoCols() throws Exception {
+        OrderByExpression orderBy = UriParser.parse(edm, new ArrayList<>(), new HashMap<>()).getOrderBy();
+        EdmEntityType type = edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName());
+        SQLSelectBuilder noop = new SQLSelectBuilder(tableMappingProvider);
+        SQLOrderByClause sqlOrderBy = new SQLOrderByClause(noop, type, orderBy);
+
+        assertEquals("T0.MESSAGEGUID ASC", sqlOrderBy.evaluate(null));
+    }
+
+    @Test
+    public void testOrderByWithNoOrderBy() throws Exception {
+        OrderByExpression orderBy = UriParser.parse(edm, new ArrayList<>(), new HashMap<>()).getOrderBy();
+        EdmEntityType type = edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName());
+        SQLSelectBuilder noop = new SQLSelectBuilder(tableMappingProvider);
+        SQLOrderByClause sqlOrderBy = new SQLOrderByClause(noop, type, orderBy);
+
+        assertEquals("T0.MESSAGEGUID ASC", sqlOrderBy.evaluate(null));
+    }
+
     private SQLOrderByClause createOrderByExpression(final String expression) {
-        OrderByExpression orderBy;
         try {
-            orderBy = UriParser.parseOrderBy(edm, edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName()),
+            OrderByExpression orderBy = UriParser.parseOrderBy(edm, edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName()),
                     expression);
             EdmEntityType type = edm.getEntityType(Entity1.class.getPackage().getName(), Entity1.class.getSimpleName());
             SQLSelectBuilder noop = new SQLSelectBuilder(tableMappingProvider);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClause.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLOrderByClause.java
@@ -33,6 +33,7 @@ import static org.apache.olingo.odata2.api.commons.HttpStatusCodes.INTERNAL_SERV
 
 public class SQLOrderByClause implements SQLClause {
 
+    private static final String EMPTY_STRING = "";
     private final OrderByExpression orderByExpression;
     private final SQLSelectBuilder query;
     private final EdmEntityType entityType;
@@ -58,6 +59,10 @@ public class SQLOrderByClause implements SQLClause {
     private String getDefaultExpression(SQLContext context)
         throws EdmException {
         List<String> keyPropertyNames = entityType.getKeyPropertyNames();
+        if (null == keyPropertyNames || keyPropertyNames.isEmpty()){
+            return EMPTY_STRING;
+        }
+
         String defaultOrderByExpression = String.join(",", keyPropertyNames);
         OrderByParserImpl orderByParser = new OrderByParserImpl(entityType);
         OrderByExpression orderExpression;


### PR DESCRIPTION
Minor fix in OrderByClause