### PR TITLE
[Templates] Add Support for Contributing Details Entity

### DIFF
--- a/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/generateUtils.js
+++ b/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/generateUtils.js
@@ -16,12 +16,18 @@ exports.generateFiles = function (model, parameters, templateSources) {
     let generatedFiles = [];
 
     let feedModels = model.entities.filter(e => e.feedUrl);
+
+    // Basic
     let uiManageModels = model.entities.filter(e => e.layoutType === "MANAGE" && e.type === "PRIMARY");
     let uiListModels = model.entities.filter(e => e.layoutType === "LIST" && e.type === "PRIMARY");
+
+    // Master-Details
     let uiManageMasterModels = model.entities.filter(e => e.layoutType === "MANAGE_MASTER" && e.type === "PRIMARY");
     let uiListMasterModels = model.entities.filter(e => e.layoutType === "LIST_MASTER" && e.type === "PRIMARY");
     let uiManageDetailsModels = model.entities.filter(e => e.layoutType === "MANAGE_DETAILS" && e.type === "DEPENDENT");
     let uiListDetailsModels = model.entities.filter(e => e.layoutType === "LIST_DETAILS" && e.type === "DEPENDENT");
+
+    // Reports
     let uiReportTableModels = model.entities.filter(e => e.layoutType === "REPORT_TABLE" && e.type === "REPORT");
     let uiReportBarsModels = model.entities.filter(e => e.layoutType === "REPORT_BAR" && e.type === "REPORT");
     let uiReportLinesModels = model.entities.filter(e => e.layoutType === "REPORT_LINE" && e.type === "REPORT");

--- a/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
+++ b/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
@@ -14,9 +14,19 @@ exports.process = function (model, parameters) {
         if (e.dataCount && parameters.tablePrefix) {
             e.dataCount = e.dataCount.replaceAll("${tablePrefix}", parameters.tablePrefix);
         }
-        if (e.referencedProjectionProjectName && e.referencedProjectionPerspectiveName) {
-            e.hasReferencedProjection = true;
+
+        if (e.type === "DEPENDENT" && (e.layoutType === "LIST_DETAILS" || e.layoutType === "MANAGE_DETAILS")) {
+            const relationshipEntityName = e.properties.filter(p => p.relationshipType === "COMPOSITION" && p.relationshipCardinality === "1_n").map(p => p.relationshipEntityName)[0];
+            if (relationshipEntityName) {
+                const projectionEntity = model.entities.filter(entity => entity.name === relationshipEntityName && entity.type === "PROJECTION")[0];
+                if (projectionEntity) {
+                    e.hasReferencedProjection = true;
+                    e.referencedProjectionProjectName = projectionEntity.projectionReferencedModel.split('/')[2];
+                    e.referencedProjectionPerspectiveName = projectionEntity.perspectiveName;
+                }
+            }
         }
+
         e.properties.forEach(p => {
             p.dataNotNull = p.dataNullable === "false";
             p.dataAutoIncrement = p.dataAutoIncrement === "true";

--- a/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
+++ b/components/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
@@ -14,6 +14,9 @@ exports.process = function (model, parameters) {
         if (e.dataCount && parameters.tablePrefix) {
             e.dataCount = e.dataCount.replaceAll("${tablePrefix}", parameters.tablePrefix);
         }
+        if (e.referencedProjectionProjectName && e.referencedProjectionPerspectiveName) {
+            e.hasReferencedProjection = true;
+        }
         e.properties.forEach(p => {
             p.dataNotNull = p.dataNullable === "false";
             p.dataAutoIncrement = p.dataAutoIncrement === "true";

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsList.js
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsList.js
@@ -26,12 +26,12 @@ function getMaster(parameters) {
             rename: "gen/ui/{{perspectiveName}}/perspective.extension",
             collection: "uiListMasterModels"
         },
-		{
-			location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
-			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
-			collection: "uiListMasterModels"
-		},
+        {
+            location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
+            action: "generate",
+            rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+            collection: "uiListMasterModels"
+        },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective.js",
             action: "generate",
@@ -130,6 +130,7 @@ function getDetails(parameters) {
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/view.extension",
             action: "generate",
+            engine: "velocity",
             rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
             collection: "uiListDetailsModels"
         },
@@ -156,6 +157,7 @@ function getDetails(parameters) {
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension",
             action: "generate",
+            engine: "velocity",
             rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
             collection: "uiListDetailsModels"
         },

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsManage.js
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsManage.js
@@ -130,6 +130,7 @@ function getDetails(parameters) {
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension",
 			action: "generate",
+			engine: "velocity",
 			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
 			collection: "uiManageDetailsModels"
 		},
@@ -156,6 +157,7 @@ function getDetails(parameters) {
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension",
 			action: "generate",
+			engine: "velocity",
 			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
 			collection: "uiManageDetailsModels"
 		},

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.extension
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.extension
@@ -1,1 +1,5 @@
-{"module":"${projectName}/gen/ui/launchpad/Home/view.js","extensionPoint":"${projectName}-view","description":"${projectName} - Application View"}
+{
+    "module": "${projectName}/gen/ui/launchpad/Home/view.js",
+    "extensionPoint": "${projectName}-view",
+    "description": "${projectName} - Application View"
+}

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.js
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.js
@@ -9,6 +9,7 @@ const viewData = {
     factory: "frame",
     region: "center",
     link: "/services/web/${projectName}/gen/ui/launchpad/Home/index.html",
+    isLaunchpad: true,
 };
 
 if (typeof exports !== 'undefined') {

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/index.html
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/index.html
@@ -47,9 +47,12 @@
                     dialogWindows: "${projectName}-dialog-window"
                 })
                 .controller('ApplicationController', ["$scope", "messageHub", function ($scope, messageHub) {
+                    const httpRequest = new XMLHttpRequest();
+                    httpRequest.open("GET", "/services/js/resources-core/services/views.js?extensionPoint=${projectName}-view", false);
+                    httpRequest.send();
 
                     $scope.layoutModel = {
-                        views: [#foreach ($view in $perspectiveViews)'${view}'#if($foreach.hasNext), #end#end]
+                        views: JSON.parse(httpRequest.responseText).filter(e => !e.isLaunchpad).map(e => e.id)
                     };
 
                 }]);

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
@@ -16,13 +16,13 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		resetPagination();
 
 		//-----------------Events-------------------//
-		messageHub.onDidReceiveMessage("${projectName}.${perspectiveName}.${masterEntity}.entitySelected", function (msg) {
+		messageHub.onDidReceiveMessage("#if($hasReferencedProjection)${referencedProjectionProjectName}.${referencedProjectionPerspectiveName}#else${projectName}.${perspectiveName}#end.${masterEntity}.entitySelected", function (msg) {
 			resetPagination();
 			$scope.selectedMainEntityId = msg.data.selectedMainEntityId;
 			$scope.loadPage($scope.dataPage);
 		}, true);
 
-		messageHub.onDidReceiveMessage("${projectName}.${perspectiveName}.${masterEntity}.clearDetails", function (msg) {
+		messageHub.onDidReceiveMessage("#if($hasReferencedProjection)${referencedProjectionProjectName}.${referencedProjectionPerspectiveName}#else${projectName}.${perspectiveName}#end.${masterEntity}.clearDetails", function (msg) {
 			$scope.$apply(function () {
 				resetPagination();
 				$scope.selectedMainEntityId = null;

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension
@@ -1,1 +1,5 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}
+{
+    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
+    "extensionPoint": "${projectName}-dialog-window",
+    "description": "${projectName} - Application Dialog Window"
+}

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.extension
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.extension
@@ -1,1 +1,5 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Details"}
+{
+    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
+    "extensionPoint": "${projectName}-view",
+    "description": "${projectName} - Application View - Details"
+}

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
@@ -16,13 +16,13 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		resetPagination();
 
 		//-----------------Events-------------------//
-		messageHub.onDidReceiveMessage("${projectName}.${perspectiveName}.${masterEntity}.entitySelected", function (msg) {
+		messageHub.onDidReceiveMessage("#if($hasReferencedProjection)${referencedProjectionProjectName}.${referencedProjectionPerspectiveName}#else${projectName}.${perspectiveName}#end.${masterEntity}.entitySelected", function (msg) {
 			resetPagination();
 			$scope.selectedMainEntityId = msg.data.selectedMainEntityId;
 			$scope.loadPage($scope.dataPage);
 		}, true);
 
-		messageHub.onDidReceiveMessage("${projectName}.${perspectiveName}.${masterEntity}.clearDetails", function (msg) {
+		messageHub.onDidReceiveMessage("#if($hasReferencedProjection)${referencedProjectionProjectName}.${referencedProjectionPerspectiveName}#else${projectName}.${perspectiveName}#end.${masterEntity}.clearDetails", function (msg) {
 			$scope.$apply(function () {
 				resetPagination();
 				$scope.selectedMainEntityId = null;

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension
@@ -1,1 +1,5 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}
+{
+    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
+    "extensionPoint": "#if($hasReferencedProjection)${referencedProjectionProjectName}#else${projectName}#end-dialog-window",
+    "description": "${projectName} - Application Dialog Window"
+}

--- a/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension
+++ b/components/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension
@@ -1,1 +1,5 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Details"}
+{
+    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
+    "extensionPoint": "#if($hasReferencedProjection)${referencedProjectionProjectName}#else${projectName}#end-view",
+    "description": "${projectName} - Application View - Details"
+}


### PR DESCRIPTION
Fixes:
- #2816

New fields to be added in the `*.model` file per entity:
- `referencedProjectionProjectName` - the project name of the referenced entity
- `referencedProjectionPerspectiveName` - the name of the perspective, which contains the referenced entity

```json
{
    "model": {
        "entities": [
            {
                "properties": [
                   ...
                ],
                "layoutType": "MANAGE_DETAILS",
                "type": "DEPENDENT",
                "referencedProjectionProjectName": "main",
                "referencedProjectionPerspectiveName": "entities"
            }
        ]
    }
}
```

**Note:** In the sample the project that's being extended is `main` and the perspective, which contains the entity that's being extended is `entities`.