### PR TITLE
[WIP] OData CUD event handlers param

### DIFF
--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlKeywords.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/ISqlKeywords.java
@@ -511,4 +511,19 @@ public interface ISqlKeywords {
      * The Constant KEYWORD_ROWSTORE.
      */
     public static final String KEYWORD_ROWSTORE = "ROWSTORE";
+
+    /**
+     * The Constant KEYWORD_LIKE
+     */
+    public static final String KEYWORD_LIKE = "LIKE";
+
+    /**
+     * The Constant KEYWORD_NO
+     */
+    public static final String KEYWORD_NO = "NO";
+
+    /**
+     * The Constant KEYWORD_DATA
+     */
+    public static final String KEYWORD_DATA = "DATA";
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/CreateBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/CreateBranchingBuilder.java
@@ -17,6 +17,7 @@ import org.eclipse.dirigible.database.sql.builders.schema.CreateSchemaBuilder;
 import org.eclipse.dirigible.database.sql.builders.sequence.CreateSequenceBuilder;
 import org.eclipse.dirigible.database.sql.builders.synonym.CreateSynonymBuilder;
 import org.eclipse.dirigible.database.sql.builders.table.CreateTableBuilder;
+import org.eclipse.dirigible.database.sql.builders.table.CreateTemporaryTableBuilder;
 import org.eclipse.dirigible.database.sql.builders.tableType.CreateTableTypeBuilder;
 import org.eclipse.dirigible.database.sql.builders.view.CreateViewBuilder;
 
@@ -46,6 +47,18 @@ public class CreateBranchingBuilder extends AbstractSqlBuilder {
 
     public CreateTableBuilder table(String table, String tableType) {
         return new CreateTableBuilder(getDialect(), table);
+    }
+
+    // TODO: check method signatures
+    /**
+     * Temporary table branch.
+     *
+     * @param table the table
+     * @param likeTable the like table
+     * @return the creates the table builder
+     */
+    public CreateTemporaryTableBuilder temporaryTable(String table, String likeTable) {
+        return new CreateTemporaryTableBuilder(getDialect(), table, likeTable);
     }
 
     /**
@@ -88,22 +101,23 @@ public class CreateBranchingBuilder extends AbstractSqlBuilder {
         return new CreateSchemaBuilder(getDialect(), schema);
     }
 
-	/**
-	 * Table Type branch.
-	 *
-	 * @param tableType
-	 *            the tableType
-	 * @return the creates the table type builder
-	 */
-	public CreateTableTypeBuilder tableType(String tableType) { return new CreateTableTypeBuilder(getDialect(), tableType); }
+    /**
+     * Table Type branch.
+     *
+     * @param tableType the tableType
+     * @return the creates the table type builder
+     */
+    public CreateTableTypeBuilder tableType(String tableType) {
+        return new CreateTableTypeBuilder(getDialect(), tableType);
+    }
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.eclipse.dirigible.database.sql.ISqlBuilder#generate()
-	 */
-	@Override
-	public String generate() {
-		throw new SqlException("Invalid method invocation of generate() for Create Branching Builder");
-	}
+    /*
+     * (non-Javadoc)
+     * @see org.eclipse.dirigible.database.sql.ISqlBuilder#generate()
+     */
+    @Override
+    public String generate() {
+        throw new SqlException("Invalid method invocation of generate() for Create Branching Builder");
+    }
 
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/CreateBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/CreateBranchingBuilder.java
@@ -49,16 +49,14 @@ public class CreateBranchingBuilder extends AbstractSqlBuilder {
         return new CreateTableBuilder(getDialect(), table);
     }
 
-    // TODO: check method signatures
     /**
      * Temporary table branch.
      *
      * @param table the table
-     * @param likeTable the like table
      * @return the creates the table builder
      */
-    public CreateTemporaryTableBuilder temporaryTable(String table, String likeTable) {
-        return new CreateTemporaryTableBuilder(getDialect(), table, likeTable);
+    public CreateTemporaryTableBuilder temporaryTable(String table) {
+        return new CreateTemporaryTableBuilder(getDialect(), table);
     }
 
     /**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/CreateTemporaryTableBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/CreateTemporaryTableBuilder.java
@@ -15,7 +15,8 @@ import org.eclipse.dirigible.database.sql.ISqlDialect;
 
 public class CreateTemporaryTableBuilder<TABLE_BUILDER extends CreateTemporaryTableBuilder> extends AbstractTableBuilder<TABLE_BUILDER> {
 
-    private String likeTable;
+    protected String likeTable;
+    protected String asSelectQuery;
 
     private static final String TEMPORARY_TABLES_NOT_SUPPORTED_FOR_THIS_DATABASE_TYPE = "Temporary tables not supported for this Database type!";
 
@@ -24,18 +25,23 @@ public class CreateTemporaryTableBuilder<TABLE_BUILDER extends CreateTemporaryTa
      *
      * @param dialect the dialect
      */
-    public CreateTemporaryTableBuilder(ISqlDialect dialect, String table, String likeTable) {
+    public CreateTemporaryTableBuilder(ISqlDialect dialect, String table) {
         super(dialect, table);
-
-        this.likeTable = likeTable;
     }
+
 
     @Override
     public String generate() {
         throw new IllegalStateException(TEMPORARY_TABLES_NOT_SUPPORTED_FOR_THIS_DATABASE_TYPE);
     }
 
-    public String getLikeTable() {
-        return this.likeTable;
+    public CreateTemporaryTableBuilder<TABLE_BUILDER> setLikeTable(String likeTable) {
+        this.likeTable = likeTable;
+        return this;
+    }
+
+    public CreateTemporaryTableBuilder<TABLE_BUILDER> setAsSelectQuery(String asSelectQuery) {
+        this.asSelectQuery = asSelectQuery;
+        return this;
     }
 }

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/CreateTemporaryTableBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/builders/table/CreateTemporaryTableBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.builders.table;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+
+public class CreateTemporaryTableBuilder<TABLE_BUILDER extends CreateTemporaryTableBuilder> extends AbstractTableBuilder<TABLE_BUILDER> {
+
+    private String likeTable;
+
+    private static final String TEMPORARY_TABLES_NOT_SUPPORTED_FOR_THIS_DATABASE_TYPE = "Temporary tables not supported for this Database type!";
+
+    /**
+     * Instantiates a new abstract sql builder.
+     *
+     * @param dialect the dialect
+     */
+    public CreateTemporaryTableBuilder(ISqlDialect dialect, String table, String likeTable) {
+        super(dialect, table);
+
+        this.likeTable = likeTable;
+    }
+
+    @Override
+    public String generate() {
+        throw new IllegalStateException(TEMPORARY_TABLES_NOT_SUPPORTED_FOR_THIS_DATABASE_TYPE);
+    }
+
+    public String getLikeTable() {
+        return this.likeTable;
+    }
+}

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateBranchingBuilder.java
@@ -56,9 +56,10 @@ public class HanaCreateBranchingBuilder extends CreateBranchingBuilder {
 	 * (non-Javadoc)
 	 * @see org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder#temporaryTable(java.lang.String)
 	 */
-	public HanaCreateTemporaryTableBuilder temporaryTable(String table, String likeTable) {
-		return new HanaCreateTemporaryTableBuilder(this.getDialect(), table, likeTable);
+	public HanaCreateTemporaryTableBuilder temporaryTable(String table) {
+		return new HanaCreateTemporaryTableBuilder(this.getDialect(), table);
 	}
+
 
 	/**
 	 * Column table.

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateBranchingBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateBranchingBuilder.java
@@ -14,6 +14,7 @@ package org.eclipse.dirigible.database.sql.dialects.hana;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
 import org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder;
 import org.eclipse.dirigible.database.sql.builders.table.CreateTableBuilder;
+import org.eclipse.dirigible.database.sql.builders.table.CreateTemporaryTableBuilder;
 import org.eclipse.dirigible.database.sql.builders.tableType.CreateTableTypeBuilder;
 
 /**
@@ -49,6 +50,14 @@ public class HanaCreateBranchingBuilder extends CreateBranchingBuilder {
 		} else {
 			throw new IllegalStateException(String.format("Unsupported table type is defined for table %s", table));
 	}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.eclipse.dirigible.database.sql.builders.CreateBranchingBuilder#temporaryTable(java.lang.String)
+	 */
+	public HanaCreateTemporaryTableBuilder temporaryTable(String table, String likeTable) {
+		return new HanaCreateTemporaryTableBuilder(this.getDialect(), table, likeTable);
 	}
 
 	/**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateTemporaryTableBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateTemporaryTableBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.database.sql.dialects.hana;
+
+import org.eclipse.dirigible.database.sql.ISqlDialect;
+import org.eclipse.dirigible.database.sql.builders.table.CreateTemporaryTableBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HanaCreateTemporaryTableBuilder extends CreateTemporaryTableBuilder<HanaCreateTemporaryTableBuilder> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CreateTemporaryTableBuilder.class);
+
+    /**
+     * Instantiates a new abstract sql builder.
+     *
+     * @param dialect   the dialect
+     * @param table
+     * @param likeTable
+     */
+    protected HanaCreateTemporaryTableBuilder(ISqlDialect dialect, String table, String likeTable) {
+        super(dialect, table, likeTable);
+    }
+
+    @Override
+    public String generate() {
+
+        StringBuilder sql = new StringBuilder();
+
+        // CREATE
+        generateCreate(sql);
+
+        sql.append(SPACE).append(METADATA_LOCAL_TEMPORARY);
+
+        // TABLE
+        generateTable(sql);
+
+        sql.append(SPACE).append(KEYWORD_LIKE).append(SPACE).append(this.getLikeTable())
+                .append(SPACE).append(KEYWORD_WITH).append(SPACE)
+                .append(KEYWORD_NO).append(SPACE).append(KEYWORD_DATA);
+
+        String generated = sql.toString();
+
+        logger.trace("generated: " + generated);
+
+        return generated;
+    }
+}

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateTemporaryTableBuilder.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/dialects/hana/HanaCreateTemporaryTableBuilder.java
@@ -20,15 +20,16 @@ public class HanaCreateTemporaryTableBuilder extends CreateTemporaryTableBuilder
 
     private static final Logger logger = LoggerFactory.getLogger(CreateTemporaryTableBuilder.class);
 
+    private static final String NO_LIKE_TABLE_OR_AS_SELECT_QUERY_SPECIFIED = "No `like` table or `as` select query specified.";
+
     /**
      * Instantiates a new abstract sql builder.
      *
      * @param dialect   the dialect
      * @param table
-     * @param likeTable
      */
-    protected HanaCreateTemporaryTableBuilder(ISqlDialect dialect, String table, String likeTable) {
-        super(dialect, table, likeTable);
+    protected HanaCreateTemporaryTableBuilder(ISqlDialect dialect, String table) {
+        super(dialect, table);
     }
 
     @Override
@@ -44,9 +45,18 @@ public class HanaCreateTemporaryTableBuilder extends CreateTemporaryTableBuilder
         // TABLE
         generateTable(sql);
 
-        sql.append(SPACE).append(KEYWORD_LIKE).append(SPACE).append(this.getLikeTable())
-                .append(SPACE).append(KEYWORD_WITH).append(SPACE)
-                .append(KEYWORD_NO).append(SPACE).append(KEYWORD_DATA);
+        sql.append(SPACE);
+        if (this.likeTable != null) {
+            // LIKE table
+            sql.append(KEYWORD_LIKE).append(SPACE).append(this.likeTable)
+                    .append(SPACE).append(KEYWORD_WITH).append(SPACE)
+                    .append(KEYWORD_NO).append(SPACE).append(KEYWORD_DATA);
+        } else if (this.asSelectQuery != null) {
+            // AS select query
+            sql.append(KEYWORD_AS).append(SPACE).append(OPEN).append(this.asSelectQuery).append(CLOSE);
+        } else {
+            throw new IllegalStateException(NO_LIKE_TABLE_OR_AS_SELECT_QUERY_SPECIFIED);
+        }
 
         String generated = sql.toString();
 

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/factory/DirigibleODataServiceFactory.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/factory/DirigibleODataServiceFactory.java
@@ -28,6 +28,9 @@ import org.apache.olingo.odata2.api.processor.ODataErrorContext;
 import org.apache.olingo.odata2.api.processor.ODataResponse;
 import org.apache.olingo.odata2.core.edm.provider.EdmxProvider;
 import org.eclipse.dirigible.api.v3.db.DatabaseFacade;
+import org.eclipse.dirigible.commons.api.context.InvalidStateException;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.engine.js.api.IJavascriptEngineExecutor;
 import org.eclipse.dirigible.engine.odata2.api.IODataCoreService;
 import org.eclipse.dirigible.engine.odata2.handler.ScriptingOData2EventHandler;
 import org.eclipse.dirigible.engine.odata2.mapping.DirigibleEdmTableMappingProvider;
@@ -37,52 +40,66 @@ import org.eclipse.dirigible.engine.odata2.sql.processor.DefaultSQLProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ServiceLoader;
+
 public class DirigibleODataServiceFactory extends ODataServiceFactory {
 
-	private static final Logger logger = LoggerFactory.getLogger(DefaultSQLProcessor.class);
-	
-	private static IODataCoreService odataCoreService = new ODataCoreService();
+    private static final Logger logger = LoggerFactory.getLogger(DefaultSQLProcessor.class);
 
-	@Override
-	public ODataService createService(ODataContext ctx) throws ODataException {
-		try {
-			EdmProvider edmProvider = new EdmxProvider();
-			((EdmxProvider) edmProvider).parse(odataCoreService.getMetadata(), false);
+    private static IODataCoreService odataCoreService = new ODataCoreService();
 
-			setDefaultDataSource(ctx);
-			
-			DirigibleEdmTableMappingProvider tableMappingProvider = new DirigibleEdmTableMappingProvider();
-			
-			OData2EventHandler odata2EventHandler = new ScriptingOData2EventHandler();
+    @Override
+    public ODataService createService(ODataContext ctx) throws ODataException {
+        try {
+            EdmProvider edmProvider = new EdmxProvider();
+            ((EdmxProvider) edmProvider).parse(odataCoreService.getMetadata(), false);
 
-			DefaultSQLProcessor singleProcessor = new DefaultSQLProcessor(tableMappingProvider, odata2EventHandler);
+            setDefaultDataSource(ctx);
 
-			return createODataSingleProcessorService(edmProvider, singleProcessor);
-		} catch (org.eclipse.dirigible.engine.odata2.api.ODataException e) {
-			logger.error(e.getMessage(), e);
-			throw new ODataException(e);
-		}
-	}
+            DirigibleEdmTableMappingProvider tableMappingProvider = new DirigibleEdmTableMappingProvider();
 
-	@Override
-	public <T extends ODataCallback> T getCallback(Class<T> callbackInterface) {
-		if (callbackInterface.isAssignableFrom(ODataErrorCallback.class)) {
-			return (T) new ODataDefaulErrorCallback();
-		}
-		return super.getCallback(callbackInterface);
-	}
+            DefaultSQLProcessor singleProcessor = new DefaultSQLProcessor(tableMappingProvider, getEventHandler());
 
-	private class ODataDefaulErrorCallback implements ODataErrorCallback {
-		@Override
-		public ODataResponse handleError(ODataErrorContext context) throws ODataApplicationException {
-			logger.error(context.getMessage(), context.getException());
-			return EntityProvider.writeErrorDocument(context);
-		}
-	}
-	
-	private void setDefaultDataSource(ODataContext ctx) throws ODataException {
+            return createODataSingleProcessorService(edmProvider, singleProcessor);
+        } catch (org.eclipse.dirigible.engine.odata2.api.ODataException e) {
+            logger.error(e.getMessage(), e);
+            throw new ODataException(e);
+        }
+    }
+
+    @Override
+    public <T extends ODataCallback> T getCallback(Class<T> callbackInterface) {
+        if (callbackInterface.isAssignableFrom(ODataErrorCallback.class)) {
+            return (T) new ODataDefaulErrorCallback();
+        }
+        return super.getCallback(callbackInterface);
+    }
+
+    private class ODataDefaulErrorCallback implements ODataErrorCallback {
+        @Override
+        public ODataResponse handleError(ODataErrorContext context) throws ODataApplicationException {
+            logger.error(context.getMessage(), context.getException());
+            return EntityProvider.writeErrorDocument(context);
+        }
+    }
+
+    private void setDefaultDataSource(ODataContext ctx) throws ODataException {
         DataSource dataSource;
         dataSource = DatabaseFacade.getDefaultDataSource();
         ctx.setParameter(DEFAULT_DATA_SOURCE_CONTEXT_KEY, dataSource);
+    }
+
+    private OData2EventHandler getEventHandler() {
+        ServiceLoader<OData2EventHandler> odata2EventHandlers = ServiceLoader.load(OData2EventHandler.class);
+
+        String odata2EventHandlerName = Configuration.get(OData2EventHandler.DIRIGIBLE_ODATA_EVENT_HANDLER_NAME,
+                OData2EventHandler.DEFAULT_ODATA_EVENT_HANDLER_NAME);
+        for (OData2EventHandler next : odata2EventHandlers) {
+            if(next.getName().equals(odata2EventHandlerName)) {
+                return next;
+            }
+        }
+
+        throw new InvalidStateException("No odata2 event handler found with name " + odata2EventHandlerName);
     }
 }

--- a/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/handler/ScriptingOData2EventHandler.java
+++ b/modules/engines/engine-odata/src/main/java/org/eclipse/dirigible/engine/odata2/handler/ScriptingOData2EventHandler.java
@@ -51,14 +51,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public void beforeCreateEntity(PostUriInfo uriInfo, String requestContentType,
-			String contentType, ODataEntry entry) {
+			String contentType, ODataEntry entry, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.create.name();
 			String type = ODataHandlerTypes.before.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("contentType", contentType);
@@ -71,14 +70,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public void afterCreateEntity(PostUriInfo uriInfo, String requestContentType,
-			String contentType, ODataEntry entry) {
+			String contentType, ODataEntry entry, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.create.name();
 			String type = ODataHandlerTypes.after.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("contentType", contentType);
@@ -107,14 +105,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public ODataResponse onCreateEntity(PostUriInfo uriInfo, InputStream content, String requestContentType,
-			String contentType) {
+			String contentType, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.create.name();
 			String type = ODataHandlerTypes.on.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("contentType", contentType);
@@ -146,14 +143,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public void beforeUpdateEntity(PutMergePatchUriInfo uriInfo, String requestContentType,
-			boolean merge, String contentType, ODataEntry entry) {
+			boolean merge, String contentType, ODataEntry entry, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.update.name();
 			String type = ODataHandlerTypes.before.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("merge", merge);
@@ -167,14 +163,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public void afterUpdateEntity(PutMergePatchUriInfo uriInfo, String requestContentType,
-			boolean merge, String contentType, ODataEntry entry) {
+			boolean merge, String contentType, ODataEntry entry, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.update.name();
 			String type = ODataHandlerTypes.after.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("merge", merge);
@@ -204,14 +199,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public ODataResponse onUpdateEntity(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType,
-			boolean merge, String contentType) {
+			boolean merge, String contentType, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.update.name();
 			String type = ODataHandlerTypes.on.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("requestContentType", requestContentType);
 			context.put("merge", merge);
@@ -243,14 +237,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 	}
 
 	@Override
-	public void beforeDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public void beforeDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.delete.name();
 			String type = ODataHandlerTypes.before.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("contentType", contentType);
 			executeHandlers(handlers, context);
@@ -260,14 +253,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 	}
 
 	@Override
-	public void afterDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public void afterDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.delete.name();
 			String type = ODataHandlerTypes.after.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("contentType", contentType);
 			executeHandlers(handlers, context);
@@ -292,14 +284,13 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 	}
 
 	@Override
-	public ODataResponse onDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public ODataResponse onDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 		try {
 			String namespace = uriInfo.getTargetType().getNamespace();
 			String name = uriInfo.getTargetType().getName();
 			String method = ODataHandlerMethods.delete.name();
 			String type = ODataHandlerTypes.on.name();
 			List<ODataHandlerDefinition> handlers = odataCoreService.getHandlers(namespace, name, method, type);
-			Map<Object, Object> context = new HashMap<Object, Object>();
 			context.put("uriInfo", uriInfo);
 			context.put("contentType", contentType);
 			String responseMessage = executeHandler(handlers, context);
@@ -325,7 +316,12 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 		}
 		return false;
 	}
-	
+
+	@Override
+	public String getName() {
+		return DEFAULT_ODATA_EVENT_HANDLER_NAME;
+	}
+
 	private void executeHandlers(List<ODataHandlerDefinition> handlers, Map<Object, Object> context) {
 		handlers.forEach(handler -> {
 			setHandlerParametersInContext(context, handler);
@@ -363,7 +359,7 @@ public class ScriptingOData2EventHandler implements OData2EventHandler {
 				IJavascriptEngineExecutor.JAVASCRIPT_TYPE_DEFAULT, DIRIGIBLE_ODATA_WRAPPER_MODULE_ON_EVENT, context);
 		return response;
 	}
-	
+
 	private void setHandlerParametersInContext(Map<Object, Object> context, ODataHandlerDefinition handler) {
 		context.put("location", handler.getLocation());
 		context.put("namespace", handler.getNamespace());

--- a/modules/engines/engine-odata/src/main/resources/META-INF/services/org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler
+++ b/modules/engines/engine-odata/src/main/resources/META-INF/services/org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler
@@ -1,0 +1,1 @@
+org.eclipse.dirigible.engine.odata2.handler.ScriptingOData2EventHandler # Scripting OData Event Handler

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/api/OData2EventHandler.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/api/OData2EventHandler.java
@@ -12,6 +12,7 @@
 package org.eclipse.dirigible.engine.odata2.sql.api;
 
 import java.io.InputStream;
+import java.util.Map;
 
 import org.apache.olingo.odata2.api.ep.entry.ODataEntry;
 import org.apache.olingo.odata2.api.processor.ODataResponse;
@@ -20,45 +21,50 @@ import org.apache.olingo.odata2.api.uri.info.PostUriInfo;
 import org.apache.olingo.odata2.api.uri.info.PutMergePatchUriInfo;
 
 public interface OData2EventHandler {
-	
+
+	public static final String DIRIGIBLE_ODATA_EVENT_HANDLER_NAME = "DIRIGIBLE_ODATA_EVENT_HANDLER_NAME";
+	public static final String DEFAULT_ODATA_EVENT_HANDLER_NAME = "default";
+
 	void beforeCreateEntity(final PostUriInfo uriInfo,
-			final String requestContentType, final String contentType, ODataEntry entry);
-	
+			final String requestContentType, final String contentType, ODataEntry entry, Map<Object, Object> context);
+
 	void afterCreateEntity(final PostUriInfo uriInfo,
-			final String requestContentType, final String contentType, final ODataEntry entry);
-	
+			final String requestContentType, final String contentType, final ODataEntry entry, Map<Object, Object> context);
+
 	boolean usingOnCreateEntity(final PostUriInfo uriInfo,
 			final String requestContentType, final String contentType);
-	
+
 	ODataResponse onCreateEntity(final PostUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final String contentType);
-	
+			final String requestContentType, final String contentType, Map<Object, Object> context);
+
 	boolean forbidCreateEntity(final PostUriInfo uriInfo,
 			final String requestContentType, final String contentType);
-	
+
 	void beforeUpdateEntity(final PutMergePatchUriInfo uriInfo,
-			final String requestContentType, final boolean merge, final String contentType, final ODataEntry entry);
-	
+			final String requestContentType, final boolean merge, final String contentType, final ODataEntry entry, Map<Object, Object> context);
+
 	void afterUpdateEntity(final PutMergePatchUriInfo uriInfo,
-			final String requestContentType, final boolean merge, final String contentType, final ODataEntry entry);
-	
+			final String requestContentType, final boolean merge, final String contentType, final ODataEntry entry, Map<Object, Object> context);
+
 	boolean usingOnUpdateEntity(final PutMergePatchUriInfo uriInfo,
 			final String requestContentType, final boolean merge, final String contentType);
-	
+
 	ODataResponse onUpdateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final boolean merge, final String contentType);
-	
+			final String requestContentType, final boolean merge, final String contentType, Map<Object, Object> context);
+
 	boolean forbidUpdateEntity(final PutMergePatchUriInfo uriInfo,
 			final String requestContentType, final boolean merge, final String contentType);
-	
-	void beforeDeleteEntity(final DeleteUriInfo uriInfo, final String contentType);
-	
-	void afterDeleteEntity(final DeleteUriInfo uriInfo, final String contentType);
-	
+
+	void beforeDeleteEntity(final DeleteUriInfo uriInfo, final String contentType, Map<Object, Object> context);
+
+	void afterDeleteEntity(final DeleteUriInfo uriInfo, final String contentType, Map<Object, Object> context);
+
 	boolean usingOnDeleteEntity(final DeleteUriInfo uriInfo, final String contentType);
-	
-	ODataResponse onDeleteEntity(final DeleteUriInfo uriInfo, final String contentType);
-	
+
+	ODataResponse onDeleteEntity(final DeleteUriInfo uriInfo, final String contentType, Map<Object, Object> context);
+
 	boolean forbidDeleteEntity(final DeleteUriInfo uriInfo, final String contentType);
+
+	String getName();
 
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLUpdateBuilder.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLUpdateBuilder.java
@@ -34,10 +34,11 @@ public class SQLUpdateBuilder extends AbstractQueryBuilder {
 
 	private  EdmEntityType target;
 	private  ODataEntry updateEntry;
+	private  String tableName;
 
 	private final List<String> nonKeyColumnNames = new ArrayList<>();
 
-	public SQLUpdateBuilder(final EdmTableBindingProvider tableMappingProvider, Map<String, Object> uriKeys) {
+	public SQLUpdateBuilder(final EdmTableBindingProvider tableMappingProvider, Map<String, Object> uriKeys) throws ODataException {
 		super(tableMappingProvider);
 		this.uriKeyProperties = uriKeys;
 	}
@@ -61,7 +62,7 @@ public class SQLUpdateBuilder extends AbstractQueryBuilder {
 				initializeQuery();
 				StringBuilder builder = new StringBuilder();
 				builder.append("UPDATE ");
-				builder.append(buildInto());
+				builder.append(tableName != null ? tableName : buildInto());
 				builder.append(" SET ");
 				builder.append(buildColumnList()).append(" WHERE ");
 
@@ -87,6 +88,14 @@ public class SQLUpdateBuilder extends AbstractQueryBuilder {
 		return target;
 	}
 
+	public SQLUpdateBuilder setTableName(String tableName) {
+		this.tableName = tableName;
+		return this;
+	}
+
+	public String getTargetTableName() {
+		return buildInto();
+	}
 
 	public void initializeQuery() throws ODataException {
 
@@ -127,7 +136,7 @@ public class SQLUpdateBuilder extends AbstractQueryBuilder {
 		}
 	}
 
-	private String buildInto() throws EdmException {
+	private String buildInto() {
 		StringBuilder into = new StringBuilder();
 		Iterator<String> it = getTablesAliasesForEntitiesInQuery();
 		while (it.hasNext()) {

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/AbstractSQLProcessor.java
@@ -59,467 +59,498 @@ import static org.eclipse.dirigible.engine.odata2.sql.utils.OData2Utils.hasExpan
 
 public abstract class AbstractSQLProcessor extends ODataSingleProcessor implements SQLProcessor {
 
-	private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
-	
-	private final OData2EventHandler odata2EventHandler;
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSQLProcessor.class);
+
+    private final OData2EventHandler odata2EventHandler;
     private DataSource dataSource;
-	private final ResultSetReader resultSetReader;
+    private final ResultSetReader resultSetReader;
 
-	public AbstractSQLProcessor() {
-		this(new DummyOData2EventHandler());
-	}
-	
-	public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
-		this.resultSetReader = new ResultSetReader(this);
-		this.odata2EventHandler = odata2EventHandler;
-	}
+    public AbstractSQLProcessor() {
+        this(new DummyOData2EventHandler());
+    }
 
-	@Override
-	public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
-		return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
-	}
+    public AbstractSQLProcessor(OData2EventHandler odata2EventHandler) {
+        this.resultSetReader = new ResultSetReader(this);
+        this.odata2EventHandler = odata2EventHandler;
+    }
 
-	@Override
-	public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
-			throw new ODataNotImplementedException();
-		}
-		try {
-			SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+    @Override
+    public ODataResponse updateEntitySimplePropertyValue(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType, String contentType) throws ODataException {
+        return super.updateEntitySimplePropertyValue(uriInfo, content, requestContentType, contentType);
+    }
 
-			try (Connection connection = getDataSource().getConnection()) {
-				int count = doCountEntitySet(sqlQuery, connection);
-				return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
-			}
-		} catch (SQLException e) {
-			throw new ODataException(e);
-		}
-	}
+    @Override
+    public ODataResponse countEntitySet(final GetEntitySetCountUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        if (uriInfo.getTop() != null || uriInfo.getSkip() != null) {
+            throw new ODataNotImplementedException();
+        }
+        try {
+            SQLSelectBuilder sqlQuery = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
 
-	@Override
-	public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		LOG.error("readEntityComplexProperty not implemented: {}",uriInfo.toString());
-		throw new ODataException("Not Implemented");
-	}
+            try (Connection connection = getDataSource().getConnection()) {
+                int count = doCountEntitySet(sqlQuery, connection);
+                return ODataResponse.fromResponse(EntityProvider.writeText(String.valueOf(count))).build();
+            }
+        } catch (SQLException e) {
+            throw new ODataException(e);
+        }
+    }
 
-	protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
-		// TODO cache the metadata, because it fires a DB query every time
-		// TODO do we really need to select the entities?
-		String sql = sqlQuery.buildSelect(createSQLContext(connection));
-		try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-			LOG.info(sql);
-			setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				// TODO do we need to assert that resultSet.next() == true and subsequently
-				// resultSet.next() == false here?
-				resultSet.next();
-				return resultSet.getInt(1);
-			}
-		}
-	}
+    @Override
+    public ODataResponse readEntityComplexProperty(final GetComplexPropertyUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        LOG.error("readEntityComplexProperty not implemented: {}", uriInfo.toString());
+        throw new ODataException("Not Implemented");
+    }
 
-	protected SQLContext createSQLContext(final Connection connection) throws SQLException {
-		return new SQLContext(connection.getMetaData(), this.getContext());
-	}
+    protected int doCountEntitySet(SQLSelectBuilder sqlQuery, final Connection connection) throws ODataException, SQLException {
+        // TODO cache the metadata, because it fires a DB query every time
+        // TODO do we really need to select the entities?
+        String sql = sqlQuery.buildSelect(createSQLContext(connection));
+        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            LOG.info(sql);
+            setParamsOnStatement(preparedStatement, sqlQuery.getStatementParams());
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                // TODO do we need to assert that resultSet.next() == true and subsequently
+                // resultSet.next() == false here?
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        }
+    }
 
-	protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
-			throws SQLException, ODataException {
-		String sql = selectQuery.buildSelect(createSQLContext(connection));
-		LOG.info(sql);
-		PreparedStatement preparedStatement = connection.prepareStatement(sql);
+    protected SQLContext createSQLContext(final Connection connection) throws SQLException {
+        return new SQLContext(connection.getMetaData(), this.getContext());
+    }
 
-		setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
-		return preparedStatement;
-	}
+    protected PreparedStatement createSelectStatement(SQLSelectBuilder selectQuery, final Connection connection)
+            throws SQLException, ODataException {
+        String sql = selectQuery.buildSelect(createSQLContext(connection));
+        LOG.info(sql);
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
 
-	@Override
-	public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
+        setParamsOnStatement(preparedStatement, selectQuery.getStatementParams());
+        return preparedStatement;
+    }
 
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+    @Override
+    public ODataResponse readEntity(final GetEntityUriInfo uriInfo, final String contentType) throws ODataException {
 
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
 
-		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createSelectStatement(query, connection)){
-				try (ResultSet resultSet = statement.executeQuery()){
-					while (resultSet.next()) {
-						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
-						if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
-							currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
-						}
-						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-						if (hasExpand(expandEntities)) {
-							resultSetReader.accumulateExpandedEntities(query, resultSet, currentAccumulator, expandEntities);
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return ExpandCallBack.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, currentAccumulator, contentType);
-	}
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
 
-
+        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {
+                        ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+                        if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
+                            currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
+                        }
+                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+                        if (hasExpand(expandEntities)) {
+                            resultSetReader.accumulateExpandedEntities(query, resultSet, currentAccumulator, expandEntities);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return ExpandCallBack.writeEntryWithExpand(getContext(), (UriInfo) uriInfo, currentAccumulator, contentType);
+    }
 
 
-	@Override
-	public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		final InlineCount inlineCountType = uriInfo.getInlineCount();
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+    @Override
+    public ODataResponse readEntitySet(final GetEntitySetUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        final InlineCount inlineCountType = uriInfo.getInlineCount();
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
 
-		Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
-		List<ResultSetReader.ExpandAccumulator> entitiesFeed = new ArrayList<>();
-		Integer count;
-		String nextLink;
-		try (Connection connection = getDataSource().getConnection()) {
-			if (inlineCountType == InlineCount.ALLPAGES) {
-				SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
-				count = doCountEntitySet(countEntitySet, connection); // does not close the connection
-			} else {
-				count = null;
-			}
-			List<String> readIdsForExpand = new ArrayList<>();
-			if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
-				LOG.debug("Reading the ids that will be used for $expand");
-				readIdsForExpand = readIdsForExpand(uriInfo);
-				LOG.info("Using IDs for $expand: {}", readIdsForExpand);
-			}
+        Collection<EdmProperty> properties = getSelectedProperties(uriInfo.getSelect(), targetEntityType);
+        List<ResultSetReader.ExpandAccumulator> entitiesFeed = new ArrayList<>();
+        Integer count;
+        String nextLink;
+        try (Connection connection = getDataSource().getConnection()) {
+            if (inlineCountType == InlineCount.ALLPAGES) {
+                SQLSelectBuilder countEntitySet = this.getSQLQueryBuilder().buildSelectCountQuery((UriInfo) uriInfo, getContext());
+                count = doCountEntitySet(countEntitySet, connection); // does not close the connection
+            } else {
+                count = null;
+            }
+            List<String> readIdsForExpand = new ArrayList<>();
+            if (OData2Utils.hasExpand((UriInfo) uriInfo)) {
+                LOG.debug("Reading the ids that will be used for $expand");
+                readIdsForExpand = readIdsForExpand(uriInfo);
+                LOG.info("Using IDs for $expand: {}", readIdsForExpand);
+            }
 
-			SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
-			try (PreparedStatement statement = createSelectStatement(query, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
-					while (resultSet.next()) {
-						ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
-						LOG.info("Current entity set object is {}", currentTargetEntity);
-						if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
-							currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
-							entitiesFeed.add(currentAccumulator);
-						}
+            SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntitySetQuery((UriInfo) uriInfo, readIdsForExpand, getContext());
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    ResultSetReader.ExpandAccumulator currentAccumulator = new ResultSetReader.ExpandAccumulator(targetEntityType);
+                    while (resultSet.next()) {
+                        ResultSetReader.ResultSetEntity currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+                        LOG.info("Current entity set object is {}", currentTargetEntity);
+                        if (!currentAccumulator.isAccumulatorFor(currentTargetEntity)) {
+                            currentAccumulator = new ResultSetReader.ExpandAccumulator(currentTargetEntity);
+                            entitiesFeed.add(currentAccumulator);
+                        }
 
-						List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
-						if (hasExpand(expandEntities)) {
-							resultSetReader.accumulateExpandedEntities(query, resultSet, currentAccumulator, expandEntities);
-						}
-					}
-					boolean needsNextLink = query.isServersidePaging() && entitiesFeed.size() == this
-							.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-					nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return ExpandCallBack.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, entitiesFeed, contentType, count, nextLink);
-	}
+                        List<ArrayList<NavigationPropertySegment>> expandEntities = uriInfo.getExpand();
+                        if (hasExpand(expandEntities)) {
+                            resultSetReader.accumulateExpandedEntities(query, resultSet, currentAccumulator, expandEntities);
+                        }
+                    }
+                    boolean needsNextLink = query.isServersidePaging() && entitiesFeed.size() == this
+                            .getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+                    nextLink = needsNextLink ? generateNextLink(query, targetEntityType) : null;
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return ExpandCallBack.writeFeedWithExpand(getContext(), (UriInfo) uriInfo, entitiesFeed, contentType, count, nextLink);
+    }
 
-	public List<String> readIdsForExpand (final GetEntitySetUriInfo uriInfo) throws ODataException {
-		List<String> idsOfLeadingEntities = new ArrayList<>();
-		try (Connection connection = getDataSource().getConnection()) {
-			SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
-			try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					while (resultSet.next()) {// TODO remove the duplication here
-						// we select only the ids here (we assume that only one key property is in the
-						// ID)
-						// Override this method if this is not the case
-						idsOfLeadingEntities.add(resultSet.getString(1));
-					}
-				}
-			}
-		} catch (Exception e) {
-			throw new ODataException(e);
-		}
-		return idsOfLeadingEntities;
-	}
-
-	
-	/**
-	 * Generates the next link for server-side paging. The next-link is based on the
-	 * URI of the current request, except that {@code $skip} or {@code $skiptoken}
-	 * will be removed.
-	 * 
-	 * @param query the query
-	 * @param targetEntityType the target entity type
-	 * @return the link
-	 * @throws ODataException in case of an error
-	 */
-	protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
-		int top = query.getSelectExpression().getTop();
-		int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
-		return OData2Utils.generateNextLink(getContext(), top, pagingSize);
-	}
-
-	@Override
-	public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType) throws ODataException {
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(targetEntityType, Collections.emptyMap());
-		Collection<EdmProperty> properties = uriInfo.getPropertyPath();
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createSelectStatement(query, connection)){
-				try (ResultSet resultSet = statement.executeQuery()){
-					while (resultSet.next()) {
-						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		return writeEntryPropertyValue(uriInfo.getPropertyPath().iterator().next(), currentTargetEntity.data, contentType);
-	}
-
-	private static ODataResponse writeEntryPropertyValue(EdmProperty property, Map<String, Object> data,  final String contentType) throws ODataException {
-		if (data == null || data.isEmpty()) {
-			return OData2Utils.noContentResponse(contentType);
-		} else {
-			return EntityProvider.writePropertyValue(property, data.get(property.getName()));
-		}
-	}
-
-	@Override
-	public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType) throws ODataException {
-		return readEntitySimplePropertyValue(uriInfo, contentType);
-	}
-
-	@Override
-	public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType) throws ODataException {
-		throw new ODataNotImplementedException();
-	}
-
-	@Override
-	public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
-			throws ODataException {
-		throw new ODataNotImplementedException();
-	}
-
-	@Override
-	public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final String contentType) throws ODataException {
-		
-		if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
-			throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
-					OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-		
-		if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
-			return this.odata2EventHandler.onCreateEntity(uriInfo, content,
-					requestContentType, contentType);
-		}
-
-		final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType entityType = entitySet.getEntityType();
-		ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
-		this.odata2EventHandler.beforeCreateEntity(uriInfo,
-				requestContentType, contentType, entry);
-
-		SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
-
-		try (Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)){
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		
-		try {
-			List<EdmProperty> keyProperties = entityType.getKeyProperties();
-			List<KeyPredicate> keyPredicates = new ArrayList<>();
-			if (!keyProperties.isEmpty()) {
-				for (EdmProperty keyProperty : keyProperties) {
-					if (entry.getProperties().get(keyProperty.getName()) != null) {
-						keyPredicates.add(new KeyPredicateImpl(
-								entry.getProperties().get(keyProperty.getName()).toString(),
-								keyProperty));
-					} else {
-						final String msg = "Cannot create entity without key(s)";
-						LOG.error(msg);
-						throw new ODataException(msg);
-					}
-				}
-				
-				((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
-				
-				// Re-read the inserted entity to get the auto-generated properties
-				SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-				ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(entityType, Collections.emptyMap());
-				Collection<EdmProperty> properties = getProperties(entityType);
-				try (Connection connection = getDataSource().getConnection()){
-					try (PreparedStatement statement = createSelectStatement(query, connection)){
-						try (ResultSet resultSet = statement.executeQuery()){
-							while (resultSet.next()) {
-								currentTargetEntity = resultSetReader.getResultSetEntity(query, entityType, properties, resultSet);
-							}
-						}
-					}
-					ODataResponse response = ExpandCallBack.writeEntryWithExpand(getContext(), //
-							(UriInfo) uriInfo, //
-							new ResultSetReader.ExpandAccumulator(currentTargetEntity), //
-							contentType);
-					this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-					return response;
-				} catch (Exception e) {
-					LOG.error("Unable to serve request", e);
-					throw new ODataException(e);
-				}
-			}
-		} catch (Throwable t) {
-			LOG.error("Unable to get back the created entity", t);
-		}
-		
-		ODataContext context = getContext();
-		EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
-				.serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
-				.build();
-		final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
-		this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry);
-		return response;
-	}
-
-	public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
-			final String requestContentType, final boolean merge) throws ODataBadRequestException {
-		try {
-			EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
-					.mergeSemantic(merge).build();
-			return EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
-		} catch (Exception e) {
-			throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
-		}
-	}
-
-	@Override
-	public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
-		if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
-			throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-		if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
-			return this.odata2EventHandler.onDeleteEntity(uriInfo, contentType);
-		}
-		this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType);
-
-		SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-		try (Connection connection = getDataSource().getConnection()) {
-			try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-
-		ODataResponse response = ODataResponse.newBuilder().build();
-		this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType);
-		return response;
-	}
-
-	private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
-		Map<String, Object> keyMap = new HashMap<>();
-		for (final KeyPredicate key : keys) {
-			final EdmProperty property = key.getProperty();
-			final EdmSimpleType type = (EdmSimpleType) property.getType();
-			keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
-					property.getFacets(), type.getDefaultType()));
-		}
-		return keyMap;
-	}
-
-	@Override
-	public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
-			final String requestContentType, final boolean merge, final String contentType) throws ODataException {
-		if (uriInfo.getFilter() != null) {
-			throw new ODataException("Update operation is not allowed with $filter.");
-		}
-		if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-			throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
-		}
-
-		if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
-			return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType);
-		}
-		
-		final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
-		final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
-
-		SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
-		ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(targetEntityType, Collections.emptyMap());
-		Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
-		try (Connection connection = getDataSource().getConnection()) {
-			try (PreparedStatement statement = createSelectStatement(query, connection)) {
-				try (ResultSet resultSet = statement.executeQuery()) {
-					while (resultSet.next()) {
-						currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
-					}
-					if (currentTargetEntity.data.isEmpty()) {
-						throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
-					}
-				}
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-
-		ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
-		this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-
-		SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
-				mapKeys(uriInfo.getKeyPredicates()), getContext());
-
-		try(Connection connection = getDataSource().getConnection()){
-			try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)){
-				statement.executeUpdate();
-			}
-		} catch (Exception e) {
-			LOG.error("Unable to serve request", e);
-			throw new ODataException(e);
-		}
-		ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
-		this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry);
-		return response;
-	}
+    public List<String> readIdsForExpand(final GetEntitySetUriInfo uriInfo) throws ODataException {
+        List<String> idsOfLeadingEntities = new ArrayList<>();
+        try (Connection connection = getDataSource().getConnection()) {
+            SQLSelectBuilder queryForIdsInExpand = this.getSQLQueryBuilder().buildSelectEntitySetIdsForTopAndExpandQuery((UriInfo) uriInfo, getContext());
+            try (PreparedStatement statement = createSelectStatement(queryForIdsInExpand, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {// TODO remove the duplication here
+                        // we select only the ids here (we assume that only one key property is in the
+                        // ID)
+                        // Override this method if this is not the case
+                        idsOfLeadingEntities.add(resultSet.getString(1));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new ODataException(e);
+        }
+        return idsOfLeadingEntities;
+    }
 
 
-	protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
+    /**
+     * Generates the next link for server-side paging. The next-link is based on the
+     * URI of the current request, except that {@code $skip} or {@code $skiptoken}
+     * will be removed.
+     *
+     * @param query            the query
+     * @param targetEntityType the target entity type
+     * @return the link
+     * @throws ODataException in case of an error
+     */
+    protected String generateNextLink(SQLSelectBuilder query, EdmEntityType targetEntityType) throws ODataException {
+        int top = query.getSelectExpression().getTop();
+        int pagingSize = this.getSQLQueryBuilder().getEntityPagingSize(targetEntityType);
+        return OData2Utils.generateNextLink(getContext(), top, pagingSize);
+    }
 
-	protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
+    @Override
+    public ODataResponse readEntitySimplePropertyValue(final GetSimplePropertyUriInfo uriInfo, final String contentType) throws ODataException {
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(targetEntityType, Collections.emptyMap());
+        Collection<EdmProperty> properties = uriInfo.getPropertyPath();
+        try (Connection connection = getDataSource().getConnection()) {
+            try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    while (resultSet.next()) {
+                        currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+        return writeEntryPropertyValue(uriInfo.getPropertyPath().iterator().next(), currentTargetEntity.data, contentType);
+    }
 
-	protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
-		return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
-	}
+    private static ODataResponse writeEntryPropertyValue(EdmProperty property, Map<String, Object> data, final String contentType) throws ODataException {
+        if (data == null || data.isEmpty()) {
+            return OData2Utils.noContentResponse(contentType);
+        } else {
+            return EntityProvider.writePropertyValue(property, data.get(property.getName()));
+        }
+    }
 
-	protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
-		String sql = statement.sql();
-		LOG.info("SQL Statement: {}", sql);
+    @Override
+    public ODataResponse readEntitySimpleProperty(final GetSimplePropertyUriInfo uriInfo, final String contentType) throws ODataException {
+        return readEntitySimplePropertyValue(uriInfo, contentType);
+    }
 
-		PreparedStatement preparedStatement = connection.prepareStatement(sql);
-		setParamsOnStatement(preparedStatement, statement.getStatementParams());
-		return preparedStatement;
-	}
+    @Override
+    public ODataResponse readEntityMedia(final GetMediaResourceUriInfo uriInfo, final String contentType) throws ODataException {
+        throw new ODataNotImplementedException();
+    }
 
-	public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws SQLException {
-		LOG.debug("SQL Params: {}", params);
-		SQLUtils.setParamsOnStatement(preparedStatement, params);
-	}
+    @Override
+    public ODataResponse readEntityLinks(final GetEntitySetLinksUriInfo uriInfo, final String contentType)
+            throws ODataException {
+        throw new ODataNotImplementedException();
+    }
+
+    @Override
+    public ODataResponse createEntity(final PostUriInfo uriInfo, final InputStream content,
+                                      final String requestContentType, final String contentType) throws ODataException {
+        //TODO: change operations order to be correct; write the updated entry in aftertablename
+
+        if (this.odata2EventHandler.forbidCreateEntity(uriInfo, requestContentType, contentType)) {
+            throw new ODataException(String.format("Create operation on entity: %s is forbidden.",
+                    OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+
+        final EdmEntitySet entitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType entityType = entitySet.getEntityType();
+        ODataEntry entry = parseEntry(entitySet, content, requestContentType, false);
+        SQLInsertBuilder insertBuilder = this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext());
+
+        try (Connection connection = getDataSource().getConnection()) {
+            Map<Object, Object> context = new HashMap<Object, Object>();
+            context.put("dummyBuilder", this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext()));
+            context.put("insertBuilder", this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext()));
+            context.put("sqlContext", createSQLContext(connection));
+            this.odata2EventHandler.beforeCreateEntity(uriInfo,
+                    requestContentType, contentType, entry, context);
+            try (PreparedStatement statement = createInsertStatement(insertBuilder, connection)) {
+                statement.executeUpdate();
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+
+        if (this.odata2EventHandler.usingOnCreateEntity(uriInfo, requestContentType, contentType)) {
+            try (Connection connection = getDataSource().getConnection()) {
+                Map<Object, Object> context = new HashMap<Object, Object>();
+                // TODO: used only to derive target table - refactor
+                context.put("dummyBuilder", this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext()));
+                context.put("insertBuilder", this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext()));
+                context.put("sqlContext", createSQLContext(connection));
+                this.odata2EventHandler.onCreateEntity(uriInfo, content,
+                        requestContentType, contentType, context); //TODO: handle return properly
+            } catch (Exception e) {
+                LOG.error("Unable to serve request", e);
+                throw new ODataException(e);
+            }
+        }
+
+        try {
+            List<EdmProperty> keyProperties = entityType.getKeyProperties();
+            List<KeyPredicate> keyPredicates = new ArrayList<>();
+            if (!keyProperties.isEmpty()) {
+                for (EdmProperty keyProperty : keyProperties) {
+                    if (entry.getProperties().get(keyProperty.getName()) != null) {
+                        keyPredicates.add(new KeyPredicateImpl(
+                                entry.getProperties().get(keyProperty.getName()).toString(),
+                                keyProperty));
+                    } else {
+                        final String msg = "Cannot create entity without key(s)";
+                        LOG.error(msg);
+                        throw new ODataException(msg);
+                    }
+                }
+
+                ((UriInfoImpl) uriInfo).setKeyPredicates(keyPredicates);
+
+                // Re-read the inserted entity to get the auto-generated properties
+                SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+                ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(entityType, Collections.emptyMap());
+                Collection<EdmProperty> properties = getProperties(entityType);
+                try (Connection connection = getDataSource().getConnection()) {
+                    try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                        try (ResultSet resultSet = statement.executeQuery()) {
+                            while (resultSet.next()) {
+                                currentTargetEntity = resultSetReader.getResultSetEntity(query, entityType, properties, resultSet);
+                            }
+                        }
+                    }
+                    ODataResponse response = ExpandCallBack.writeEntryWithExpand(getContext(), //
+                            (UriInfo) uriInfo, //
+                            new ResultSetReader.ExpandAccumulator(currentTargetEntity), //
+                            contentType);
+                    Map<Object, Object> context = new HashMap<Object, Object>();
+                    context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+                    context.put("sqlContext", createSQLContext(connection));
+                    this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry, context);
+                    return response;
+                } catch (Exception e) {
+                    LOG.error("Unable to serve request", e);
+                    throw new ODataException(e);
+                }
+            }
+        } catch (Throwable t) {
+            LOG.error("Unable to get back the created entity", t);
+        }
+
+        ODataContext context = getContext();
+        EntityProviderWriteProperties writeProperties = EntityProviderWriteProperties
+                .serviceRoot(context.getPathInfo().getServiceRoot()).expandSelectTree(entry.getExpandSelectTree())
+                .build();
+        final ODataResponse response = EntityProvider.writeEntry(contentType, entitySet, entry.getProperties(), writeProperties);
+        this.odata2EventHandler.afterCreateEntity(uriInfo, requestContentType, contentType, entry, new HashMap<Object, Object>());
+        return response;
+    }
+
+    public final ODataEntry parseEntry(final EdmEntitySet entitySet, final InputStream content,
+                                       final String requestContentType, final boolean merge) throws ODataBadRequestException {
+        try {
+            EntityProviderReadProperties entityProviderProperties = EntityProviderReadProperties.init()
+                    .mergeSemantic(merge).build();
+            return EntityProvider.readEntry(requestContentType, entitySet, content, entityProviderProperties);
+        } catch (Exception e) {
+            throw new ODataBadRequestException(ODataBadRequestException.BODY, e);
+        }
+    }
+
+    @Override
+    public ODataResponse deleteEntity(final DeleteUriInfo uriInfo, final String contentType) throws ODataException {
+        if (this.odata2EventHandler.forbidDeleteEntity(uriInfo, contentType)) {
+            throw new ODataException(String.format("Delete operation on entity: %s is forbidden.", OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+
+        SQLDeleteBuilder deleteBuilder = this.getSQLQueryBuilder().buildDeleteEntityQuery((UriInfo) uriInfo, mapKeys(uriInfo.getKeyPredicates()), getContext());
+
+        try (Connection connection = dataSource.getConnection()) {
+            Map<Object, Object> context = new HashMap<Object, Object>();
+            context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+            this.odata2EventHandler.beforeDeleteEntity(uriInfo, contentType, context);
+
+            if (this.odata2EventHandler.usingOnDeleteEntity(uriInfo, contentType)) {
+                context = new HashMap<Object, Object>();
+                context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+                this.odata2EventHandler.onDeleteEntity(uriInfo, contentType, context); //TODO: handle return properly
+            } else {
+                try (PreparedStatement statement = createDeleteStatement(deleteBuilder, connection)) {
+                    statement.executeUpdate();
+                }
+            }
+
+            ODataResponse response = ODataResponse.newBuilder().build();
+            context = new HashMap<Object, Object>();
+            this.odata2EventHandler.afterDeleteEntity(uriInfo, contentType, context);
+            return response;
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+    }
+
+    private static Map<String, Object> mapKeys(final List<KeyPredicate> keys) throws EdmException {
+        Map<String, Object> keyMap = new HashMap<>();
+        for (final KeyPredicate key : keys) {
+            final EdmProperty property = key.getProperty();
+            final EdmSimpleType type = (EdmSimpleType) property.getType();
+            keyMap.put(property.getName(), type.valueOfString(key.getLiteral(), EdmLiteralKind.DEFAULT,
+                    property.getFacets(), type.getDefaultType()));
+        }
+        return keyMap;
+    }
+
+    @Override
+    public ODataResponse updateEntity(final PutMergePatchUriInfo uriInfo, final InputStream content,
+                                      final String requestContentType, final boolean merge, final String contentType) throws ODataException {
+        if (uriInfo.getFilter() != null) {
+            throw new ODataException("Update operation is not allowed with $filter.");
+        }
+        if (this.odata2EventHandler.forbidUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+            throw new ODataException(String.format("Update operation forbidden on entity: %s", OData2Utils.fqn(uriInfo.getTargetType())));
+        }
+
+        final EdmEntitySet targetEntitySet = uriInfo.getTargetEntitySet();
+        final EdmEntityType targetEntityType = targetEntitySet.getEntityType();
+
+        ODataEntry entry = parseEntry(targetEntitySet, content, requestContentType, false);
+        SQLSelectBuilder query = this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext());
+        try (Connection connection = dataSource.getConnection()) {
+            Map<Object, Object> context = new HashMap<Object, Object>();
+            context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+            context.put("updateBuilder", this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
+                    mapKeys(uriInfo.getKeyPredicates()), getContext()));
+            context.put("sqlContext", createSQLContext(connection));
+            this.odata2EventHandler.beforeUpdateEntity(uriInfo, requestContentType, merge, contentType, entry, context);
+
+            if (this.odata2EventHandler.usingOnUpdateEntity(uriInfo, requestContentType, merge, contentType)) {
+                context = new HashMap<Object, Object>();
+                context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+                context.put("updateBuilder", this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
+                        mapKeys(uriInfo.getKeyPredicates()), getContext()));
+                context.put("sqlContext", createSQLContext(connection));
+                return this.odata2EventHandler.onUpdateEntity(uriInfo, content, requestContentType, merge, contentType, context); //TODO: handle return properly
+            } else {
+                ResultSetReader.ResultSetEntity currentTargetEntity = new ResultSetReader.ResultSetEntity(targetEntityType, Collections.emptyMap());
+                Collection<EdmProperty> properties = targetEntityType.getKeyProperties();
+                try (PreparedStatement statement = createSelectStatement(query, connection)) {
+                    try (ResultSet resultSet = statement.executeQuery()) {
+                        while (resultSet.next()) {
+                            currentTargetEntity = resultSetReader.getResultSetEntity(query, targetEntityType, properties, resultSet);
+                        }
+                        if (currentTargetEntity.data.isEmpty()) {
+                            throw new ODataNotFoundException(ODataNotFoundException.ENTITY);
+                        }
+                    }
+                }
+
+                SQLUpdateBuilder updateBuilder = this.getSQLQueryBuilder().buildUpdateEntityQuery((UriInfo) uriInfo, entry,
+                        mapKeys(uriInfo.getKeyPredicates()), getContext());
+                try (PreparedStatement statement = createUpdateStatement(updateBuilder, connection)) {
+                    statement.executeUpdate();
+                }
+
+                ODataResponse response = ODataResponse.newBuilder().status(HttpStatusCodes.NO_CONTENT).build();
+                context = new HashMap<Object, Object>();
+                context.put("dummyBuilder", this.getSQLQueryBuilder().buildInsertEntityQuery((UriInfo) uriInfo, entry, getContext()));
+                context.put("selectBuilder", this.getSQLQueryBuilder().buildSelectEntityQuery((UriInfo) uriInfo, getContext()));
+                context.put("sqlContext", createSQLContext(connection));
+                this.odata2EventHandler.afterUpdateEntity(uriInfo, requestContentType, merge, contentType, entry, context);
+                return response;
+            }
+        } catch (Exception e) {
+            LOG.error("Unable to serve request", e);
+            throw new ODataException(e);
+        }
+    }
+
+
+    protected PreparedStatement createInsertStatement(SQLInsertBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
+
+    protected PreparedStatement createDeleteStatement(SQLDeleteBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
+
+    protected PreparedStatement createUpdateStatement(SQLUpdateBuilder builder, final Connection connection) throws SQLException, ODataException {
+        return createPreparedStatement(connection, builder.build(createSQLContext(connection)));
+    }
+
+    protected PreparedStatement createPreparedStatement(Connection connection, SQLStatement statement) throws ODataException, SQLException {
+        String sql = statement.sql();
+        LOG.info("SQL Statement: {}", sql);
+
+        PreparedStatement preparedStatement = connection.prepareStatement(sql);
+        setParamsOnStatement(preparedStatement, statement.getStatementParams());
+        return preparedStatement;
+    }
+
+    public void setParamsOnStatement(PreparedStatement preparedStatement, List<SQLStatementParam> params) throws SQLException {
+        LOG.debug("SQL Params: {}", params);
+        SQLUtils.setParamsOnStatement(preparedStatement, params);
+    }
 
     @Override
     public DataSource getDataSource() {
@@ -556,8 +587,8 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
         DataSource originalDataSource = this.getDataSource();
         try (Connection connection = getDataSource().getConnection()) {
             SingleConnectionDataSource singleConnectionDataSource = new SingleConnectionDataSource(connection);
-			this.setDataSource(singleConnectionDataSource);
-			boolean originalAutoCommit = connection.getAutoCommit();
+            this.setDataSource(singleConnectionDataSource);
+            boolean originalAutoCommit = connection.getAutoCommit();
             try {
                 //override the setDataSource so that all requests in a change set run in the same connection
                 return doExecuteChangeSet(handler, requests);
@@ -614,5 +645,12 @@ public abstract class AbstractSQLProcessor extends ODataSingleProcessor implemen
                 }
             }
         }
+    }
+
+    private Map<Object, Object> createHandlerContext(Connection connection, AbstractQueryBuilder queryBuilder) throws SQLException {
+        Map<Object, Object> context = new HashMap<>();
+        context.put("tableBindingProvider", queryBuilder.getTableBinding());
+        context.put("sqlContext", createSQLContext(connection));
+        return context;
     }
 }

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/DummyOData2EventHandler.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/processor/DummyOData2EventHandler.java
@@ -12,6 +12,7 @@
 package org.eclipse.dirigible.engine.odata2.sql.processor;
 
 import java.io.InputStream;
+import java.util.Map;
 
 import org.apache.olingo.odata2.api.ep.entry.ODataEntry;
 import org.apache.olingo.odata2.api.processor.ODataResponse;
@@ -22,14 +23,16 @@ import org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler;
 
 public class DummyOData2EventHandler implements OData2EventHandler {
 
+	private static final String ODATA2_EVENT_HANDLER_NAME = "dummy";
+
 	@Override
 	public void beforeCreateEntity(PostUriInfo uriInfo, String requestContentType,
-			String contentType, ODataEntry entry) {
+			String contentType, ODataEntry entry, Map<Object, Object> context) {
 	}
 
 	@Override
 	public void afterCreateEntity(PostUriInfo uriInfo, String requestContentType,
-			String contentType, ODataEntry entry) {
+			String contentType, ODataEntry entry, Map<Object, Object> context) {
 	}
 
 	@Override
@@ -40,7 +43,7 @@ public class DummyOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public ODataResponse onCreateEntity(PostUriInfo uriInfo, InputStream content, String requestContentType,
-			String contentType) {
+			String contentType, Map<Object, Object> context) {
 		return null;
 	}
 
@@ -52,12 +55,12 @@ public class DummyOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public void beforeUpdateEntity(PutMergePatchUriInfo uriInfo, String requestContentType,
-			boolean merge, String contentType, ODataEntry entry) {
+			boolean merge, String contentType, ODataEntry entry, Map<Object, Object> context) {
 	}
 
 	@Override
 	public void afterUpdateEntity(PutMergePatchUriInfo uriInfo, String requestContentType,
-			boolean merge, String contentType, ODataEntry entry) {
+			boolean merge, String contentType, ODataEntry entry, Map<Object, Object> context) {
 	}
 
 	@Override
@@ -68,7 +71,7 @@ public class DummyOData2EventHandler implements OData2EventHandler {
 
 	@Override
 	public ODataResponse onUpdateEntity(PutMergePatchUriInfo uriInfo, InputStream content, String requestContentType,
-			boolean merge, String contentType) {
+			boolean merge, String contentType, Map<Object, Object> context) {
 		return null;
 	}
 
@@ -79,11 +82,11 @@ public class DummyOData2EventHandler implements OData2EventHandler {
 	}
 
 	@Override
-	public void beforeDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public void beforeDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 	}
 
 	@Override
-	public void afterDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public void afterDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 	}
 
 	@Override
@@ -92,13 +95,18 @@ public class DummyOData2EventHandler implements OData2EventHandler {
 	}
 
 	@Override
-	public ODataResponse onDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
+	public ODataResponse onDeleteEntity(DeleteUriInfo uriInfo, String contentType, Map<Object, Object> context) {
 		return null;
 	}
 
 	@Override
 	public boolean forbidDeleteEntity(DeleteUriInfo uriInfo, String contentType) {
 		return false;
+	}
+
+	@Override
+	public String getName() {
+		return ODATA2_EVENT_HANDLER_NAME;
 	}
 
 }

--- a/modules/odata/odata-core/src/main/resources/META-INF/services/org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler
+++ b/modules/odata/odata-core/src/main/resources/META-INF/services/org.eclipse.dirigible.engine.odata2.sql.api.OData2EventHandler
@@ -1,0 +1,1 @@
+org.eclipse.dirigible.engine.odata2.sql.processor.DummyOData2EventHandler # Dummy OData Event Handler


### PR DESCRIPTION
Defines OData2EventHandler as a service. 
Introduces needed changes to SQL Builders to support setting the table name while building the statement (needed for temporary table names). 
Sets the appropriate context for the various CUD Odata events so that temporary table manipulation can be handled.
Expands sql dialects to support the creation of temporary tables, with an implementation for the HANA driver.