### PR TITLE
Enable connection to on-premise mail server via SOCKS5 proxy

### DIFF
--- a/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/ConnectivitySocks5ProxySocket.java
+++ b/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/ConnectivitySocks5ProxySocket.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.api.v3.mail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.ByteBuffer;
+
+import java.util.Base64; // or any other library for base64 encoding
+import java.util.Properties;
+
+public class ConnectivitySocks5ProxySocket extends Socket {
+
+	private static final byte SOCKS5_VERSION = 0x05;
+	private static final byte SOCKS5_PASSWORD_AUTHENTICATION_METHOD = (byte) 0x02;
+	private static final byte SOCKS5_PASSWORD_AUTHENTICATION_METHOD_VERSION = 0x01;
+	private static final byte SOCKS5_COMMAND_CONNECT_BYTE = 0x01;
+	private static final byte SOCKS5_COMMAND_REQUEST_RESERVED_BYTE = 0x00;
+	private static final byte SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE = 0x01;
+	private static final byte SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE = 0x03;
+	private static final byte SOCKS5_AUTHENTICATION_METHODS_COUNT = 0x01;
+	private static final int SOCKS5_PASSWORD_AUTHENTICATION_METHOD_UNSIGNED_VALUE = 0x02 & 0xFF;
+	private static final byte SOCKS5_AUTHENTICATION_SUCCESS_BYTE = 0x00;
+
+	private final InetSocketAddress proxyAddress;
+	private final String username;
+	private final String password;
+
+	public ConnectivitySocks5ProxySocket(String host, String port, String username, String password) {
+		this.proxyAddress = new InetSocketAddress(host, Integer.parseInt(port));
+		this.username = username;
+		this.password = password;
+	}
+
+	@Override
+	public void connect(SocketAddress endpoint, int timeout) throws IOException {
+		super.connect(this.proxyAddress, timeout);
+
+		OutputStream outputStream = getOutputStream();
+
+		executeSOCKS5InitialRequest(outputStream);
+
+		executeSOCKS5AuthenticationRequest(outputStream);
+
+		executeSOCKS5ConnectRequest(outputStream, (InetSocketAddress) endpoint);
+	}
+
+	@Override
+	public void connect(SocketAddress endpoint) throws IOException {
+		this.connect(endpoint, 0);
+	}
+
+	private void executeSOCKS5InitialRequest(OutputStream outputStream) throws IOException {
+		byte[] initialRequest = createInitialSOCKS5Request();
+		outputStream.write(initialRequest);
+
+		assertServerInitialResponse();
+	}
+
+	private byte[] createInitialSOCKS5Request() throws IOException {
+		ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream();
+		try {
+			byteArraysStream.write(SOCKS5_VERSION);
+			byteArraysStream.write(SOCKS5_AUTHENTICATION_METHODS_COUNT);
+			byteArraysStream.write(SOCKS5_PASSWORD_AUTHENTICATION_METHOD);
+			return byteArraysStream.toByteArray();
+		} finally {
+			byteArraysStream.close();
+		}
+	}
+
+	private void assertServerInitialResponse() throws IOException {
+		InputStream inputStream = getInputStream();
+
+		int versionByte = inputStream.read();
+		if (SOCKS5_VERSION != versionByte) {
+			throw new SocketException(String.format("Unsupported SOCKS version - expected %s, but received %s", SOCKS5_VERSION, versionByte));
+		}
+
+		int authenticationMethodValue = inputStream.read();
+		if (SOCKS5_PASSWORD_AUTHENTICATION_METHOD_UNSIGNED_VALUE != authenticationMethodValue) {
+			throw new SocketException(String.format("Unsupported authentication method value - expected %s, but received %s",
+					SOCKS5_PASSWORD_AUTHENTICATION_METHOD_UNSIGNED_VALUE, authenticationMethodValue));
+		}
+	}
+
+	private void executeSOCKS5AuthenticationRequest(OutputStream outputStream) throws IOException {
+		byte[] authenticationRequest = createPasswordAuthenticationRequest();
+		outputStream.write(authenticationRequest);
+
+		assertAuthenticationResponse();
+	}
+
+	private byte[] createPasswordAuthenticationRequest() throws IOException {
+		ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream();
+		try {
+			byteArraysStream.write(SOCKS5_PASSWORD_AUTHENTICATION_METHOD_VERSION);
+			byteArraysStream.write(ByteBuffer.allocate(1).put((byte)this.username.getBytes().length).array());
+			byteArraysStream.write(this.username.getBytes());
+			byteArraysStream.write(ByteBuffer.allocate(1).put((byte)this.password.getBytes().length).array());
+			byteArraysStream.write(this.password.getBytes());
+			return byteArraysStream.toByteArray();
+		} finally {
+			byteArraysStream.close();
+		}
+	}
+
+	private void assertAuthenticationResponse() throws IOException {
+		InputStream inputStream = getInputStream();
+
+		int authenticationMethodVersion = inputStream.read();
+		if (SOCKS5_PASSWORD_AUTHENTICATION_METHOD_VERSION != authenticationMethodVersion) {
+			throw new SocketException(String.format("Unsupported authentication method version - expected %s, but received %s",
+					SOCKS5_PASSWORD_AUTHENTICATION_METHOD_VERSION, authenticationMethodVersion));
+		}
+
+		int authenticationStatus = inputStream.read();
+		if (SOCKS5_AUTHENTICATION_SUCCESS_BYTE != authenticationStatus) {
+			throw new SocketException("Authentication failed!");
+		}
+	}
+
+	private void executeSOCKS5ConnectRequest(OutputStream outputStream, InetSocketAddress endpoint) throws IOException {
+		byte[] commandRequest = createConnectCommandRequest(endpoint);
+		outputStream.write(commandRequest);
+
+		assertConnectCommandResponse();
+	}
+
+	private byte[] createConnectCommandRequest(InetSocketAddress endpoint) throws IOException {
+		String host = endpoint.getHostName();
+		int port = endpoint.getPort();
+		ByteArrayOutputStream byteArraysStream = new ByteArrayOutputStream();
+		try {
+			byteArraysStream.write(SOCKS5_VERSION);
+			byteArraysStream.write(SOCKS5_COMMAND_CONNECT_BYTE);
+			byteArraysStream.write(SOCKS5_COMMAND_REQUEST_RESERVED_BYTE);
+			byte[] hostToIPv4 = parseHostToIPv4(host);
+			if (hostToIPv4 != null) {
+				byteArraysStream.write(SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE);
+				byteArraysStream.write(hostToIPv4);
+			} else {
+				byteArraysStream.write(SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE);
+				byteArraysStream.write(ByteBuffer.allocate(1).put((byte) host.getBytes().length).array());
+				byteArraysStream.write(host.getBytes());
+			}
+			byteArraysStream.write(ByteBuffer.allocate(2).putShort((short) port).array());
+			return byteArraysStream.toByteArray();
+		} finally {
+			byteArraysStream.close();
+		}
+	}
+
+	private void assertConnectCommandResponse() throws IOException {
+		InputStream inputStream = getInputStream();
+
+		int versionByte = inputStream.read();
+		if (SOCKS5_VERSION != versionByte) {
+			throw new SocketException(String.format("Unsupported SOCKS version - expected %s, but received %s", SOCKS5_VERSION, versionByte));
+		}
+
+		int connectStatusByte = inputStream.read();
+		assertConnectStatus(connectStatusByte);
+
+		readRemainingCommandResponseBytes(inputStream);
+	}
+
+	private void assertConnectStatus(int commandConnectStatus) throws IOException {
+		if (commandConnectStatus == 0) {
+			return;
+		}
+
+		String commandConnectStatusTranslation;
+		switch (commandConnectStatus) {
+			case 1:
+				commandConnectStatusTranslation = "FAILURE";
+				break;
+			case 2:
+				commandConnectStatusTranslation = "FORBIDDEN";
+				break;
+			case 3:
+				commandConnectStatusTranslation = "NETWORK_UNREACHABLE";
+				break;
+			case 4:
+				commandConnectStatusTranslation = "HOST_UNREACHABLE";
+				break;
+			case 5:
+				commandConnectStatusTranslation = "CONNECTION_REFUSED";
+				break;
+			case 6:
+				commandConnectStatusTranslation = "TTL_EXPIRED";
+				break;
+			case 7:
+				commandConnectStatusTranslation = "COMMAND_UNSUPPORTED";
+				break;
+			case 8:
+				commandConnectStatusTranslation = "ADDRESS_UNSUPPORTED";
+				break;
+			default:
+				commandConnectStatusTranslation = "UNKNOWN";
+				break;
+		}
+		throw new SocketException("SOCKS5 command failed with status: " + commandConnectStatusTranslation);
+	}
+
+	private byte[] parseHostToIPv4(String hostName) {
+		byte[] parsedHostName = null;
+		String[] virtualHostOctets = hostName.split("\\.", -1);
+		int octetsCount = virtualHostOctets.length;
+		if (octetsCount == 4) {
+			try {
+				byte[] ipOctets = new byte[octetsCount];
+				for (int i = 0; i < octetsCount; i++) {
+					int currentOctet = Integer.parseInt(virtualHostOctets[i]);
+					if ((currentOctet < 0) || (currentOctet > 255)) {
+						throw new IllegalArgumentException(String.format("Provided octet %s is not in the range of [0-255]", currentOctet));
+					}
+					ipOctets[i] = (byte) currentOctet;
+				}
+				parsedHostName = ipOctets;
+			} catch (IllegalArgumentException ex) {
+				return null;
+			}
+		}
+
+		return parsedHostName;
+	}
+
+	private void readRemainingCommandResponseBytes(InputStream inputStream) throws IOException {
+		inputStream.read(); // skipping over SOCKS5 reserved byte
+		int addressTypeByte = inputStream.read();
+		if (SOCKS5_COMMAND_ADDRESS_TYPE_IPv4_BYTE == addressTypeByte) {
+			for (int i = 0; i < 6; i++) {
+				inputStream.read();
+			}
+		} else if (SOCKS5_COMMAND_ADDRESS_TYPE_DOMAIN_BYTE == addressTypeByte) {
+			int domainNameLength = inputStream.read();
+			int portBytes = 2;
+			inputStream.read(new byte[domainNameLength + portBytes], 0, domainNameLength + portBytes);
+		}
+	}
+}

--- a/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/MailClient.java
+++ b/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/MailClient.java
@@ -34,7 +34,7 @@ public class MailClient {
 	private static final String SMTP_TRANSPORT = "smtp";
 	private static final String SMTPS_TRANSPORT = "smtps";
 
-	private Properties properties;
+	private final Properties properties;
 
 	/**
 	 * @param properties mail client configuration options


### PR DESCRIPTION
The ConnectivitySocks5ProxySocket class is a modified version of the one taken from [here](https://help.sap.com/docs/CP_CONNECTIVITY/cca91383641e40ffbe03bdc78f00f681/cd1583775afa43f0bb9ec69d9dbcc880.html). The changes allow for username/password authentication to the proxy server instead of JWT and are required since authentication on Kyma is done so.

closes #1718 