### PR TITLE
Jackson Databind version 2.13.2.2

### DIFF
--- a/ext/ext-api/api-spark/pom.xml
+++ b/ext/ext-api/api-spark/pom.xml
@@ -161,7 +161,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.1</version>
+			<version>${jackson.databind.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.1</version>
+			<version>${jackson.databind.version}</version>
 		</dependency>
 
 		<!-- Java 11 Dependencies -->
@@ -724,6 +724,7 @@
 		<testcontainers.elasticsearch.version>1.16.3</testcontainers.elasticsearch.version>
 		<logcaptor.version>2.7.8</logcaptor.version>
 		<exec.maven.plugin>3.0.0</exec.maven.plugin>
+		<jackson.databind.version>2.13.2.2</jackson.databind.version>
 
 		<profile.content.phase>none</profile.content.phase>
 


### PR DESCRIPTION
Set Jackson Databind version to 2.13.2.2 to fix security vulnerability 