### PR TITLE
Fix odata filter with null predicate

### DIFF
--- a/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLWhereClauseTest.java
+++ b/modules/odata/odata-core-test/src/test/java/org/eclipse/dirigible/engine/odata2/sql/clause/SQLWhereClauseTest.java
@@ -103,6 +103,38 @@ public final class SQLWhereClauseTest {
     }
 
     @Test
+    public void testIsNullFilter() throws Exception {
+        SQLWhereClause where = createWhereClause("MessageGuid eq null");
+        assertTrue("Statement params are not expected for \"Is Null\" filter", where.getStatementParams().isEmpty());
+
+        assertEquals("Unexpected where clause generated for Null predicate", "T0.MESSAGEGUID IS NULL", where.getWhereClause());
+    }
+
+    @Test
+    public void testIsNotNullFilter() throws Exception {
+        SQLWhereClause where = createWhereClause("MessageGuid ne null");
+        assertTrue("Statement params are not expected for \"Is Not Null\" filter", where.getStatementParams().isEmpty());
+
+        assertEquals("Unexpected where clause generated for Null predicate", "T0.MESSAGEGUID IS NOT NULL", where.getWhereClause());
+    }
+
+    @Test
+    public void testIsNotNullAndNullFilter() throws Exception {
+        SQLWhereClause where = createWhereClause("MessageGuid ne null").and(createWhereClause("Status eq null"));
+        assertTrue("Statement params are not expected filter with Null predicates only", where.getStatementParams().isEmpty());
+
+        assertEquals("Unexpected where clause generated for Null predicate", "T0.MESSAGEGUID IS NOT NULL AND T0.STATUS IS NULL", where.getWhereClause());
+    }
+
+    @Test
+    public void testIsNullWithAdditionalFilter() throws Exception {
+        SQLWhereClause where = createWhereClause("MessageGuid eq null").and(createWhereClause("Status eq 'SUCCESS'"));
+        assertParamListEquals(new String[]{"SUCCESS"}, where.getStatementParams());
+
+        assertEquals("Unexpected where clause generated for Null predicate", "T0.MESSAGEGUID IS NULL AND T0.STATUS = ?", where.getWhereClause());
+    }
+
+    @Test
     public void testOrClauseWithEquals() throws Exception {
 
         // OR combined with empty clause

--- a/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLUtils.java
+++ b/modules/odata/odata-core/src/main/java/org/eclipse/dirigible/engine/odata2/sql/builder/SQLUtils.java
@@ -81,6 +81,8 @@ public final class SQLUtils {
                     preparedStatement.setBigDecimal(i + 1, (BigDecimal) value);
                     break;
                 case Null:
+                    preparedStatement.setObject(i + 1, null);
+                    break;
                 case Guid:
                     preparedStatement.setObject(i + 1, value);
                     break;


### PR DESCRIPTION
Fixes #1781 

Current behaviour is that $filter=LastName eq null is transformed to WHERE LastName = null SQL which is incorrect SQL for working with NULL predicate.

With this PR **IS NULL/IS NOT NULL** will be used in the SQL when you have OData filter with right side of type Edm.Null