### PR TITLE
feat: add prettier formatting support

### DIFF
--- a/api/api-facade/api-platform/src/main/java/org/eclipse/dirigible/api/v3/platform/RepositoryFacade.java
+++ b/api/api-facade/api-platform/src/main/java/org/eclipse/dirigible/api/v3/platform/RepositoryFacade.java
@@ -164,20 +164,6 @@ public class RepositoryFacade {
 	 * @throws ScriptingException in case of an error
 	 */
 	public static String find(String path, String pattern) throws IOException, ScriptingException {
-		ICollection collection = getCollection(path);
-		if (collection.exists() && collection instanceof LocalCollection) {
-			List<String> list = FileSystemUtils.find(((LocalCollection) collection).getFolder().getPath(), pattern);
-			int repositoryRootLength = ((LocalCollection) collection.getRepository().getRoot()).getFolder().getPath().length();
-			List<String> prepared = new ArrayList<String>();
-			list.forEach(item -> {
-					String truncated = item.substring(repositoryRootLength);
-					if (!IRepository.SEPARATOR.equals(File.separator)) {
-						truncated = truncated.replace(File.separator, IRepository.SEPARATOR);
-					}
-					prepared.add(truncated);
-				});
-			return GsonHelper.GSON.toJson(prepared);
-		}
-		return "[]";
+		return repositoryProcessor.find(path, pattern);
 	}
 }

--- a/groups/ide-services-all/pom.xml
+++ b/groups/ide-services-all/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>dirigible-ide-service-workspaces</artifactId>
             <version>7.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-ide-service-editor</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/ide/services/ide-editor/pom.xml
+++ b/ide/services/ide-editor/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.dirigible</groupId>
+        <artifactId>dirigible-ide-service-parent</artifactId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>IDE - Service - Editor</name>
+    <artifactId>dirigible-ide-service-editor</artifactId>
+    <packaging>jar</packaging>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <debug>true</debug>
+                    <debuglevel>lines,vars,source</debuglevel>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-commons-api</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-api-facade-security</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-api-facade-platform</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <license.header.location>../../../licensing-header.txt</license.header.location>
+    </properties>
+
+</project>

--- a/ide/services/ide-editor/src/main/java/org/eclipse/dirigible/runtime/ide/editor/services/EditorRestService.java
+++ b/ide/services/ide-editor/src/main/java/org/eclipse/dirigible/runtime/ide/editor/services/EditorRestService.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.runtime.ide.editor.services;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.dirigible.api.v3.security.UserFacade;
+import org.eclipse.dirigible.commons.api.helpers.ContentTypeHelper;
+import org.eclipse.dirigible.commons.api.service.AbstractRestService;
+import org.eclipse.dirigible.commons.api.service.IRestService;
+import org.eclipse.dirigible.commons.config.StaticObjects;
+import org.eclipse.dirigible.repository.api.ICollection;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IResource;
+import org.eclipse.dirigible.repository.api.RepositoryPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Objects;
+
+/**
+ * Front facing REST service serving the Editor content.
+ */
+@Path("/ide/editor")
+@Api(value = "IDE - Editor", authorizations = {@Authorization(value = "basicAuth", scopes = {})})
+@ApiResponses({@ApiResponse(code = 401, message = "Unauthorized"), @ApiResponse(code = 403, message = "Forbidden")})
+public class EditorRestService extends AbstractRestService implements IRestService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EditorRestService.class);
+
+    private final IRepository repository = (IRepository) StaticObjects.get(StaticObjects.REPOSITORY);
+
+    @Context
+    private HttpServletResponse response;
+
+    /**
+     * Finds all prettier config file paths inside a project
+     *
+     * @param workspaceName the workspace
+     * @param projectName   the project to search the config file in
+     * @param filePath      the config file name with extension
+     * @return the found prettier config paths
+     */
+    @GET
+    @Path("/prettier/config/{workspaceName}/{projectName}/{path:.*}")
+    public Response findPrettierConfig(
+            @PathParam("workspaceName") String workspaceName,
+            @PathParam("projectName") String projectName,
+            @PathParam("path") String filePath,
+            @Context HttpServletRequest request) {
+        String user = UserFacade.getName();
+        if (user == null) {
+            return createErrorResponseForbidden(NO_LOGGED_IN_USER);
+        }
+
+        String configFileName = ".prettierrc.json";
+        String configContentType = "application/json";
+        String separator = IRepository.SEPARATOR;
+
+        String projectPath = joinPathParts(separator, "users", user, workspaceName, projectName);
+        String queryPath = joinPathParts(separator, "prettier", "config", workspaceName, projectName, filePath);
+
+        RepositoryPath sourceFilePath = new RepositoryPath(projectPath + IRepository.SEPARATOR + filePath);
+        RepositoryPath sourceFolder = sourceFilePath.getParentPath();
+        String sourceFileName = sourceFilePath.getLastSegment();
+        ICollection lookupDirectory = repository.getCollection(sourceFolder.getPath());
+
+        if (!isPathNormalized(queryPath) || !isResourceInDirectory(lookupDirectory, sourceFileName)) {
+            return createErrorResponseNotFound(
+                    logMessage("There is resource at the specified path", queryPath)
+            );
+        }
+
+        while (isSubPath(projectPath, lookupDirectory.getPath())) {
+            String content = getConfigFileContent(lookupDirectory, configFileName);
+            if(content != null && !content.isEmpty()) {
+                return Response.ok(content).type(configContentType).build();
+            }
+
+            lookupDirectory = lookupDirectory.getParent();
+        }
+
+        return createErrorResponseNotFound(
+                logMessage("There is no config file for resource", queryPath)
+        );
+    }
+
+    private String logMessage(String reason, String queryPath) {
+        final String message = String.format("%s: %s", reason, queryPath);
+        logger.error(message);
+        return message;
+    }
+
+    private boolean isPathNormalized(String queryPath) {
+        return Objects.equals(FilenameUtils.normalize(queryPath), queryPath);
+    }
+
+    private boolean isResourceInDirectory(ICollection directory, String resourceName) {
+        return directory.getResource(resourceName).exists();
+    }
+
+    private String joinPathParts(String delimiter, String... args) {
+        return delimiter + String.join(delimiter, args);
+    }
+
+    private boolean isSubPath(String superPath, String subPath) {
+        return subPath.startsWith(superPath);
+    }
+
+    private String getConfigFileContent(ICollection directory, String configFileName) {
+        IResource config = directory.getResource(configFileName);
+        if (config.exists()) {
+            return new String(config.getContent(), StandardCharsets.UTF_8);
+        }
+        return null;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return logger;
+    }
+
+    @Override
+    public Class<? extends IRestService> getType() {
+        return EditorRestService.class;
+    }
+}

--- a/ide/services/ide-editor/src/main/resources/META-INF/services/org.eclipse.dirigible.commons.api.service.IRestService
+++ b/ide/services/ide-editor/src/main/resources/META-INF/services/org.eclipse.dirigible.commons.api.service.IRestService
@@ -1,0 +1,1 @@
+org.eclipse.dirigible.runtime.ide.editor.services.EditorRestService # Editor Service

--- a/ide/services/pom.xml
+++ b/ide/services/pom.xml
@@ -19,6 +19,7 @@
 		<module>ide-core</module>
 		<module>ide-databases</module>
 		<module>ide-git</module>
+		<module>ide-editor</module>
 		<module>ide-publisher</module>
 		<module>ide-terminal</module>
 		<module>ide-workspaces</module>

--- a/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/editor.html
+++ b/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/editor.html
@@ -24,7 +24,7 @@
 			<div class="loading-message">Loading...</div>
 		</div>
 		<div id="embeddedEditor"></div>
-		<script type="text/javascript" src="js/editor.js"></script>
+		<script type="module" src="js/editor.js"></script>
 	</body>
 
 </html>

--- a/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
+++ b/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
@@ -21,6 +21,9 @@ let parameters = {
     file: ""
 };
 
+import prettier from "https://unpkg.com/prettier@2.5.1/esm/standalone.mjs";
+import parserBabel from "https://unpkg.com/prettier@2.5.1/esm/parser-babel.mjs";
+
 /*eslint-disable no-extend-native */
 String.prototype.replaceAll = function (search, replacement) {
     let target = this;
@@ -608,6 +611,54 @@ function getModuleImports(text) {
     return moduleImports;
 }
 
+function setupPrettier(fileName) {
+    let editorApi = "/services/v4/ide/editor/prettier/config";
+    let prettierConfigRequest = `${editorApi}${fileName}`
+
+    fetch(prettierConfigRequest, {
+        method: "GET"
+    })
+    .then(function(response) { return response.json(); })
+    .then(function(configJson) {
+        registerPrettierFormatter(configJson, "javascript");
+    })
+    .catch((error) => {
+        let defaultConfigJson = {
+              "trailingComma": "es5",
+              "tabWidth": 4,
+              "semi": false,
+              "singleQuote": true,
+        };
+        registerPrettierFormatter(defaultConfigJson, "javascript");
+    });
+}
+
+function registerPrettierFormatter(configJson, language) {
+    configJson["plugins"] = [parserBabel];
+    configJson["parser"] = "babel";
+
+    monaco.languages.registerDocumentFormattingEditProvider(language, {
+        provideDocumentFormattingEdits: function (model, options, token) {
+            var textEditRange = model.getFullModelRange();
+            var sourceCode = model.getValue();
+
+            try {
+                sourceCode = prettier.format(sourceCode, configJson);
+            }
+            catch(formatError) {
+                console.log(formatError.stack);
+            }
+
+            return [
+                {
+                    range: textEditRange,
+                    text:  sourceCode
+                }
+            ];
+        }
+    });
+}
+
 function traverseAssignment(assignment, assignmentInfo) {
     if (assignment.parentModule) {
         traverseAssignment(assignment.parentModule, assignmentInfo);
@@ -904,5 +955,7 @@ function traverseAssignment(assignment, assignmentInfo) {
             indent_with_tabs: false,
         });
         monaco.editor.setTheme(monacoTheme);
+
+        setupPrettier(fileName);
     });
 })();

--- a/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
+++ b/ide/ui/ide-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
@@ -624,18 +624,18 @@ function setupPrettier(fileName) {
     })
     .catch((error) => {
         let defaultConfigJson = {
-              "trailingComma": "es5",
-              "tabWidth": 4,
-              "semi": false,
-              "singleQuote": true,
+              trailingComma: "es5",
+              tabWidth: 4,
+              semi: false,
+              singleQuote: true,
         };
         registerPrettierFormatter(defaultConfigJson, "javascript");
     });
 }
 
 function registerPrettierFormatter(configJson, language) {
-    configJson["plugins"] = [parserBabel];
-    configJson["parser"] = "babel";
+    configJson.plugins = [parserBabel];
+    configJson.parser = "babel";
 
     monaco.languages.registerDocumentFormattingEditProvider(language, {
         provideDocumentFormattingEdits: function (model, options, token) {
@@ -646,7 +646,7 @@ function registerPrettierFormatter(configJson, language) {
                 sourceCode = prettier.format(sourceCode, configJson);
             }
             catch(formatError) {
-                console.log(formatError.stack);
+                console.error(formatError.stack);
             }
 
             return [

--- a/modules/services/service-repository/pom.xml
+++ b/modules/services/service-repository/pom.xml
@@ -46,6 +46,12 @@
             <artifactId>dirigible-api-facade-utils</artifactId>
             <version>7.0.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-repository-local</artifactId>
+            <version>7.0.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <properties>


### PR DESCRIPTION
* Prettier standalone is now registered as a custom formatter in monaco editor (in the browser) to format `.js` files.
* Added a new rest service for ide releated features.
* `.prettierrc.json` files are supported as configuration files.
* When you save a javascript file formatting occurs, the closest .prettierrc.json file in a bottom-up 
traversal of the folder structure is used as a formatting configuration.