### PR TITLE
Truncating synchroniser artefact message because it could be too long

### DIFF
--- a/modules/core/core-scheduler/src/main/java/org/eclipse/dirigible/core/scheduler/service/definition/SynchronizerStateArtefactDefinition.java
+++ b/modules/core/core-scheduler/src/main/java/org/eclipse/dirigible/core/scheduler/service/definition/SynchronizerStateArtefactDefinition.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.dirigible.core.scheduler.service.definition;
 
+import org.apache.commons.lang3.StringUtils;
+
 import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -150,7 +152,7 @@ public class SynchronizerStateArtefactDefinition {
 	 * @param message the message to set
 	 */
 	public void setMessage(String message) {
-		this.message = message;
+		this.message = StringUtils.truncate(message, 512);
 	}
 
 	/**


### PR DESCRIPTION
### What issues does this PR fix or reference?
Truncate SYNCHRONIZER_ARTEFACT_MESSAGE

Messages stored by the artefact synchroniser could be too long. Thats why we store only the first 512 characters. 

Fixes: https://github.com/sap/xsk/issues/1326