### PR TITLE
[IDE] #2876 - Move resizing buttons in the top toolbar

### DIFF
--- a/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/css/styles.css
+++ b/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/css/styles.css
@@ -3,10 +3,12 @@
   padding: 0.438rem 0.875rem;
   color: var(--sapButton_Lite_TextColor);
 }
+
 .mx-sidebar-icon:hover {
   cursor: pointer;
   background-color: var(--sapButton_Lite_Hover_Background #ebf5fe);
 }
+
 .outlineContainer {
   background: var(--sapBackgroundColor, #f7f7f7);
   box-sizing: border-box;
@@ -15,6 +17,7 @@
   border-top: none;
   border-right: none;
 }
+
 div.mxPopupMenu {
   background-color: var(--sapList_Background, #fff) !important;
   font-size: var(--sapFontSize, 0.875rem);
@@ -36,17 +39,21 @@ div.mxPopupMenu {
   border-radius: var(--sapElement_BorderCornerRadius, 0.25rem);
   opacity: 1;
 }
+
 table.mxPopupMenu {
   margin-top: 3px;
   margin-bottom: 3px;
 }
+
 tr.mxPopupMenuItem {
   color: var(--sapTextColor, #32363a) !important;
 }
+
 tr.mxPopupMenuItemHover {
   color: var(--sapTextColor, #32363a) !important;
   background-color: var(--sapList_Hover_Background, #f5f5f5);
 }
+
 td.mxPopupMenuItem {
   padding: 0.625rem 0.625rem 0.625rem 0px;
   white-space: nowrap;
@@ -54,11 +61,13 @@ td.mxPopupMenuItem {
   font-weight: 400;
   font-size: var(--sapFontSize, 0.875rem);
 }
+
 td.mxPopupMenuIcon {
   padding: 0.625rem !important;
   color: var(--sapTextColor, #32363a);
   background: transparent;
 }
+
 .dsm-table-icon {
   color: var(--sapTextColor, #32363a);
   margin-right: 0.125rem;
@@ -68,9 +77,22 @@ td.mxPopupMenuIcon {
   width: 1rem;
   height: 1rem;
 }
+
 .dsm-table-spacer {
   display: inline-block;
   width: 1rem;
   height: 1px;
   margin-right: 0.125rem;
+}
+
+@media only screen and (min-width: 853px) {
+  .edmSmallScreen {
+    display: none;
+  }
+}
+
+@media only screen and (max-width: 852px) {
+  .edmBigScreen {
+    display: none;
+  }
 }

--- a/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/css/styles.css
+++ b/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/css/styles.css
@@ -18,6 +18,10 @@
   border-right: none;
 }
 
+.editorContainer {
+  height: calc(100% - var(--fdToolbar_Height, 2.75rem));
+}
+
 div.mxPopupMenu {
   background-color: var(--sapList_Background, #fff) !important;
   font-size: var(--sapFontSize, 0.875rem);

--- a/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
+++ b/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
@@ -120,9 +120,9 @@
                 </fd-button>
             </fd-toolbar-overflow>
         </fd-toolbar>
-        <div class="dg-full-height dg-hbox" ng-show="!state.error && !state.isBusy">
+        <div class="dg-hbox editorContainer" ng-show="!state.error && !state.isBusy">
             <div id="sidebarContainer" class="dg-vbox dg-border-right"></div>
-            <div id="graphContainer" class="dg-full-width"></div>
+            <div id="graphContainer" fd-scrollbar class="dg-full-width"></div>
         </div>
         <div id="outlineContainer" class="outlineContainer" ng-show="!state.error && !state.isBusy"></div>
         <fd-message-page glyph="sap-icon--error" ng-if="state.error">

--- a/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
+++ b/components/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
@@ -43,9 +43,20 @@
             {{state.busyText}}
         </fd-busy-indicator-extended>
         <fd-toolbar id="toolbarContainer" ng-show="!state.error && !state.isBusy">
-            <fd-toolbar-spacer></fd-toolbar-spacer>
+            <fd-button dg-type="transparent" glyph="sap-icon--undo" aria-label="Undo" title="Undo" ng-click="undo()">
+            </fd-button>
+            <fd-button dg-type="transparent" glyph="sap-icon--redo" aria-label="Redo" title="Redo" ng-click="redo()">
+            </fd-button>
+            <fd-toolbar-separator></fd-toolbar-separator>
             <fd-button dg-type="transparent" glyph="sap-icon--save" aria-label="Save" title="Save" ng-click="save()">
             </fd-button>
+            <fd-toolbar-separator></fd-toolbar-separator>
+            <fd-button dg-type="transparent" glyph="sap-icon--copy" aria-label="Copy" title="Copy" ng-click="copy()">
+            </fd-button>
+            <fd-button dg-type="transparent" glyph="sap-icon--paste" aria-label="Paste" title="Paste"
+                ng-click="paste()">
+            </fd-button>
+            <fd-toolbar-spacer></fd-toolbar-spacer>
             <fd-button dg-type="transparent" glyph="sap-icon--list" aria-label="Properties" title="Properties"
                 ng-click="properties()">
             </fd-button>
@@ -58,17 +69,6 @@
                 ng-click="navigation()">
             </fd-button>
             <fd-toolbar-separator></fd-toolbar-separator>
-            <fd-button dg-type="transparent" glyph="sap-icon--copy" aria-label="Copy" title="Copy" ng-click="copy()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--paste" aria-label="Paste" title="Paste"
-                ng-click="paste()">
-            </fd-button>
-            <fd-toolbar-separator></fd-toolbar-separator>
-            <fd-button dg-type="transparent" glyph="sap-icon--undo" aria-label="Undo" title="Undo" ng-click="undo()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--redo" aria-label="Redo" title="Redo" ng-click="redo()">
-            </fd-button>
-            <fd-toolbar-separator></fd-toolbar-separator>
             <fd-button dg-type="transparent" glyph="sap-icon--delete" aria-label="Delete" title="Delete"
                 ng-click="delete()">
             </fd-button>
@@ -78,35 +78,53 @@
             <fd-button dg-type="transparent" glyph="sap-icon--print" aria-label="Print" title="Print"
                 ng-click="print()">
             </fd-button>
+            <fd-toolbar-separator></fd-toolbar-separator>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--collapse" aria-label="Collapse all"
+                title="Collapse all" ng-click="collapseAll()">
+            </fd-button>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--expand" aria-label="Expand all"
+                title="Expand all" ng-click="expandAll()">
+            </fd-button>
+            <fd-toolbar-separator class="edmBigScreen"></fd-toolbar-separator>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--zoom-in" aria-label="Zoom in"
+                title="Zoom in" ng-click="zoomIn()">
+            </fd-button>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--zoom-out" aria-label="Zoom out"
+                title="Zoom out" ng-click="zoomOut()">
+            </fd-button>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--search" aria-label="Actual size"
+                title="Actual size" ng-click="actualSize()">
+            </fd-button>
+            <fd-button class="edmBigScreen" dg-type="transparent" glyph="sap-icon--exitfullscreen"
+                aria-label="Fit to screen" title="Fit" ng-click="fit()">
+            </fd-button>
+            <fd-toolbar-overflow class="edmSmallScreen">
+                <fd-button dg-type="transparent" dg-label="Collapse all" glyph="sap-icon--collapse" is-overflow="true"
+                    ng-click="collapseAll()">
+                </fd-button>
+                <fd-button dg-type="transparent" dg-label="Expand all" glyph="sap-icon--expand" is-overflow="true"
+                    ng-click="expandAll()">
+                </fd-button>
+                <fd-toolbar-separator></fd-toolbar-separator>
+                <fd-button dg-type="transparent" dg-label="Zoom in" glyph="sap-icon--zoom-in" is-overflow="true"
+                    ng-click="zoomIn()">
+                </fd-button>
+                <fd-button dg-type="transparent" dg-label="Zoom out" glyph="sap-icon--zoom-out" is-overflow="true"
+                    ng-click="zoomOut()">
+                </fd-button>
+                <fd-button dg-type="transparent" dg-label="Actual size" glyph="sap-icon--search" is-overflow="true"
+                    ng-click="actualSize()">
+                </fd-button>
+                <fd-button dg-type="transparent" dg-label="Fit to screen" glyph="sap-icon--exitfullscreen"
+                    is-overflow="true" ng-click="fit()">
+                </fd-button>
+            </fd-toolbar-overflow>
         </fd-toolbar>
         <div class="dg-full-height dg-hbox" ng-show="!state.error && !state.isBusy">
             <div id="sidebarContainer" class="dg-vbox dg-border-right"></div>
             <div id="graphContainer" class="dg-full-width"></div>
         </div>
         <div id="outlineContainer" class="outlineContainer" ng-show="!state.error && !state.isBusy"></div>
-        <fd-toolbar id="statusContainer" class="dg-border-top" no-bottom-border="true"
-            ng-show="!state.error && !state.isBusy">
-            <fd-toolbar-spacer></fd-toolbar-spacer>
-            <fd-button dg-type="transparent" glyph="sap-icon--collapse" aria-label="Collapse all" title="Collapse all"
-                ng-click="collapseAll()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--expand" aria-label="Expand all" title="Expand all"
-                ng-click="expandAll()">
-            </fd-button>
-            <fd-toolbar-separator></fd-toolbar-separator>
-            <fd-button dg-type="transparent" glyph="sap-icon--zoom-in" aria-label="Zoom in" title="Zoom in"
-                ng-click="zoomIn()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--zoom-out" aria-label="Zoom out" title="Zoom out"
-                ng-click="zoomOut()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--search" aria-label="Actual size" title="Actual size"
-                ng-click="actualSize()">
-            </fd-button>
-            <fd-button dg-type="transparent" glyph="sap-icon--exitfullscreen" aria-label="Fit to screen" title="Fit"
-                ng-click="fit()">
-            </fd-button>
-        </fd-toolbar>
         <fd-message-page glyph="sap-icon--error" ng-if="state.error">
             <fd-message-page-title>Editor encounterd an error!</fd-message-page-title>
             <fd-message-page-subtitle>{{errorMessage}}</fd-message-page-subtitle>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Moves the resizing buttons in  the top toolbar.

Wide screen:
![Screenshot from 2023-10-30 14-02-47](https://github.com/eclipse/dirigible/assets/82379274/be5e6d7a-5fb9-4921-9f78-f5e2fca834ee)

Narrow screen:
![Screenshot from 2023-10-30 14-01-48](https://github.com/eclipse/dirigible/assets/82379274/6858b12f-c74a-4b9b-8fc5-d243a20692b1)

### What issues does this PR fix or reference?

#2876 
