### PR TITLE
#2820 - Selecting a CSV file start "download" instead of "preview"

### DIFF
--- a/components/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
+++ b/components/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
@@ -163,10 +163,12 @@
                     </fd-scrollbar>
                 </split-pane>
                 <split-pane size="50">
-                    <iframe id="preview-iframe" ng-show="selectedFile" src="about:blank"></iframe>
-                    <fd-message-page ng-if="!selectedFile" glyph="sap-icon--detail-view">
+                    <iframe id="preview-iframe" ng-show="selectedFile && canPreview" src="about:blank"></iframe>
+                    <fd-message-page ng-if="!selectedFile || !canPreview" glyph="sap-icon--detail-view">
                         <fd-message-page-title>File Preview</fd-message-page-title>
-                        <fd-message-page-subtitle>Click on a file to see its preview</fd-message-page-subtitle>
+                        <fd-message-page-subtitle>
+                            {{ canPreview ? "Click on a file to see its preview" : "This file cannot be previewed" }}
+                        </fd-message-page-subtitle>
                     </fd-message-page>
                 </split-pane>
             </split>

--- a/components/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/js/controllers.js
+++ b/components/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/js/controllers.js
@@ -45,6 +45,7 @@ documentsApp.controller('DocServiceCtrl', ['$scope', '$http', '$timeout', '$elem
 	let iframe;
 	const getIFrame = () => iframe || (iframe = $element.find('#preview-iframe')[0]);
 
+	$scope.canPreview = true;
 	$scope.downloadPath = '/services/js/ide-documents/api/documents.js/download'
 	$scope.previewPath = '/services/js/ide-documents/api/documents.js/preview';
 	$scope.downloadZipPath = zipApi;
@@ -298,6 +299,51 @@ documentsApp.controller('DocServiceCtrl', ['$scope', '$http', '$timeout', '$elem
 		);
 	};
 
+	$scope.canPreviewFile = function (fileName) {
+		let type = fileName.substring(fileName.lastIndexOf('.') + 1);
+		switch (type) {
+			case 'edm':
+			case 'dsm':
+			case 'bpmn':
+			case 'job':
+			case 'xsjob':
+			case 'calculationview':
+			case 'websocket':
+			case 'hdi':
+			case 'hdbtable':
+			case 'hdbstructurе':
+			case 'hdbview':
+			case 'hdbtablefunction':
+			case 'hdbprocedure':
+			case 'hdbschema':
+			case 'hdbsynonym':
+			case 'hdbdd':
+			case 'hdbsequence':
+			case 'hdbcalculationview':
+			case 'xsaccess':
+			case 'xsprivileges':
+			case 'xshttpdest':
+			case 'listener':
+			case 'extensionpoint':
+			case 'extension':
+			case 'table':
+			case 'view':
+			case 'access':
+			case 'roles':
+			case 'sh':
+			case 'csv':
+			case 'csvim':
+			case 'hdbti':
+			case 'camel':
+			case 'form':
+				$scope.canPreview = false;
+				return false;
+			default:
+				$scope.canPreview = true;
+				return true;
+		}
+	};
+
 	messageHub.onDidReceiveMessage(
 		'ide-documents.documents.delete',
 		function (msg) {
@@ -362,11 +408,14 @@ documentsApp.controller('DocServiceCtrl', ['$scope', '$http', '$timeout', '$elem
 	};
 
 	function setSelectedFile(selectedFile) {
-		$scope.selectedFile = selectedFile;
+		if (selectedFile === null) $scope.selectedFile = selectedFile;
+		else if ($scope.canPreviewFile(selectedFile.name)) {
+			$scope.selectedFile = selectedFile;
 
-		const iframe = getIFrame();
-		if (iframe) {
-			iframe.contentWindow.location.replace($scope.getFilePreviewUrl($scope.selectedFile));
+			const iframe = getIFrame();
+			if (iframe) {
+				iframe.contentWindow.location.replace($scope.getFilePreviewUrl($scope.selectedFile));
+			}
 		}
 	};
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Introduces a function in the document perspective preview, that checks if the selected file type can be previewed and warns the user.

### What issues does this PR fix or reference?

#2820 
