### PR TITLE
improve jobhandler error logging

### DIFF
--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobHandler.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobHandler.java
@@ -63,7 +63,7 @@ public class JobHandler implements Job {
                 runner.run(handlerPath);
             } catch (RuntimeException ex) {
                 registeredFailed(name, handler, triggered, ex);
-                String msg = "Failed to execute JS. Job name [" + name + "], handler[" + handler + "]";
+                String msg = "Failed to execute JS. Job name [" + name + "], handler [" + handler + "]";
                 logger.error(msg, ex);
                 throw new JobExecutionException(msg, ex);
             }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobHandler.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobHandler.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.dirigible.components.jobs.handler;
 
+import java.nio.file.Path;
+import java.util.Date;
 import org.eclipse.dirigible.components.jobs.domain.JobLog;
 import org.eclipse.dirigible.components.jobs.service.JobLogService;
 import org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner;
@@ -19,9 +21,6 @@ import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.nio.file.Path;
-import java.util.Date;
 
 /**
  * The built-in scripting service job handler.
@@ -62,9 +61,11 @@ public class JobHandler implements Job {
 
             try (DirigibleJavascriptCodeRunner runner = new DirigibleJavascriptCodeRunner()) {
                 runner.run(handlerPath);
-            } catch (Exception e) {
-                registeredFailed(name, handler, triggered, e);
-                throw new JobExecutionException(e);
+            } catch (RuntimeException ex) {
+                registeredFailed(name, handler, triggered, ex);
+                String msg = "Failed to execute JS. Job name [" + name + "], handler[" + handler + "]";
+                logger.error(msg, ex);
+                throw new JobExecutionException(msg, ex);
             }
 
             registeredFinished(name, handler, triggered);


### PR DESCRIPTION
```
2023-12-05 14:30:00.145 [ERROR] [schedulerFactoryBean_Worker-2] o.e.d.c.jobs.handler.JobHandler - Failed to execute JS. Job name [synchronize], handler[ide-documents/security/synchronize.js]
org.graalvm.polyglot.PolyglotException: TypeError: cmis.getSession is not a function
	at <js>.:anonymous(ide-documents/utils/cmis/object:13) ~[na:na]
	at <js>.:anonymous(ide-documents/utils/cmis/document:14) ~[na:na]
	at <js>.:anonymous(ide-documents/api/processors/constraintsProcessor:13) ~[na:na]
	at <js>.:module:eval(synchronize.js:12) ~[na:na]
	at org.graalvm.polyglot.Context.eval(Context.java:402) ~[polyglot-23.1.1.jar:na]
	at org.eclipse.dirigible.graalium.core.javascript.GraalJSCodeRunner.run(GraalJSCodeRunner.java:149) ~[classes/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.run(DirigibleJavascriptCodeRunner.java:160) ~[classes/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.run(DirigibleJavascriptCodeRunner.java:174) ~[classes/:na]
	at org.eclipse.dirigible.components.jobs.handler.JobHandler.execute(JobHandler.java:63) ~[classes/:na]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) ~[quartz-2.3.2.jar:na]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) ~[quartz-2.3.2.jar:na]
```