### PR TITLE
Treat CSV as text in client facade

### DIFF
--- a/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
+++ b/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -207,17 +207,18 @@ public class HttpClientFacade implements IScriptingFacade {
 			if (entity != null && entity.getContent() != null) {
 				byte[] content = IOUtils.toByteArray(entity.getContent());
 
-				String[] textMimeTypes = {
-						"application/CSV", "application/csv", "text/csv",
-						ContentType.TEXT_PLAIN.getMimeType(),
-						ContentType.TEXT_HTML.getMimeType(),
-						ContentType.TEXT_XML.getMimeType(),
-						ContentType.APPLICATION_JSON.getMimeType(),
-						ContentType.APPLICATION_ATOM_XML.getMimeType(),
-						ContentType.APPLICATION_XML.getMimeType(),
-						ContentType.APPLICATION_XHTML_XML.getMimeType()
-				};
-				boolean isTextType = Arrays.stream(textMimeTypes).anyMatch(ContentType.getOrDefault(entity).getMimeType()::equals);
+				 HashMap<String, Boolean> textMimeTypes = new HashMap<String, Boolean>();
+						textMimeTypes.put("application/CSV", true);
+						textMimeTypes.put("application/csv", true);
+						textMimeTypes.put("text/csv", true);
+						textMimeTypes.put(ContentType.TEXT_PLAIN.getMimeType(), true);
+						textMimeTypes.put(ContentType.TEXT_HTML.getMimeType(), true);
+						textMimeTypes.put(ContentType.TEXT_XML.getMimeType(), true);
+						textMimeTypes.put(ContentType.APPLICATION_JSON.getMimeType(), true);
+						textMimeTypes.put(ContentType.APPLICATION_ATOM_XML.getMimeType(), true);
+						textMimeTypes.put(ContentType.APPLICATION_XML.getMimeType(), true);
+						textMimeTypes.put(ContentType.APPLICATION_XHTML_XML.getMimeType(), true);
+				final boolean isTextType = textMimeTypes.get(ContentType.getOrDefault(entity).getMimeType()) != null;
 
 				if (isTextType && (!binary)) {
 					Charset charset = ContentType.getOrDefault(entity).getCharset();

--- a/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
+++ b/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -206,13 +207,19 @@ public class HttpClientFacade implements IScriptingFacade {
 			if (entity != null && entity.getContent() != null) {
 				byte[] content = IOUtils.toByteArray(entity.getContent());
 
-				if ((ContentType.getOrDefault(entity).getMimeType().equals(ContentType.TEXT_PLAIN.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.TEXT_HTML.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.TEXT_XML.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.APPLICATION_JSON.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.APPLICATION_ATOM_XML.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.APPLICATION_XML.getMimeType())
-						|| ContentType.getOrDefault(entity).getMimeType().equals(ContentType.APPLICATION_XHTML_XML.getMimeType())) && (!binary)) {
+				String[] textMimeTypes = {
+						"application/CSV", "application/csv", "text/csv",
+						ContentType.TEXT_PLAIN.getMimeType(),
+						ContentType.TEXT_HTML.getMimeType(),
+						ContentType.TEXT_XML.getMimeType(),
+						ContentType.APPLICATION_JSON.getMimeType(),
+						ContentType.APPLICATION_ATOM_XML.getMimeType(),
+						ContentType.APPLICATION_XML.getMimeType(),
+						ContentType.APPLICATION_XHTML_XML.getMimeType()
+				};
+				boolean isTextType = Arrays.stream(textMimeTypes).anyMatch(ContentType.getOrDefault(entity).getMimeType()::equals);
+
+				if (isTextType && (!binary)) {
 					Charset charset = ContentType.getOrDefault(entity).getCharset();
 					String text = new String(content, charset != null ? charset : StandardCharsets.UTF_8);
 					httpClientResponse.setText(text);

--- a/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
+++ b/api/api-facade/api-http/src/main/java/org/eclipse/dirigible/api/v3/http/HttpClientFacade.java
@@ -194,7 +194,7 @@ public class HttpClientFacade implements IScriptingFacade {
 		}
 	}
 
-	private static final String[] supportedTextMimeTypes = new String[] {
+	private static final HashSet<String> recognizedTextMimeTypes = new HashSet<>(Arrays.asList(
 			"application/CSV",
 			"application/csv",
 			"text/csv",
@@ -205,8 +205,7 @@ public class HttpClientFacade implements IScriptingFacade {
 			ContentType.APPLICATION_ATOM_XML.getMimeType(),
 			ContentType.APPLICATION_XML.getMimeType(),
 			ContentType.APPLICATION_XHTML_XML.getMimeType()
-	};
-	private static final Set<String> recognizedTextMimeTypes = new HashSet<>(Arrays.asList(supportedTextMimeTypes));
+	));
 
 	public static HttpClientResponse processHttpClientResponse(CloseableHttpResponse response, boolean binary) throws IOException {
 		try {
@@ -218,8 +217,8 @@ public class HttpClientFacade implements IScriptingFacade {
 			HttpEntity entity = response.getEntity();
 			if (entity != null && entity.getContent() != null) {
 				byte[] content = IOUtils.toByteArray(entity.getContent());
-				final String processedContentType = ContentType.getOrDefault(entity).getMimeType();
-				final boolean isSupportedTextType = recognizedTextMimeTypes.contains(processedContentType);
+				String processedContentType = ContentType.getOrDefault(entity).getMimeType();
+				boolean isSupportedTextType = recognizedTextMimeTypes.contains(processedContentType);
 
 				if (!binary && isSupportedTextType) {
 					Charset charset = ContentType.getOrDefault(entity).getCharset();


### PR DESCRIPTION
Signed-off-by: dimitarquanterall <d.aleksandrov@sap.com>

### What does this PR do?

It was detected CSV was recognised as text while processing client responses in HTTP client facade. 
This PR adds CSV content types.

### What issues does this PR fix or reference?

Detected while working on fix https://github.com/SAP/xsk/issues/1585