### PR TITLE
feat: initial react support

### DIFF
--- a/components/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/api/extensions/core.js
+++ b/components/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/api/extensions/core.js
@@ -2,8 +2,10 @@ exports.getFileTypes = function () {
     return {
         ".abap": "abap",
         ".js": "javascript",
+        ".jsx": "javascript",
         ".mjs": "javascript",
         ".ts": "typescript",
+        ".tsx": "typescript",
         ".html": "html",
         ".css": "css",
         ".json": "json",

--- a/components/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
+++ b/components/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
@@ -1002,8 +1002,10 @@ function isDirty(model) {
             noFallthroughCasesInSwitch: true,
             module: (fileName?.endsWith(".mjs") === true) ? monaco.languages.typescript.ModuleKind.ESNext : monaco.languages.typescript.ModuleKind.CommonJS
         });
-        monaco.languages.typescript.javascriptDefaults.getCompilerOptions().moduleResolution = monaco.languages.typescript.ModuleResolutionKind.NodeJs
-        monaco.languages.typescript.typescriptDefaults.getCompilerOptions().moduleResolution = monaco.languages.typescript.ModuleResolutionKind.NodeJs
+        monaco.languages.typescript.javascriptDefaults.getCompilerOptions().moduleResolution = monaco.languages.typescript.ModuleResolutionKind.NodeJs;
+        monaco.languages.typescript.typescriptDefaults.getCompilerOptions().moduleResolution = monaco.languages.typescript.ModuleResolutionKind.NodeJs;
+        monaco.languages.typescript.typescriptDefaults.getCompilerOptions().jsx = (fileName?.endsWith(".tsx") === true) ? "react" : undefined;
+        monaco.languages.typescript.javascriptDefaults.getCompilerOptions().jsx = (fileName?.endsWith(".jsx") === true) ? "react" : undefined,
 
         monaco.languages.html.registerHTMLLanguageService('xml', {}, { documentFormattingEdits: true });
         monaco.languages.html.htmlDefaults.setOptions({


### PR DESCRIPTION
Example Dirigible project setup:

1. Create some project
2. Add `index.tsx`:
``` TypeScript
import React from "https://esm.sh/react@18.2.0";
import ReactDOM from "https://esm.sh/react-dom@18.2.0";

function App() {
  return (
    <div>Hello, React!!! </div>
  );
}

ReactDOM.render(<App />, document.getElementById("root"));
```
3. Add `project.json`:
``` JSON
{
    "guid": "some_project_id",
    "actions": [
        {
            "name": "Build",
            "command": "esbuild index.tsx --bundle --outfile=public/index.js --loader:.js=jsx --format=esm",
            "publish": "true"
        }
    ]
}
```

4. Add folder `public`
5. Add file `public/index.html`:
``` HTML
<!DOCTYPE html>
<html>

    <head>
        <meta charset="UTF-8" />
        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
        <title>Hello, React!</title>
    </head>

    <body>
        <div id="root"></div>
        <script src="index.js" type="module"></script>
    </body>

</html>

```