### PR TITLE
fix: return 500 for js errors and fix eval file names

### DIFF
--- a/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/callbacks/Require.java
+++ b/modules/engines/engine-javascript-graalvm/src/main/java/org/eclipse/dirigible/engine/js/graalvm/callbacks/Require.java
@@ -53,7 +53,7 @@ public class Require {
                 + " _loadedModules[path] = moduleInfo;" //
                 + " var compiledWrapper = null;" //
                 + " try {" //
-                + "   compiledWrapper = eval(code);" //
+                + "   compiledWrapper = load({ name: path, script: code});" //
                 + " } catch (e) {" //
                 + "   throw new Error('Error evaluating module ' + path + ' line #' + e.lineNumber + ' : ' + e.message, path, e.lineNumber);" //
                 + " }" //

--- a/modules/engines/engine-javascript-graalvm/src/main/resources/Module.js
+++ b/modules/engines/engine-javascript-graalvm/src/main/resources/Module.js
@@ -221,7 +221,10 @@
 
 
        try {
-           var compiledWrapper = eval(wrapper);
+           var compiledWrapper = load({
+            name: filename,
+            script: wrapper
+           });
            compiledWrapper.apply(self.exports, [self.exports, require, self, filename, path.dirname(filename)]);
            return self.exports;
        } catch (e) {
@@ -250,7 +253,10 @@
 
 
        try {
-           var compiledWrapper = eval(wrapper);
+           var compiledWrapper = load({
+             name: filename,
+             script: wrapper
+           });
            compiledWrapper.apply(self.exports, [self.exports, require, self, filename, path.dirname(filename)]);
            return self.exports;
        } catch (e) {

--- a/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/service/ScriptingDependencyExceptionHandler.java
+++ b/modules/engines/engine-javascript/src/main/java/org/eclipse/dirigible/engine/js/service/ScriptingDependencyExceptionHandler.java
@@ -49,7 +49,7 @@ public class ScriptingDependencyExceptionHandler extends AbstractExceptionHandle
 	 */
 	@Override
 	protected Status getResponseStatus(ScriptingDependencyException exception) {
-		return Status.ACCEPTED;
+		return Status.INTERNAL_SERVER_ERROR;
 	}
 
 	/*


### PR DESCRIPTION
This PR changes several things:
- Throw a `ScriptingException` if there is an exception while evaluating JS code
- Return 500 from the REST service if there is a `ScriptingException`
- Do not `eval` source code as string
- Use GraalVM's `load` instead of `eval` in order to provide a file name of the code being loaded

Fixes: https://github.com/SAP/xsk/issues/1461
Fixes: https://github.com/SAP/xsk/issues/646