### PR TITLE
OData now uses row_num value as ID for HANA views

### DIFF
--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformer.java
@@ -148,6 +148,10 @@ public class OData2ODataMTransformer {
                 buff.append(String.join(",\n", assembleRefNav)).append(",\n");
             }
 
+            if(entity.getKeyGenerated() != null && !entity.getKeyGenerated().isEmpty()) {
+                buff.append("\t\"keyGenerated\": \"").append(entity.getKeyGenerated()).append("\",\n");
+            }
+
             String[] pks = idColumns.stream().map(PersistenceTableColumnModel::getName).collect(Collectors.toList()).toArray(new String[]{});
             buff.append("\t\"_pk_\" : \"").append(String.join(",", pks)).append("\"");
             buff.append("\n}");

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
@@ -303,7 +303,7 @@ public class OData2ODataMTransformerTest extends AbstractDirigibleTest {
                 "\t\"sqlTable\": \"UserRole\",\n" +
                 "\t\"ZUSR_ROLE\": \"ZUSR_ROLE\",\n" +
                 "\t\"ZROLE_NAME\": \"ZROLE_NAME\",\n" +
-                "\t\"KeyGenerated\": \"ID\",\n" +
+                "\t\"keyGenerated\": \"ID\",\n" +
                 "\t\"_pk_\" : \"\"\n" +
                 "}";
 

--- a/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
+++ b/modules/engines/engine-odata/src/test/java/org/eclipse/dirigible/engine/odata2/transformers/OData2ODataMTransformerTest.java
@@ -16,6 +16,7 @@ import org.eclipse.dirigible.core.test.AbstractDirigibleTest;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableColumnModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableModel;
 import org.eclipse.dirigible.database.persistence.model.PersistenceTableRelationModel;
+import org.eclipse.dirigible.database.sql.ISqlKeywords;
 import org.eclipse.dirigible.engine.odata2.definition.ODataDefinition;
 import org.eclipse.dirigible.engine.odata2.definition.ODataDefinitionFactoryTest;
 import org.eclipse.dirigible.engine.odata2.definition.factory.ODataDefinitionFactory;
@@ -283,6 +284,31 @@ public class OData2ODataMTransformerTest extends AbstractDirigibleTest {
                 "}";
         String[] transformed = odata2ODataMTransformer.transform(definition);
         assertArrayEquals(new String[]{entityUser, entityGroup}, transformed);
+    }
+
+    @Test
+    public void testViewTransformation() throws IOException, SQLException {
+        String view = IOUtils.toString(ODataDefinitionFactoryTest.class.getResourceAsStream("/view/View.odata"), Charset.defaultCharset());
+        ODataDefinition definition = ODataDefinitionFactory.parseOData("/view/View.odata", view);
+
+        PersistenceTableColumnModel column1 = new PersistenceTableColumnModel("ZUSR_ROLE", "Edm.String", true, false);
+        PersistenceTableColumnModel column2 = new PersistenceTableColumnModel("ZROLE_NAME", "Edm.String", true, false);
+        PersistenceTableModel model = new PersistenceTableModel("UserRole", Arrays.asList(column1, column2), new ArrayList<>());
+        model.setTableType(ISqlKeywords.KEYWORD_VIEW);
+        when(dbMetadataUtil.getTableMetadata("UserRole", null)).thenReturn(model);
+
+        String entityView = "{\n" +
+                "\t\"edmType\": \"UserRoleType\",\n" +
+                "\t\"edmTypeFqn\": \"org.apache.olingo.odata2.ODataUserRole.UserRoleType\",\n" +
+                "\t\"sqlTable\": \"UserRole\",\n" +
+                "\t\"ZUSR_ROLE\": \"ZUSR_ROLE\",\n" +
+                "\t\"ZROLE_NAME\": \"ZROLE_NAME\",\n" +
+                "\t\"KeyGenerated\": \"ID\",\n" +
+                "\t\"_pk_\" : \"\"\n" +
+                "}";
+
+        String[] transformed = odata2ODataMTransformer.transform(definition);
+        assertArrayEquals(new String[]{entityView}, transformed);
     }
 
 //    @Test

--- a/modules/engines/engine-odata/src/test/resources/view/View.odata
+++ b/modules/engines/engine-odata/src/test/resources/view/View.odata
@@ -1,0 +1,29 @@
+{
+    "namespace":"org.apache.olingo.odata2.ODataUserRole",
+    "entities": [{
+        "name": "UserRole",
+        "alias": "UserRole",
+        "table": "UserRole",
+        "keyGenerated": "ID",
+        "properties": [{
+            "name": "ZUSR_ROLE",
+            "column": "ZUSR_ROLE",
+            "nullable": true,
+            "type": "Edm.String",
+            "annotationsProperty": {}
+        },
+        {
+            "name": "ZROLE_NAME",
+            "column": "ZROLE_NAME",
+            "nullable": true,
+            "type": "Edm.String",
+            "annotationsProperty": {}
+        }],
+        "navigations": [],
+        "handlers": [],
+        "keys": [],
+        "annotationsEntitySet": {},
+        "annotationsEntityType": {}
+    }],
+    "associations":[]
+}

--- a/modules/odata/odata-api/src/main/java/org/eclipse/dirigible/engine/odata2/definition/ODataEntityDefinition.java
+++ b/modules/odata/odata-api/src/main/java/org/eclipse/dirigible/engine/odata2/definition/ODataEntityDefinition.java
@@ -24,6 +24,8 @@ public class ODataEntityDefinition {
 
     private String table;
 
+	private String keyGenerated;
+
     private List<ODataProperty> properties = new ArrayList<>();
 
     private List<ODataNavigation> navigations = new ArrayList<>();
@@ -71,6 +73,14 @@ public class ODataEntityDefinition {
 
 	public void setTable(String table) {
 		this.table = table;
+	}
+
+	public String getKeyGenerated() {
+		return keyGenerated;
+	}
+
+	public void setKeyGenerated(String keyGenerated) {
+		this.keyGenerated = keyGenerated;
 	}
 
 	public List<ODataProperty> getProperties() {

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/AbstractQueryBuilder.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/AbstractQueryBuilder.java
@@ -113,6 +113,11 @@ public abstract class AbstractQueryBuilder implements SQLStatementBuilder {
         return mapping.hasMappingTable(to);
     }
 
+    public boolean hasKeyGeneratedPresent(final EdmStructuralType target) {
+        EdmTableBinding mapping = tableBinding.getEdmTableBinding(target);
+        return mapping.isPropertyMapped("keyGenerated");
+    }
+
     public String getSQLTablePrimaryKey(final EdmStructuralType type) throws EdmException {
         return tableBinding.getEdmTableBinding(type).getPrimaryKey();
     }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLSelectClause.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLSelectClause.java
@@ -213,6 +213,10 @@ public final class SQLSelectClause {
 
             StringBuilder select = new StringBuilder();
             Iterator<Integer> i = columnMapping.keySet().iterator();
+            if(query.hasKeyGeneratedPresent(target) && i.hasNext()) {
+                select.append("row_number() over() \"row_num\"");
+                select.append(", ");
+            }
             while (i.hasNext()) {
                 Integer column = i.next();
                 EdmStructuralType type = getTargetType(column);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -148,7 +148,10 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 			try (PreparedStatement statement = createSelectStatement(query, connection)){
 				try (ResultSet resultSet = statement.executeQuery()){
 					while (resultSet.next()) {
-						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+						boolean hasGeneratedId = query.hasKeyGeneratedPresent(targetEntitySet.getEntityType());
+						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query,
+								targetEntityType, properties, resultSet, hasGeneratedId);
+
 						if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
 							currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
 						}
@@ -199,12 +202,10 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 				try (ResultSet resultSet = statement.executeQuery()) {
 					ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
 					while (resultSet.next()) {
-						ResultSetReader.ResultSetEntity currentTargetEntity;
-						if(query.hasKeyGeneratedPresent(targetEntitySet.getEntityType())) {
-							currentTargetEntity = resultSetReader.getResultSetEntityForView(query, targetEntityType, properties, resultSet);
-						} else {
-							currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
-						}
+						boolean hasGeneratedId = query.hasKeyGeneratedPresent(targetEntitySet.getEntityType());
+						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query,
+								targetEntityType, properties, resultSet, hasGeneratedId);
+
 						LOG.info("Current entity set object is {}", currentTargetEntity);
 						if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
 							currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
@@ -276,7 +277,8 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 			try (PreparedStatement statement = createSelectStatement(query, connection)){
 				try (ResultSet resultSet = statement.executeQuery()){
 					while (resultSet.next()) {
-						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+						boolean hasGeneratedId = query.hasKeyGeneratedPresent(targetEntitySet.getEntityType());
+						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet, hasGeneratedId);
 					}
 				}
 			}
@@ -368,7 +370,8 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 					try (PreparedStatement statement = createSelectStatement(query, connection)){
 						try (ResultSet resultSet = statement.executeQuery()){
 							while (resultSet.next()) {
-								currentTargetEntity = resultSetReader.getResultSetEntity(query, entityType, properties, resultSet);
+								boolean hasGeneratedId = query.hasKeyGeneratedPresent(entitySet.getEntityType());
+								currentTargetEntity = resultSetReader.getResultSetEntity(query, entityType, properties, resultSet, hasGeneratedId);
 							}
 						}
 					}
@@ -468,7 +471,8 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 			try (PreparedStatement statement = createSelectStatement(query, connection)) {
 				try (ResultSet resultSet = statement.executeQuery()) {
 					while (resultSet.next()) {
-						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+						boolean hasGeneratedId = query.hasKeyGeneratedPresent(targetEntitySet.getEntityType());
+						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet, hasGeneratedId);
 					}
 					if (currentTargetEntity.data.isEmpty()) {
 						throw new ODataNotFoundException(ODataNotFoundException.ENTITY);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -199,7 +199,12 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
 				try (ResultSet resultSet = statement.executeQuery()) {
 					ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
 					while (resultSet.next()) {
-						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+						ResultSetReader.ResultSetEntity currentTargetEntity;
+						if(query.hasKeyGeneratedPresent(targetEntitySet.getEntityType())) {
+							currentTargetEntity = resultSetReader.getResultSetEntityForView(query, targetEntityType, properties, resultSet);
+						} else {
+							currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+						}
 						LOG.info("Current entity set object is {}", currentTargetEntity);
 						if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
 							currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/ResultSetReader.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/ResultSetReader.java
@@ -41,27 +41,14 @@ public class ResultSetReader {
         return result;
     }
 
-
-    protected ResultSetEntity getResultSetEntityForView(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
-                                                        Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException, IOException {
-
-        return getResultSetEntityForObject(selectEntityQuery, entityType, properties, resultSet, true);
-    }
-
     protected ResultSetEntity getResultSetEntity(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
-                                                 Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException, IOException {
-
-        return getResultSetEntityForObject(selectEntityQuery, entityType, properties, resultSet, false);
-    }
-
-    protected ResultSetEntity getResultSetEntityForObject(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
-                                                          Collection<EdmProperty> properties, final ResultSet resultSet, boolean isView) throws SQLException, ODataException, IOException {
+                                                          Collection<EdmProperty> properties, final ResultSet resultSet, boolean hasGeneratedId) throws SQLException, ODataException, IOException {
         Map<String, Object> data = new HashMap<>();
         for (EdmProperty property : properties) {
             data.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
         }
 
-        if(isView) {
+        if(hasGeneratedId) {
             return new ResultSetEntity(entityType, data, String.valueOf(resultSet.getInt("row_num")));
         }
         return new ResultSetEntity(entityType, data);

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/ResultSetReader.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/ResultSetReader.java
@@ -42,11 +42,27 @@ public class ResultSetReader {
     }
 
 
+    protected ResultSetEntity getResultSetEntityForView(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
+                                                        Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException, IOException {
+
+        return getResultSetEntityForObject(selectEntityQuery, entityType, properties, resultSet, true);
+    }
+
     protected ResultSetEntity getResultSetEntity(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
                                                  Collection<EdmProperty> properties, final ResultSet resultSet) throws SQLException, ODataException, IOException {
+
+        return getResultSetEntityForObject(selectEntityQuery, entityType, properties, resultSet, false);
+    }
+
+    protected ResultSetEntity getResultSetEntityForObject(SQLSelectBuilder selectEntityQuery, final EdmEntityType entityType,
+                                                          Collection<EdmProperty> properties, final ResultSet resultSet, boolean isView) throws SQLException, ODataException, IOException {
         Map<String, Object> data = new HashMap<>();
         for (EdmProperty property : properties) {
             data.put(property.getName(), readProperty(entityType, property, selectEntityQuery, resultSet));
+        }
+
+        if(isView) {
+            return new ResultSetEntity(entityType, data, String.valueOf(resultSet.getInt("row_num")));
         }
         return new ResultSetEntity(entityType, data);
     }
@@ -197,6 +213,13 @@ public class ResultSetReader {
                 String name = p.getName();
                 keys.put(name, data.get(name));
             }
+        }
+
+        public ResultSetEntity(EdmEntityType type, Map<String, Object> data, String key) throws EdmException {
+            this.entityType = type;
+            this.data = data;
+            this.keys = new HashMap<>();
+            keys.put("Id", key);
         }
 
         public boolean isEmpty() throws ODataException {


### PR DESCRIPTION
Related to https://github.com/SAP/xsk/issues/1444

Changelog:
1. ODataEntityDefinition now has a separate field for generated keys.
2. OData2ODataMTransformer now checks the keyGenerated field and adds it to the json.
3. SQLSelectClause will add HANA's row_num value to the select clause when we have keyGenerated in the table binding.
4. AbstractSQLProcessor now builds two different ResultSetEntities - one that uses the table keys for entities and one that uses the row_num values as key when we have a HANA view.