### PR TITLE
Configure ActiveMQ redelivery policy

### DIFF
--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManager.java
@@ -10,21 +10,29 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import jakarta.jms.Connection;
-import jakarta.jms.Destination;
-import jakarta.jms.JMSException;
-import jakarta.jms.MessageConsumer;
-import jakarta.jms.Session;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.RedeliveryPolicy;
+import org.apache.activemq.broker.region.policy.RedeliveryPolicyMap;
+import org.apache.activemq.command.ActiveMQDestination;
 import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
 import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import jakarta.jms.Connection;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Session;
 
 /**
  * The Class BackgroundListenerManager.
  */
 public class ListenerManager {
+
+    private static final int INITIAL_REDELIVERY_DELAY = 1000;
+    private static final int REDELIVERY_DELAY = 5000;
+    private static final int MAXIMUM_REDELIVERIES = 3;
 
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(ListenerManager.class);
@@ -67,7 +75,9 @@ public class ListenerManager {
             Connection connection = connectionArtifactsFactory.createConnection(exceptionListener);
             Session session = connectionArtifactsFactory.createSession(connection);
 
-            Destination destination = craeteDestination(session);
+            Destination destination = createDestination(session);
+            configureRedeliveryPolicy(connection, destination);
+
             MessageConsumer consumer = session.createConsumer(destination);
 
             AsynchronousMessageListener messageListener = new AsynchronousMessageListener(listener);
@@ -80,23 +90,47 @@ public class ListenerManager {
     }
 
     /**
-     * Craete destination.
+     * Create destination.
      *
      * @param session the session
      * @return the destination
      * @throws JMSException the JMS exception
      */
-    private Destination craeteDestination(Session session) throws JMSException {
+    private Destination createDestination(Session session) throws JMSException {
         String destination = listener.getName();
-        ListenerKind kind = listener.getKind();
-        if (null == kind) {
-            throw new IllegalArgumentException("Invalid listener: " + listener + ", kind IS null");
-        }
+        ListenerKind kind = getKind();
         return switch (kind) {
             case QUEUE -> session.createQueue(destination);
             case TOPIC -> session.createTopic(destination);
             default -> throw new IllegalArgumentException("Invalid kind: " + kind);
         };
+    }
+
+    private void configureRedeliveryPolicy(Connection connection, Destination destination) {
+        if (connection instanceof ActiveMQConnection amqConnection && destination instanceof ActiveMQDestination amqDestination) {
+            RedeliveryPolicy redeliveryPolicy = createRedeliveryPolicy();
+            RedeliveryPolicyMap policyMap = amqConnection.getRedeliveryPolicyMap();
+            policyMap.put(amqDestination, redeliveryPolicy);
+        }
+    }
+
+    private RedeliveryPolicy createRedeliveryPolicy() {
+        RedeliveryPolicy redeliveryPolicy = new RedeliveryPolicy();
+
+        redeliveryPolicy.setInitialRedeliveryDelay(INITIAL_REDELIVERY_DELAY);
+        redeliveryPolicy.setRedeliveryDelay(REDELIVERY_DELAY);
+        redeliveryPolicy.setUseExponentialBackOff(true);
+        redeliveryPolicy.setMaximumRedeliveries(MAXIMUM_REDELIVERIES);
+
+        return redeliveryPolicy;
+    }
+
+    private ListenerKind getKind() {
+        ListenerKind kind = listener.getKind();
+        if (null == kind) {
+            throw new IllegalArgumentException("Invalid listener: " + listener + ", kind IS null");
+        }
+        return kind;
     }
 
     /**


### PR DESCRIPTION
Configure default redelivery policy for all listeners.

An example execution of the handlers with this configuration:
```
# First execution
2024-01-11 13:29:35.496 [INFO ] [ActiveMQ Session Task-1] app.out - ### Handler Execution

# Retries
2024-01-11 13:29:36.634 [INFO ] [ActiveMQ Session Task-1] app.out - ### Handler Execution
2024-01-11 13:29:41.741 [INFO ] [ActiveMQ Session Task-1] app.out - ### Handler Execution
2024-01-11 13:30:06.824 [INFO ] [ActiveMQ Session Task-1] app.out - ### Handler Execution
```
@delchev consider to extend the `.listener` spec with configurations for redelivery