### PR TITLE
yakov/fix-mail-auth

### DIFF
--- a/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/MailClient.java
+++ b/api/api-facade/api-mail/src/main/java/org/eclipse/dirigible/api/v3/mail/MailClient.java
@@ -83,9 +83,11 @@ public class MailClient {
 
 			transport.connect(socket);
 		} else {
-			transport.connect();
+			transport.connect(
+				this.properties.getProperty(MAIL_USER),
+				this.properties.getProperty(MAIL_PASSWORD)
+			);
 		}
-
 
 		MimeMessage mimeMessage = createMimeMessage(session, from, to, cc, bcc, subject, parts);
 		mimeMessage.saveChanges();


### PR DESCRIPTION
When attempting use `sendinblue` and `twillo` `SMTP-Relay` via `MailClient.send()` when it calls `transport.connect()` and then sends a mail via `transport.sendMessage()` the response is 'Unauthorised', although there is some `PasswordAuthenticator` assigned to the session in `MailClient.getSession()`.
This seemed to resolve itself by calling `transport.connect(user, pass)` and the send mail request was forwarded without any unauthorised responses.