### PR TITLE
fix SystemDB visualization when using env variable

### DIFF
--- a/components/data/data-sources/src/main/resources/META-INF/dirigible/datasources/SystemDB.datasource
+++ b/components/data/data-sources/src/main/resources/META-INF/dirigible/datasources/SystemDB.datasource
@@ -1,10 +1,10 @@
 {
   "location":"/datasources/SystemDB.datasource",
   "name":"SystemDB",
-  "driver":"${DIRIGIBLE_DATASOURCE_SYSTEM_DRIVER}.{org.h2.Driver}",
-  "url":"${DIRIGIBLE_DATASOURCE_SYSTEM_URL}.{jdbc:h2:file:./target/dirigible/h2/SystemDB}",
-  "username":"${DIRIGIBLE_DATASOURCE_SYSTEM_USERNAME}.{sa}",
-  "password":"${DIRIGIBLE_DATASOURCE_SYSTEM_PASSWORD}.{}",
+  "driver":"${DIRIGIBLE_DATABASE_SYSTEM_DRIVER}.{org.h2.Driver}",
+  "url":"${DIRIGIBLE_DATABASE_SYSTEM_URL}.{jdbc:h2:file:./target/dirigible/h2/SystemDB}",
+  "username":"${DIRIGIBLE_DATABASE_SYSTEM_USERNAME}.{sa}",
+  "password":"${DIRIGIBLE_DATABASE_SYSTEM_PASSWORD}.{}",
   "properties":[
   ]
 }


### PR DESCRIPTION
When you are using env variables like the following:
```
export DIRIGIBLE_DATABASE_SYSTEM_URL='jdbc:h2:file:/Users/iliyan/work/dirigible-work-dir/h2/SystemDB'
export DIRIGIBLE_DATABASE_SYSTEM_USERNAME='admin'
export DIRIGIBLE_DATABASE_SYSTEM_PASSWORD='admin'
```
Tables are not shown in the UI
![image](https://github.com/eclipse/dirigible/assets/5058839/b8eea677-2a5a-40f3-b2a8-c855100d03f6)

