### PR TITLE
feat: Add integration tests for Camel PlatformHTTP and @dirigible/integrations API

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
@@ -1,7 +1,7 @@
 const SpringBeanProvider = Java.type("org.eclipse.dirigible.components.spring.SpringBeanProvider");
 const Invoker = Java.type('org.eclipse.dirigible.components.engine.camel.invoke.Invoker');
 const invoker = SpringBeanProvider.getBean(Invoker.class);
-const String = Java.type('java.lang.String');
+const CamelMessage = Java.type('org.apache.camel.Message');
 
 export function invokeRoute(routeId, payload, headers) {
     return invoker.invokeRoute(routeId, payload, headers);
@@ -11,53 +11,27 @@ export function getInvokingRouteMessage() {
     return __context.camelMessage;
 }
 
-// Define an interface for the headers
-export interface Headers {
-    [key: string]: any;
+export interface HeadersMap {
+    [key: string]: string | string[];
 }
 
-// Wrapper class for Camel Message
-export class IntegrationMessage {
-    private message: any; // Replace 'any' with the actual type of Camel Message
+export interface IntegrationMessage {
 
-    constructor(message: any) {
-        this.message = message;
-    }
+    constructor(message: any);
 
-    // Get the body of the message
-    getBody(): String {
-        return this.message.getBody(String.class);
-    }
+    getBody(): any;
 
-    // Set the body of the message
-    setBody(body: String): void {
-        this.message.setBody(body);
-    }
+    getBodyAsString(): string;
 
-    // Get headers of the message
-    getHeaders(): Headers {
-        const headers: Headers = {};
-        const headerNames = this.message.getHeaders().keySet().toArray();
-        for (const headerName of headerNames) {
-            headers[headerName] = this.message.getHeader(headerName);
-        }
-        return headers;
-    }
+    setBody(body: any): void;
 
-    // Set headers of the message
-    setHeaders(headers: Headers): void {
-        for (const [key, value] of Object.entries(headers)) {
-            this.message.setHeader(key, value);
-        }
-    }
+    getHeaders(): HeadersMap;
 
-    // Set header of the message
-    setHeader(key: String, value: any): void {
-        this.message.setHeader(key, value);
-    }
+    getHeader(key: string): string | string[];
 
-    // Returns the original camel message
-    getCamelMessage(): any {
-        return this.message;
-    }
+    setHeaders(headers: HeadersMap): void;
+
+    setHeader(key: string, value: string | string[]): void;
+
+    getCamelMessage(): typeof CamelMessage;
 }

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
@@ -10,3 +10,28 @@ export function invokeRoute(routeId, payload, headers) {
 export function getInvokingRouteMessage() {
     return __context.camelMessage;
 }
+
+export interface HeadersMap {
+    [key: string]: string | string[];
+}
+
+export interface IntegrationMessage {
+
+    constructor(message: any);
+
+    getBody(): any;
+
+    getBodyAsString(): string;
+
+    setBody(body: any): void;
+
+    getHeaders(): HeadersMap;
+
+    getHeader(key: string): string | string[];
+
+    setHeaders(headers: HeadersMap): void;
+
+    setHeader(key: string, value: string | string[]): void;
+
+    getCamelMessage(): typeof CamelMessage;
+}

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
@@ -1,6 +1,7 @@
 const SpringBeanProvider = Java.type("org.eclipse.dirigible.components.spring.SpringBeanProvider");
 const Invoker = Java.type('org.eclipse.dirigible.components.engine.camel.invoke.Invoker');
 const invoker = SpringBeanProvider.getBean(Invoker.class);
+const String = Java.type('java.lang.String');
 
 export function invokeRoute(routeId, payload, headers) {
     return invoker.invokeRoute(routeId, payload, headers);
@@ -8,4 +9,55 @@ export function invokeRoute(routeId, payload, headers) {
 
 export function getInvokingRouteMessage() {
     return __context.camelMessage;
+}
+
+// Define an interface for the headers
+export interface Headers {
+    [key: string]: any;
+}
+
+// Wrapper class for Camel Message
+export class IntegrationMessage {
+    private message: any; // Replace 'any' with the actual type of Camel Message
+
+    constructor(message: any) {
+        this.message = message;
+    }
+
+    // Get the body of the message
+    getBody(): String {
+        return this.message.getBody(String.class);
+    }
+
+    // Set the body of the message
+    setBody(body: String): void {
+        this.message.setBody(body);
+    }
+
+    // Get headers of the message
+    getHeaders(): Headers {
+        const headers: Headers = {};
+        const headerNames = this.message.getHeaders().keySet().toArray();
+        for (const headerName of headerNames) {
+            headers[headerName] = this.message.getHeader(headerName);
+        }
+        return headers;
+    }
+
+    // Set headers of the message
+    setHeaders(headers: Headers): void {
+        for (const [key, value] of Object.entries(headers)) {
+            this.message.setHeader(key, value);
+        }
+    }
+
+    // Set header of the message
+    setHeader(key: String, value: any): void {
+        this.message.setHeader(key, value);
+    }
+
+    // Returns the original camel message
+    getCamelMessage(): any {
+        return this.message;
+    }
 }

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/integrations/index.ts
@@ -10,28 +10,3 @@ export function invokeRoute(routeId, payload, headers) {
 export function getInvokingRouteMessage() {
     return __context.camelMessage;
 }
-
-export interface HeadersMap {
-    [key: string]: string | string[];
-}
-
-export interface IntegrationMessage {
-
-    constructor(message: any);
-
-    getBody(): any;
-
-    getBodyAsString(): string;
-
-    setBody(body: any): void;
-
-    getHeaders(): HeadersMap;
-
-    getHeader(key: string): string | string[];
-
-    setHeaders(headers: HeadersMap): void;
-
-    setHeader(key: string, value: string | string[]): void;
-
-    getCamelMessage(): typeof CamelMessage;
-}

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceLifecycleListener.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceLifecycleListener.java
@@ -13,9 +13,10 @@ package org.eclipse.dirigible.components.data.sources.service;
 import org.eclipse.dirigible.components.data.sources.domain.DataSource;
 
 /**
- * The listener interface for receiving dataSourceLifecycle events. The class that is interested in processing a dataSourceLifecycle event
- * implements this interface, and the object created with that class is registered with a component using the component's
- * addDataSourceLifecycleListener method. When the dataSourceLifecycle event occurs, that object's appropriate method is invoked.
+ * The listener interface for receiving dataSourceLifecycle events. The class that is interested in
+ * processing a dataSourceLifecycle event implements this interface, and the object created with
+ * that class is registered with a component using the component's addDataSourceLifecycleListener
+ * method. When the dataSourceLifecycle event occurs, that object's appropriate method is invoked.
  */
 public interface DataSourceLifecycleListener {
 

--- a/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceLifecycleListener.java
+++ b/components/data/data-sources/src/main/java/org/eclipse/dirigible/components/data/sources/service/DataSourceLifecycleListener.java
@@ -13,11 +13,9 @@ package org.eclipse.dirigible.components.data.sources.service;
 import org.eclipse.dirigible.components.data.sources.domain.DataSource;
 
 /**
- * The listener interface for receiving dataSourceLifecycle events. The class that is interested in
- * processing a dataSourceLifecycle event implements this interface, and the object created with
- * that class is registered with a component using the component's addDataSourceLifecycleListener
- * method. When the dataSourceLifecycle event occurs, that object's appropriate method is invoked.
- *
+ * The listener interface for receiving dataSourceLifecycle events. The class that is interested in processing a dataSourceLifecycle event
+ * implements this interface, and the object created with that class is registered with a component using the component's
+ * addDataSourceLifecycleListener method. When the dataSourceLifecycle event occurs, that object's appropriate method is invoked.
  */
 public interface DataSourceLifecycleListener {
 

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/IntegrationMessage.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/IntegrationMessage.java
@@ -1,0 +1,41 @@
+package org.eclipse.dirigible.components.engine.camel.invoke;
+
+import org.apache.camel.Message;
+
+import java.util.Map;
+
+public class IntegrationMessage {
+    private final Message message;
+
+    public IntegrationMessage(Message message) {
+        this.message = message;
+    }
+
+    public String getBodyAsString() {
+        return message.getBody(String.class);
+    }
+
+    public Object getBody() {
+        return message.getBody();
+    }
+
+    public void setBody(Object body) {
+        message.setBody(body);
+    }
+
+    public Map<String, Object> getHeaders() {
+        return message.getHeaders();
+    }
+
+    public void setHeaders(Map<String, Object> headers) {
+        message.setHeaders(headers);
+    }
+
+    public void setHeader(String key, Object value) {
+        message.setHeader(key, value);
+    }
+
+    public Message getCamelMessage() {
+        return message;
+    }
+}

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -37,12 +37,13 @@ public class Invoker {
     public void invoke(Message camelMessage) throws IOException {
         resetCodeRunner();
         String resourcePath = (String) camelMessage.getExchange()
-                .getProperty("resource");
+                                                   .getProperty("resource");
 
         var module = runner.run(Path.of(resourcePath));
         var result = runner.runMethod(module, "onMessage", wrapCamelMessage(camelMessage));
 
-        camelMessage.getExchange().setMessage(unwrapCamelMessage(result));
+        camelMessage.getExchange()
+                    .setMessage(unwrapCamelMessage(result));
     }
 
     private IntegrationMessage wrapCamelMessage(Message camelMessage) {
@@ -51,22 +52,20 @@ public class Invoker {
 
     private Message unwrapCamelMessage(Value value) {
         if (value == null || !value.isHostObject()) {
-            throw new IllegalStateException("Unexpected null value or return type received from " +
-                    "@dirigible/integrations::onMessage(). " +
-                    "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
+            throw new IllegalStateException("Unexpected null value or return type received from " + "@dirigible/integrations::onMessage(). "
+                    + "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
         }
 
         Object hostObject = value.asHostObject();
 
         if (!(hostObject instanceof IntegrationMessage integrationMessage)) {
-            throw new IllegalArgumentException("Unexpected return type received from " +
-                    "@dirigible/integrations::onMessage(). " +
-                    "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
+            throw new IllegalArgumentException("Unexpected return type received from " + "@dirigible/integrations::onMessage(). "
+                    + "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
         }
 
         if (integrationMessage.getCamelMessage() == null) {
-            throw new IllegalStateException("IntegrationMessage does not contain a valid Camel Message. " +
-                    "Expected a non-null Camel Message.");
+            throw new IllegalStateException(
+                    "IntegrationMessage does not contain a valid Camel Message. " + "Expected a non-null Camel Message.");
         }
 
         return integrationMessage.getCamelMessage();

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -52,12 +52,26 @@ public class Invoker {
     }
 
     private Message unwrapCamelMessage(Value value) {
-        if (value.isHostObject()) {
-            IntegrationMessage integrationMessage = value.asHostObject();
-            return integrationMessage.getCamelMessage();
-        } else {
-            throw new IllegalStateException("Unexpected @dirigible/integrations onMessage() return type");
+        if (value == null || !value.isHostObject()) {
+            throw new IllegalStateException("Unexpected null value or return type received from " +
+                    "@dirigible/integrations::onMessage(). " +
+                    "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
         }
+
+        Object hostObject = value.asHostObject();
+
+        if (!(hostObject instanceof IntegrationMessage integrationMessage)) {
+            throw new IllegalArgumentException("Unexpected return type received from " +
+                    "@dirigible/integrations::onMessage(). " +
+                    "Expected return type: org.eclipse.dirigible.components.engine.camel.invoke.IntegrationMessage");
+        }
+
+        if (integrationMessage.getCamelMessage() == null) {
+            throw new IllegalStateException("IntegrationMessage does not contain a valid Camel Message. " +
+                    "Expected a non-null Camel Message.");
+        }
+
+        return integrationMessage.getCamelMessage();
     }
 
     private void resetCodeRunner() {

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -47,22 +47,35 @@ public class Invoker {
                     .setMessage(unwrapCamelMessage(result));
     }
 
-    private Value wrapCamelMessage(Message camelMessage) {
-        var context = runner.getCodeRunner()
-                            .getGraalContext();
-        context.eval("js", "const IntegrationMessage = require( \"integrations\").IntegrationMessage");
-        context.getBindings("js")
-               .putMember("camelMessage", camelMessage);
-        Value wrappedCamelMessage = context.eval("js", " new IntegrationMessage(camelMessage)");
-        context.getBindings("js")
-               .removeMember("camelMessage");
-        return wrappedCamelMessage;
+    // private Value wrapCamelMessage(Message camelMessage) {
+    // var context = runner.getCodeRunner()
+    // .getGraalContext();
+    // context.eval("js", "const IntegrationMessage = require( \"integrations\").IntegrationMessage");
+    // context.getBindings("js")
+    // .putMember("camelMessage", camelMessage);
+    // Value wrappedCamelMessage = context.eval("js", " new IntegrationMessage(camelMessage)");
+    // context.getBindings("js")
+    // .removeMember("camelMessage");
+    // return wrappedCamelMessage;
+    // }
+    //
+    // private Message unwrapCamelMessage(Value wrappedCamelMessage) {
+    // if (!wrappedCamelMessage.isNull() && wrappedCamelMessage.canInvokeMember("getCamelMessage")) {
+    // return wrappedCamelMessage.invokeMember("getCamelMessage")
+    // .as(Message.class);
+    // } else {
+    // throw new IllegalStateException("Unexpected @dirigible/integrations onMessage() return type");
+    // }
+    // }
+
+    private IntegrationMessage wrapCamelMessage(Message camelMessage) {
+        return new IntegrationMessage(camelMessage);
     }
 
-    private Message unwrapCamelMessage(Value wrappedCamelMessage) {
-        if (!wrappedCamelMessage.isNull() && wrappedCamelMessage.canInvokeMember("getCamelMessage")) {
-            return wrappedCamelMessage.invokeMember("getCamelMessage")
-                                      .as(Message.class);
+    private Message unwrapCamelMessage(Value value) {
+        if (value.isHostObject()) {
+            IntegrationMessage integrationMessage = value.asHostObject();
+            return integrationMessage.getCamelMessage();
         } else {
             throw new IllegalStateException("Unexpected @dirigible/integrations onMessage() return type");
         }

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -11,7 +11,6 @@
 package org.eclipse.dirigible.components.engine.camel.invoke;
 
 import org.apache.camel.Message;
-import org.apache.camel.component.platform.http.springboot.PlatformHttpMessage;
 import org.eclipse.dirigible.components.engine.camel.processor.CamelProcessor;
 import org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner;
 import org.eclipse.dirigible.graalium.core.javascript.CalledFromJS;

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -37,13 +37,12 @@ public class Invoker {
     public void invoke(Message camelMessage) throws IOException {
         resetCodeRunner();
         String resourcePath = (String) camelMessage.getExchange()
-                                                   .getProperty("resource");
+                .getProperty("resource");
 
         var module = runner.run(Path.of(resourcePath));
         var result = runner.runMethod(module, "onMessage", wrapCamelMessage(camelMessage));
 
-        camelMessage.getExchange()
-                    .setMessage(unwrapCamelMessage(result));
+        camelMessage.getExchange().setMessage(unwrapCamelMessage(result));
     }
 
     private IntegrationMessage wrapCamelMessage(Message camelMessage) {

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/invoke/Invoker.java
@@ -47,27 +47,6 @@ public class Invoker {
                     .setMessage(unwrapCamelMessage(result));
     }
 
-    // private Value wrapCamelMessage(Message camelMessage) {
-    // var context = runner.getCodeRunner()
-    // .getGraalContext();
-    // context.eval("js", "const IntegrationMessage = require( \"integrations\").IntegrationMessage");
-    // context.getBindings("js")
-    // .putMember("camelMessage", camelMessage);
-    // Value wrappedCamelMessage = context.eval("js", " new IntegrationMessage(camelMessage)");
-    // context.getBindings("js")
-    // .removeMember("camelMessage");
-    // return wrappedCamelMessage;
-    // }
-    //
-    // private Message unwrapCamelMessage(Value wrappedCamelMessage) {
-    // if (!wrappedCamelMessage.isNull() && wrappedCamelMessage.canInvokeMember("getCamelMessage")) {
-    // return wrappedCamelMessage.invokeMember("getCamelMessage")
-    // .as(Message.class);
-    // } else {
-    // throw new IllegalStateException("Unexpected @dirigible/integrations onMessage() return type");
-    // }
-    // }
-
     private IntegrationMessage wrapCamelMessage(Message camelMessage) {
         return new IntegrationMessage(camelMessage);
     }

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
@@ -14,8 +14,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.FluentProducerTemplate;
-import org.apache.camel.Processor;
-import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.platform.http.springboot.CamelRequestHandlerMapping;
 import org.apache.camel.impl.engine.DefaultRoutesLoader;
 import org.apache.camel.spi.Resource;

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
@@ -56,13 +56,13 @@ public class CamelProcessor {
 
     private void addAllRoutes() {
         camels.values()
-                .forEach(routesResource -> {
-                    try {
-                        loader.loadRoutes(routesResource);
-                    } catch (Exception e) {
-                        throw new CamelProcessorException(e);
-                    }
-                });
+              .forEach(routesResource -> {
+                  try {
+                      loader.loadRoutes(routesResource);
+                  } catch (Exception e) {
+                      throw new CamelProcessorException(e);
+                  }
+              });
     }
 
     private void removeAllRoutes() {
@@ -70,7 +70,7 @@ public class CamelProcessor {
             context.stopAllRoutes();
             context.removeAllRoutes();
             camelRequestHandlerMapping.getHandlerMethods()
-                    .forEach((info, method) -> camelRequestHandlerMapping.unregisterMapping(info));
+                                      .forEach((info, method) -> camelRequestHandlerMapping.unregisterMapping(info));
         } catch (Exception e) {
             throw new CamelProcessorException(e);
         }
@@ -79,9 +79,9 @@ public class CamelProcessor {
     public Object invokeRoute(String routeId, Object payload, Map<String, Object> headers) {
         try (FluentProducerTemplate producer = context.createFluentProducerTemplate()) {
             return producer.withHeaders(headers)
-                    .withBody(payload)
-                    .to(routeId)
-                    .request();
+                           .withBody(payload)
+                           .to(routeId)
+                           .request();
         } catch (IOException e) {
             throw new CamelProcessorException("Could not invoke route: " + routeId, e);
         }

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
@@ -13,6 +13,7 @@ package org.eclipse.dirigible.components.engine.camel.processor;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.apache.camel.FluentProducerTemplate;
 import org.apache.camel.component.platform.http.springboot.CamelRequestHandlerMapping;
 import org.apache.camel.impl.engine.DefaultRoutesLoader;
@@ -23,6 +24,10 @@ import org.apache.camel.support.ResourceHelper;
 import org.eclipse.dirigible.components.engine.camel.domain.Camel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class CamelProcessor {
@@ -55,13 +60,13 @@ public class CamelProcessor {
 
     private void addAllRoutes() {
         camels.values()
-              .forEach(routesResource -> {
-                  try {
-                      loader.loadRoutes(routesResource);
-                  } catch (Exception e) {
-                      throw new CamelProcessorException(e);
-                  }
-              });
+                .forEach(routesResource -> {
+                    try {
+                        loader.loadRoutes(routesResource);
+                    } catch (Exception e) {
+                        throw new CamelProcessorException(e);
+                    }
+                });
     }
 
     private void removeAllRoutes() {
@@ -69,7 +74,7 @@ public class CamelProcessor {
             context.stopAllRoutes();
             context.removeAllRoutes();
             camelRequestHandlerMapping.getHandlerMethods()
-                                      .forEach((info, method) -> camelRequestHandlerMapping.unregisterMapping(info));
+                    .forEach((info, method) -> camelRequestHandlerMapping.unregisterMapping(info));
         } catch (Exception e) {
             throw new CamelProcessorException(e);
         }
@@ -78,9 +83,9 @@ public class CamelProcessor {
     public Object invokeRoute(String routeId, Object payload, Map<String, Object> headers) {
         try (FluentProducerTemplate producer = context.createFluentProducerTemplate()) {
             return producer.withHeaders(headers)
-                           .withBody(payload)
-                           .to(routeId)
-                           .request();
+                    .withBody(payload)
+                    .to(routeId)
+                    .request();
         } catch (IOException e) {
             throw new CamelProcessorException("Could not invoke route: " + routeId, e);
         }

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.camel.FluentProducerTemplate;
+import org.apache.camel.Processor;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.platform.http.springboot.CamelRequestHandlerMapping;
 import org.apache.camel.impl.engine.DefaultRoutesLoader;
 import org.apache.camel.spi.Resource;
@@ -76,7 +78,7 @@ public class CamelProcessor {
     }
 
     public Object invokeRoute(String routeId, Object payload, Map<String, Object> headers) {
-        try (FluentProducerTemplate producer = context.createFluentProducerTemplate();) {
+        try (FluentProducerTemplate producer = context.createFluentProducerTemplate()) {
             return producer.withHeaders(headers)
                            .withBody(payload)
                            .to(routeId)

--- a/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
+++ b/components/engine/engine-camel/src/main/java/org/eclipse/dirigible/components/engine/camel/processor/CamelProcessor.java
@@ -25,10 +25,6 @@ import org.eclipse.dirigible.components.engine.camel.domain.Camel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
 @Component
 public class CamelProcessor {
     private final SpringBootCamelContext context;

--- a/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
+++ b/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible
+ * contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.services.integrations;
+
+import org.eclipse.dirigible.integration.tests.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class CamelPlatformHttpTest extends IntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // Test an HTTP/POST request towards a camel platform http route.
+    // The route sends the request towards a dirigible js file
+    // which responds by appending to the inbound message.
+    @Test
+    void postToJsTest() throws Exception {
+        String requestBody = "initial message";
+
+        String actualResponseBody = mockMvc.perform(MockMvcRequestBuilders.post("/services/integrations/camelTest")
+                                                                          .content(requestBody)
+                                                                          .contentType(MediaType.APPLICATION_JSON)
+                                                                          .accept(MediaType.APPLICATION_JSON))
+                                           .andExpect(status().isOk())
+                                           .andReturn()
+                                           .getResponse()
+                                           .getContentAsString();
+
+        String expectedResponseBody = requestBody + " -> calledFromCamel.js handled this message";
+
+        assertEquals("Unexpected response from camel platform http endpoint", expectedResponseBody, actualResponseBody);
+
+    }
+
+}

--- a/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
+++ b/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
@@ -30,9 +30,6 @@ class CamelPlatformHttpTest extends IntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
-    // Test an HTTP/POST request towards a camel platform http route.
-    // The route sends the request towards a dirigible js file
-    // which responds by appending to the inbound message.
     @Test
     void postToJsTest() throws Exception {
         String requestBody = "initial message";

--- a/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
+++ b/tests/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -24,7 +23,6 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class CamelPlatformHttpTest extends IntegrationTest {
 
     @Autowired
@@ -43,7 +41,7 @@ class CamelPlatformHttpTest extends IntegrationTest {
                                            .getResponse()
                                            .getContentAsString();
 
-        String expectedResponseBody = requestBody + " -> calledFromCamel.js handled this message";
+        String expectedResponseBody = requestBody + " -> calledFromCamel.mjs handled this message";
 
         assertEquals("Unexpected response from camel platform http endpoint", expectedResponseBody, actualResponseBody);
 

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
@@ -1,7 +1,0 @@
-exports.onMessage = (message) => {
-    let messageBody = message.getBodyAsString();
-    let modifiedMessageBody = messageBody + " -> calledFromCamel.js handled this message";
-    console.log('[CamelTest] CalledFromCamel.js called with message: ' + messageBody);
-    message.setBody(modifiedMessageBody);
-    return message;
-}

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
@@ -1,4 +1,7 @@
 exports.onMessage = (message) => {
-    console.log('[CamelTest] CalledFromCamel.js called with message: ' + message);
-    return message + " -> calledFromCamel.js handled this message";
+    let messageBody = message.getBodyAsString();
+    let modifiedMessageBody = messageBody + " -> calledFromCamel.js handled this message";
+    console.log('[CamelTest] CalledFromCamel.js called with message: ' + messageBody);
+    message.setBody(modifiedMessageBody);
+    return message;
 }

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.js
@@ -1,0 +1,4 @@
+exports.onMessage = (message) => {
+    console.log('[CamelTest] CalledFromCamel.js called with message: ' + message);
+    return message + " -> calledFromCamel.js handled this message";
+}

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.mjs
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/calledFromCamel.mjs
@@ -1,0 +1,6 @@
+export function onMessage(message) {
+    const messageBody = message.getBodyAsString();
+    const modifiedMessageBody = `${messageBody} -> calledFromCamel.mjs handled this message`;
+    message.setBody(modifiedMessageBody);
+    return message;
+}

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/test-routes.camel
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/test-routes.camel
@@ -1,0 +1,33 @@
+- route:
+    id: route-e308
+    from:
+      uri: platform-http:/camelTest
+      id: from-48ea
+      steps:
+        - setProperty:
+            name: resource
+            id: setProperty-8ed5
+            expression:
+              constant:
+                expression: camel_test/calledFromCamel.js
+                id: constant-f4ba
+        - to:
+            uri: class:org.eclipse.dirigible.components.engine.camel.invoke.Invoker
+            id: to-5fb3
+            parameters:
+              method: invoke
+- route:
+    id: route-bda8
+    from:
+      uri: direct:inbound1
+      id: from-3850
+      steps:
+        - log:
+            message: '[CamelTest] Route inbound1 called with message: ${body}'
+            id: log-be9c
+        - setBody:
+            id: setBody-0552
+            expression:
+              simple:
+                expression: ${body} -> camel route inbound1 handled this message
+                id: simple-57b6

--- a/tests/src/test/resources/META-INF/dirigible/camel_test/test-routes.camel
+++ b/tests/src/test/resources/META-INF/dirigible/camel_test/test-routes.camel
@@ -9,7 +9,7 @@
             id: setProperty-8ed5
             expression:
               constant:
-                expression: camel_test/calledFromCamel.js
+                expression: camel_test/calledFromCamel.mjs
                 id: constant-f4ba
         - to:
             uri: class:org.eclipse.dirigible.components.engine.camel.invoke.Invoker

--- a/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
+++ b/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
@@ -3,8 +3,7 @@ import * as camel from "@dirigible/integrations"
 
 test('dirigible-js-to-camel-route-test', () => {
     const message = "Initial Message";
-    const expected = message + " -> camel route inbound1 handled this message";
-	const actual = camel.invokeRoute('direct:inbound1', message, []);
-    console.log('[CamelTest] Camel route inbound1 responded with message: ' + actual);
-	assertEquals("Received an unexpected message from route inbound1 ", expected, actual);
+    const expected = `${message} -> camel route inbound1 handled this message`;
+    const actual = camel.invokeRoute('direct:inbound1', message, []);
+    assertEquals("Received an unexpected message from route inbound1 ", expected, actual);
 });

--- a/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
+++ b/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
@@ -1,0 +1,12 @@
+import { test, assertEquals } from "@dirigible/junit"
+import * as camel from "@dirigible/integrations"
+
+// Test the camel @dirigible/integrations js api with a call
+// to a direct route which responds by appending to the initial message.
+test('dirigible-js-to-camel-route-test', () => {
+    const message = "Initial Message";
+    const expected = message + " -> camel route inbound1 handled this message";
+	const actual = camel.invokeRoute('direct:inbound1', message, []);
+    console.log('[CamelTest] Camel route inbound1 responded with message: ' + actual);
+	assertEquals("Received an unexpected message from route inbound1 ", expected, actual);
+});

--- a/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
+++ b/tests/src/test/resources/META-INF/dirigible/modules-tests/src/services/integrations/dirigible-js-to-camel-route-test.js
@@ -1,8 +1,6 @@
 import { test, assertEquals } from "@dirigible/junit"
 import * as camel from "@dirigible/integrations"
 
-// Test the camel @dirigible/integrations js api with a call
-// to a direct route which responds by appending to the initial message.
 test('dirigible-js-to-camel-route-test', () => {
     const message = "Initial Message";
     const expected = message + " -> camel route inbound1 handled this message";


### PR DESCRIPTION
- Modified JS invoker to return response to any invoking camel routes.
- Adds an integration test which calls a PlatformHttp route, which in turn provides the payload to a dirigible js script that forms a response.
- Adds an integration test which from a dirigible js script calls a camel direct route via the js api that forms a response.
- Dirigible code runner closes context after route completes when camel invokes dirigible js/mjs/ts files

