### PR TITLE
feat: support absolute path imports from projects root

### DIFF
--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/GraalJSFileSystem.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/GraalJSFileSystem.java
@@ -39,6 +39,7 @@ public class GraalJSFileSystem implements FileSystem {
      */
     private Path currentWorkingDirectoryPath;
 
+
     /**
      * The module resolvers.
      */
@@ -126,6 +127,10 @@ public class GraalJSFileSystem implements FileSystem {
      */
     @Override
     public Path toRealPath(Path path, LinkOption... linkOptions) throws IOException {
+        if (path.isAbsolute() && !path.startsWith(currentWorkingDirectoryPath)) {
+            path = currentWorkingDirectoryPath.resolve(path.toString().substring(1));
+        }
+
         String pathString = path.toString();
         if (!pathString.endsWith(".js")
                 && !pathString.endsWith(".mjs")


### PR DESCRIPTION
Adds support for importing ESM modules from other projects:
```JS
import { someExportedMember } from "/project-name/module-name.mjs"
```

Is it according to the specification?

> The module specifier provides a string that the JavaScript environment can resolve to a path to the module file. In a browser, this could be a path relative to the site root, which for our basic-modules example would be /js-examples/module-examples/basic-modules. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules

In our case, the root is the public registry directory.

