### PR TITLE
Support more complex placeholders in config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,3 +325,4 @@ Unicons by IconScout: [https://github.com/Iconscout/unicons](https://github.com/
 - Mailing List: [https://dev.eclipse.org/mailman/listinfo/dirigible-dev](https://dev.eclipse.org/mailman/listinfo/dirigible-dev)
 - Issues: [https://github.com/eclipse/dirigible/issues](https://github.com/eclipse/dirigible/issues)
 - Eclipse Foundation Help Desk: https://gitlab.eclipse.org/eclipsefdn/helpdesk
+

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/Configuration.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/Configuration.java
@@ -20,6 +20,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,8 +36,11 @@ import org.slf4j.LoggerFactory;
  */
 public class Configuration {
 
+
     /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
+    private static final String MULTIVARIABLE_REGEX = "\\$\\{([^}]+)\\}";
+    private static final Pattern MULTIVARIABLE_PATTERN = Pattern.compile(MULTIVARIABLE_REGEX);
 
     /**
      * The Enum ConfigType.
@@ -578,13 +583,23 @@ public class Configuration {
                                 String k = s.substring(2, s.length() - 1);
                                 FieldUtils.writeField(field, o, Configuration.get(k), true);
                             }
+                        } else {
+                            Matcher matcher = MULTIVARIABLE_PATTERN.matcher(s);
+                            String finalValue = s;
+                            while (matcher.find()) {
+                                String placeholder = matcher.group(0);
+                                String configName = matcher.group(1);
+                                finalValue = finalValue.replaceAll(Pattern.quote(placeholder), Configuration.get(configName));
+                            }
+                            FieldUtils.writeField(field, o, finalValue, true);
                         }
                     }
                 }
             }
-        } catch (SecurityException | IllegalArgumentException | IllegalAccessException e) {
+        } catch (SecurityException | IllegalArgumentException |
+
+                IllegalAccessException e) {
             logger.error(e.getMessage(), e);
         }
     }
-
 }

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/Configuration.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/Configuration.java
@@ -585,12 +585,16 @@ public class Configuration {
                             }
                         } else {
                             Matcher matcher = MULTIVARIABLE_PATTERN.matcher(s);
+                            if (!matcher.find()) {
+                                continue;
+                            }
+
                             String finalValue = s;
-                            while (matcher.find()) {
+                            do {
                                 String placeholder = matcher.group(0);
                                 String configName = matcher.group(1);
                                 finalValue = finalValue.replaceAll(Pattern.quote(placeholder), Configuration.get(configName));
-                            }
+                            } while (matcher.find());
                             FieldUtils.writeField(field, o, finalValue, true);
                         }
                     }

--- a/modules/commons/commons-config/src/test/java/org/eclipse/dirigible/commons/config/ConfigurationTest.java
+++ b/modules/commons/commons-config/src/test/java/org/eclipse/dirigible/commons/config/ConfigurationTest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
 import org.junit.Test;
 
 /**
@@ -157,58 +156,22 @@ public class ConfigurationTest {
     @Test
     public void configureObjectTest() {
         Configuration.set("S2_VALUE", "s2");
+        Configuration.set("PORTUNUS_OPENCART_DB_HOST", "localhost");
+        Configuration.set("PORTUNUS_OPENCART_DB_PORT", "3306");
+        Configuration.set("PORTUNUS_OPENCART_DB_NAME", "bitnami_opencart");
+
         class TestObject {
             String s1 = "s1";
             String s2 = "${S2_VALUE}";
             String s3 = "${S3_VALUE}.{s3}";
-
-            /**
-             * @return the s1
-             */
-            public String getS1() {
-                return s1;
-            }
-
-            /**
-             * @param s1 the s1 to set
-             */
-            public void setS1(String s1) {
-                this.s1 = s1;
-            }
-
-            /**
-             * @return the s2
-             */
-            public String getS2() {
-                return s2;
-            }
-
-            /**
-             * @param s2 the s2 to set
-             */
-            public void setS2(String s2) {
-                this.s2 = s2;
-            }
-
-            /**
-             * @return the s3
-             */
-            public String getS3() {
-                return s3;
-            }
-
-            /**
-             * @param s3 the s3 to set
-             */
-            public void setS3(String s3) {
-                this.s3 = s3;
-            }
-
+            String s4 = "jdbc:mariadb://${PORTUNUS_OPENCART_DB_HOST}:${PORTUNUS_OPENCART_DB_PORT}/${PORTUNUS_OPENCART_DB_NAME}";
         }
         TestObject o = new TestObject();
         Configuration.configureObject(o);
-        assertEquals("s1", o.getS1());
-        assertEquals("s2", o.getS2());
-        assertEquals("s3", o.getS3());
+
+        assertEquals("s1", o.s1);
+        assertEquals("s2", o.s2);
+        assertEquals("s3", o.s3);
+        assertEquals("jdbc:mariadb://localhost:3306/bitnami_opencart", o.s4);
     }
 }


### PR DESCRIPTION
example config property: `jdbc:mariadb://${PORTUNUS_OPENCART_DB_HOST}:${PORTUNUS_OPENCART_DB_PORT}/${PORTUNUS_OPENCART_DB_NAME}`