### PR TITLE
Exclude org.json:json

### DIFF
--- a/ext/ext-api/api-redis/pom.xml
+++ b/ext/ext-api/api-redis/pom.xml
@@ -114,7 +114,13 @@
 			<artifactId>jedis</artifactId>
 			<version>${jedis.version}</version>
 			<type>jar</type>
-			<scope>compile</scope>
+			<scope>compile</scope>         
+			<exclusions>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions> 
 		</dependency>
 		<!-- / Redis dependencies -->
 


### PR DESCRIPTION
This PR excludes the `org.json:json` library from the build. This library is distributed under the JSON license which includes field of use restrictions that are not compatible with the project license.

The tests all pass with this exclusion, but I am not familiar enough with the project to understand if removing this library will result in any runtime failures.