### PR TITLE
fix: decorators module rename and default exports, fix rs arrow function args

### DIFF
--- a/components/api/api-modules-javascript/pom.xml
+++ b/components/api/api-modules-javascript/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -51,7 +51,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>${basedir}/src/main/resources/META-INF/dirigible/modules/build${script.extension}</executable>
+                    <executable>${basedir}/src/main/resources/META-INF/dirigible/modules/build${script.extension}
+                    </executable>
                     <workingDirectory>src/main/resources/META-INF/dirigible/modules</workingDirectory>
                 </configuration>
             </plugin>

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/build-source.sh
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/build-source.sh
@@ -1,3 +1,6 @@
+# fail the whole script if any command bellow fails
+set -e
+
 # clean
 rm -rf ./dist
 

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/decorators.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/decorators.ts
@@ -15,7 +15,7 @@ import * as rs from "@dirigible/http/rs"
 const router = rs.service();
 let instance = null;
 
-export function Controller(ctr) {
+export function Controller(ctr: {new()}, context: ClassDecoratorContext): void {
     instance = new ctr();
     router.execute();
 }
@@ -29,7 +29,7 @@ export const Head = createRequestDecorator("head")
 export const Options = createRequestDecorator("options")
 
 function createRequestDecorator(httpMethod) {
-    return function (path) {
+    return function (path: string): any {
         return function (target, propertyKey, descriptor) {
             const handler = descriptor ? descriptor.value : target;
             router[httpMethod](

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/index.ts
@@ -1,8 +1,9 @@
 export * as client from "./client";
 export * as asyncClient from "./client-async";
-export * as controller from "./controller";
 export * as rs from "./rs";
 export * as upload from "./upload";
 export * as request from "./request";
 export * as response from "./response";
 export * as session from "./session";
+export * as decorators from "./decorators";
+export * from "./decorators";

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/rs/resource-http-controller.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/http/rs/resource-http-controller.ts
@@ -53,13 +53,14 @@ export class HttpController {
 
         //weave-in HTTP method-based factory functions - shortcut for service().resource(sPath).method
         ['get', 'post', 'put', 'delete', 'remove', 'method'].forEach((sMethodName) => {
-            this[sMethodName] = (sPath, sVerb, arrConsumes, arrProduces) => {
-                if (arguments.length < 1)
+            this[sMethodName] = (sPath, sVerb, arrConsumes, arrProduces, ...args) => {
+                const allArguments = [sPath, sVerb, arrConsumes, arrProduces, ...args];
+                if (allArguments.length < 1)
                     throw Error('Insufficient arguments provided to HttpController method ' + sMethodName + '.');
                 if (sPath === undefined)
                     sPath = "";
                 const resource = this.resourceMappings.find(sPath, sVerb, arrConsumes, arrProduces) || this.resourceMappings.resource(sPath);
-                resource[sMethodName]['apply'](resource, Array.prototype.slice.call(arguments, 1));
+                resource[sMethodName]['apply'](resource, Array.prototype.slice.call(allArguments, 1));
                 return this;
             };
         });


### PR DESCRIPTION
The following should work in both ESM and TS files:
``` TypeScript
import { Controller, Get, Post } from "@dirigible/http"
// or if you use the CJS modules support
// const { Controller, Get, Post } = require("http/v4/rs/decorators");

@Controller
class MyApi {

    @Get("/")
    onGet() {
        return "Hello there!";
    }

    @Post("/")
    onPost(body) {
        return {
            some: "data"
        }
    }
}
```