### PR TITLE
Introduce OData property name escaper

### DIFF
--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaper.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaper.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.engine.odata2.transformers;
 
 class DefaultPropertyNameEscaper implements ODataPropertyNameEscaper {

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaper.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaper.java
@@ -1,0 +1,18 @@
+package org.eclipse.dirigible.engine.odata2.transformers;
+
+class DefaultPropertyNameEscaper implements ODataPropertyNameEscaper {
+
+    /**
+     * Replace unsupported olingo symbols with underscore symbol
+     * The olingo do not allow dot symbol to be part of the property name.
+     *
+     * @param propertyName
+     *          entity property name
+     * @return replaced string
+     * @see  org.apache.olingo.odata2.core.edm.provider.EdmNamedImplProv
+     */
+    @Override
+    public String escape(String propertyName) {
+        return propertyName.replace('.', '_');
+    }
+}

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
@@ -30,8 +30,17 @@ import java.util.stream.Collectors;
 public class OData2ODataMTransformer {
 
     private static final Logger logger = LoggerFactory.getLogger(OData2ODataMTransformer.class);
+    private final ODataPropertyNameEscaper propertyNameEscaper;
 
     private DBMetadataUtil dbMetadataUtil = new DBMetadataUtil();
+
+    public OData2ODataMTransformer(ODataPropertyNameEscaper propertyNameEscaper){
+        this.propertyNameEscaper = propertyNameEscaper;
+    }
+
+    public OData2ODataMTransformer(){
+        this(new DefaultPropertyNameEscaper());
+    }
 
     public String[] transform(ODataDefinition model) throws SQLException {
 
@@ -64,13 +73,13 @@ public class OData2ODataMTransformer {
             if (entityProperties.isEmpty()) {
                 tableMetadata.getColumns().forEach(column -> {
                     String columnValue = DBMetadataUtil.getPropertyNameFromDbColumnName(column.getName(), entityProperties, isPretty);
-                    buff.append("\t\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(columnValue)).append("\": \"").append(column.getName()).append("\",\n");
+                    buff.append("\t\"").append(propertyNameEscaper.escape(columnValue)).append("\": \"").append(column.getName()).append("\",\n");
                 });
             } else {
                 //in case entity props are defined expose only them
                 entityProperties.forEach(prop -> {
                     List<PersistenceTableColumnModel> dbColumnName = tableMetadata.getColumns().stream().filter(x -> x.getName().equals(prop.getColumn())).collect(Collectors.toList());
-                    buff.append("\t\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(prop.getName())).append("\": \"").append(dbColumnName.get(0).getName()).append("\",\n");
+                    buff.append("\t\"").append(propertyNameEscaper.escape(prop.getName())).append("\": \"").append(dbColumnName.get(0).getName()).append("\",\n");
                 });
             }
 

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataXTransformer.java
@@ -33,10 +33,16 @@ public class OData2ODataXTransformer {
 
     public static final List<String> VIEW_TYPES = List.of(ISqlKeywords.METADATA_VIEW, ISqlKeywords.METADATA_CALC_VIEW);
 
-    private ITableMetadataProvider tableMetadataProvider;
+    private final ODataPropertyNameEscaper propertyNameEscaper;
+    private final ITableMetadataProvider tableMetadataProvider;
 
     public OData2ODataXTransformer(ITableMetadataProvider tableMetadataProvider) {
+        this(tableMetadataProvider, new DefaultPropertyNameEscaper());
+    }
+
+    public OData2ODataXTransformer(ITableMetadataProvider tableMetadataProvider, ODataPropertyNameEscaper propertyNameEscaper){
         this.tableMetadataProvider = tableMetadataProvider;
+        this.propertyNameEscaper = propertyNameEscaper;
     }
 
     public String[] transform(ODataDefinition model) throws SQLException {
@@ -84,16 +90,16 @@ public class OData2ODataXTransformer {
                 if (entityOrigKeys.size() > 0) {
                     entityOrigKeys.forEach(key -> {
                         String columnValue = DBMetadataUtil.getPropertyNameFromDbColumnName(key.getName(), entityProperties, isPretty);
-                        buff.append("\t\t\t<PropertyRef Name=\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(columnValue)).append("\" />\n");
+                        buff.append("\t\t\t<PropertyRef Name=\"").append(propertyNameEscaper.escape(columnValue)).append("\" />\n");
                     });
                 } else {
                     //local key was generated
-                    entity.getKeys().forEach(key -> buff.append("\t\t\t<PropertyRef Name=\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(key)).append("\" />\n"));
+                    entity.getKeys().forEach(key -> buff.append("\t\t\t<PropertyRef Name=\"").append(propertyNameEscaper.escape(key)).append("\" />\n"));
                 }
             } else {
                 idColumns.forEach(column -> {
                     String nameValue = DBMetadataUtil.getPropertyNameFromDbColumnName(column.getName(), entityProperties, isPretty);
-                    buff.append("\t\t\t<PropertyRef Name=\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(nameValue)).append("\" />\n");
+                    buff.append("\t\t\t<PropertyRef Name=\"").append(propertyNameEscaper.escape(nameValue)).append("\" />\n");
                 });
             }
             buff.append("\t\t</Key>\n");
@@ -109,7 +115,7 @@ public class OData2ODataXTransformer {
             if (entityProperties.isEmpty()) {
                 tableMetadata.getColumns().forEach(column -> {
                     String columnValue = DBMetadataUtil.getPropertyNameFromDbColumnName(column.getName(), entityProperties, isPretty);
-                    buff.append("\t\t<Property Name=\"").append(ODataMetadataUtil.replaceUnSupportedPropOlingoSymbols(columnValue)).append("\"")
+                    buff.append("\t\t<Property Name=\"").append(propertyNameEscaper.escape(columnValue)).append("\"")
                             .append(" Nullable=\"").append(DBMetadataUtil.isNullable(column, entityProperties)).append("\"").append(" Type=\"").append(DBMetadataUtil.getType(column, entityProperties)).append("\"");
                     buff.append("/>\n");
                 });

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataMetadataUtil.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataMetadataUtil.java
@@ -126,17 +126,4 @@ public class ODataMetadataUtil {
         }
     }
 
-    /**
-     * Replace unsupported olingo symbols with underscore symbol
-     * The olingo do not allow dot symbol to be part of the property name.
-     *
-     * @param propName
-     *          entity property name
-     * @return replaced string
-     * @see  org.apache.olingo.odata2.core.edm.provider.EdmNamedImplProv
-     */
-    public static String replaceUnSupportedPropOlingoSymbols(String propName) {
-        return propName.replace('.', '_');
-    }
-
 }

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataPropertyNameEscaper.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataPropertyNameEscaper.java
@@ -1,0 +1,7 @@
+package org.eclipse.dirigible.engine.odata2.transformers;
+
+public interface ODataPropertyNameEscaper {
+
+    String escape(String propertyName);
+
+}

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataPropertyNameEscaper.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/ODataPropertyNameEscaper.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.engine.odata2.transformers;
 
 public interface ODataPropertyNameEscaper {

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaperTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaperTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.engine.odata2.transformers;
 
 import static org.junit.Assert.*;

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaperTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/DefaultPropertyNameEscaperTest.java
@@ -1,0 +1,35 @@
+package org.eclipse.dirigible.engine.odata2.transformers;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultPropertyNameEscaperTest {
+
+    private DefaultPropertyNameEscaper escaper;
+
+    @Before
+    public void setUp(){
+        this.escaper = new DefaultPropertyNameEscaper();
+    }
+    
+    @Test
+    public void testEscapeDots(){
+        assertEquals("Unexpected escaped property name", "Property_Name_With_Dots", escaper.escape("Property.Name.With.Dots"));
+    }
+
+    @Test
+    public void testEscapeDot(){
+        assertEquals("Unexpected escaped property name", "Property_Name", escaper.escape("Property.Name"));
+    }
+
+    @Test
+    public void testEscapeValidName(){
+        assertEquals("Unexpected escaped property name", "PropertyName", escaper.escape("PropertyName"));
+    }
+
+}

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
@@ -43,7 +43,7 @@ public class OData2ODataMTransformerTest extends AbstractDirigibleTest {
     private DBMetadataUtil dbMetadataUtil;
 
     @InjectMocks
-    OData2ODataMTransformer odata2ODataMTransformer;
+    OData2ODataMTransformer odata2ODataMTransformer = new OData2ODataMTransformer(new DefaultPropertyNameEscaper());
 
     @Test
     public void testTransformOrders() throws IOException, SQLException {


### PR DESCRIPTION
Introduce OData property name escaper, so that different implementation can be supplied for different requirements.