### PR TITLE
[#3353] Generate model from schema

### DIFF
--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -442,11 +442,11 @@ public class DatabaseFacade implements InitializingBean {
                     preparedStatement.setString(i++, value);
                 } else if (DataTypeUtils.isCharacterVarying(dataType)) {
                     if (!valueElement.isJsonPrimitive() || !valueElement.getAsJsonPrimitive()
-                            .isString()) {
+                                                                        .isString()) {
                         throw new IllegalArgumentException("Wrong value of the parameter of type CHARACTER VARYING");
                     }
                     String value = valueElement.getAsJsonPrimitive()
-                            .getAsString();
+                                               .getAsString();
                     preparedStatement.setString(i++, value);
                 } else if (DataTypeUtils.isNvarchar(dataType)) {
                     if (!valueElement.isJsonPrimitive() || !valueElement.getAsJsonPrimitive()

--- a/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
+++ b/components/api/api-database/src/main/java/org/eclipse/dirigible/components/api/db/DatabaseFacade.java
@@ -440,10 +440,18 @@ public class DatabaseFacade implements InitializingBean {
                     String value = valueElement.getAsJsonPrimitive()
                                                .getAsString();
                     preparedStatement.setString(i++, value);
+                } else if (DataTypeUtils.isCharacterVarying(dataType)) {
+                    if (!valueElement.isJsonPrimitive() || !valueElement.getAsJsonPrimitive()
+                            .isString()) {
+                        throw new IllegalArgumentException("Wrong value of the parameter of type CHARACTER VARYING");
+                    }
+                    String value = valueElement.getAsJsonPrimitive()
+                            .getAsString();
+                    preparedStatement.setString(i++, value);
                 } else if (DataTypeUtils.isNvarchar(dataType)) {
                     if (!valueElement.isJsonPrimitive() || !valueElement.getAsJsonPrimitive()
                                                                         .isString()) {
-                        throw new IllegalArgumentException("Wrong value of the parameter of type VARCHAR");
+                        throw new IllegalArgumentException("Wrong value of the parameter of type NVARCHAR");
                     }
                     String value = valueElement.getAsJsonPrimitive()
                                                .getAsString();

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpoint.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpoint.java
@@ -14,7 +14,6 @@ package org.eclipse.dirigible.components.data.export.endpoint;
 import static java.text.MessageFormat.format;
 
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
@@ -106,6 +105,30 @@ public class DataExportEndpoint {
         }
 
         dataExportService.exportSchemaInCsvs(datasource, schema);
+
+        return ResponseEntity.ok(new URI("/" + BaseEndpoint.PREFIX_ENDPOINT_IDE + "workspaces" + "/" + schema));
+    }
+
+    /**
+     * Export schema data in project as model.
+     *
+     * @param datasource the datasource
+     * @param schema the schema name
+     * @return the response
+     * @throws URISyntaxException the URI syntax exception
+     * @throws SQLException the SQL exception
+     */
+
+    @PutMapping(value = "/model/{datasource}/{schema}")
+    public ResponseEntity<URI> exportSchemaAsModel(@PathVariable("datasource") String datasource, @PathVariable("schema") String schema)
+            throws SQLException, URISyntaxException {
+
+        if (!databaseMetadataService.existsDataSourceMetadata(datasource)) {
+            String error = format("Datasource {0} does not exist.", datasource);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, error);
+        }
+
+        dataExportService.exportSchemaModel(datasource, schema);
 
         return ResponseEntity.ok(new URI("/" + BaseEndpoint.PREFIX_ENDPOINT_IDE + "workspaces" + "/" + schema));
     }

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpoint.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpoint.java
@@ -128,7 +128,7 @@ public class DataExportEndpoint {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, error);
         }
 
-        dataExportService.exportSchemaModel(datasource, schema);
+        dataExportService.exportSchemaAsModel(datasource, schema);
 
         return ResponseEntity.ok(new URI("/" + BaseEndpoint.PREFIX_ENDPOINT_IDE + "workspaces" + "/" + schema));
     }

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
@@ -304,23 +304,33 @@ public class DataExportService {
         entitiesArray.add(tableObject);
     }
 
-    private void populateTableProperties(JsonObject tableObject, Table table){
+    private void populateTableProperties(JsonObject tableObject, Table table) {
         tableObject.addProperty("caption", "Manage entity " + table.getName());
-        tableObject.addProperty("dataCount", "SELECT COUNT(*) AS COUNT FROM \"${tablePrefix}_" + table.getName().toUpperCase() + "\"");
-        tableObject.addProperty("dataName", table.getName().toUpperCase());
+        tableObject.addProperty("dataCount", "SELECT COUNT(*) AS COUNT FROM \"${tablePrefix}_" + table.getName()
+                                                                                                      .toUpperCase()
+                + "\"");
+        tableObject.addProperty("dataName", table.getName()
+                                                 .toUpperCase());
         tableObject.addProperty("dataQuery", "");
         tableObject.addProperty("icon", "cubes");
         tableObject.addProperty("layoutType", "MANAGE");
-        tableObject.addProperty("menuIndex", table.getName().toLowerCase());
-        tableObject.addProperty("menuKey", table.getName().toLowerCase());
-        tableObject.addProperty("menuLabel", table.getName().toLowerCase());
-        tableObject.addProperty("name", table.getName().toLowerCase());
+        tableObject.addProperty("menuIndex", table.getName()
+                                                  .toLowerCase());
+        tableObject.addProperty("menuKey", table.getName()
+                                                .toLowerCase());
+        tableObject.addProperty("menuLabel", table.getName()
+                                                  .toLowerCase());
+        tableObject.addProperty("name", table.getName()
+                                             .toLowerCase());
         tableObject.addProperty("navigationPath", "/Home");
-        tableObject.addProperty("perspectiveIcon", "/services/web/resources/unicons/arrows-resize-v.svg");  // should not be hardcoded
-        tableObject.addProperty("perspectiveName", table.getName().toLowerCase());
+        tableObject.addProperty("perspectiveIcon", "/services/web/resources/unicons/arrows-resize-v.svg"); // should not be hardcoded
+        tableObject.addProperty("perspectiveName", table.getName()
+                                                        .toLowerCase());
         tableObject.addProperty("perspectiveOrder", "");
-        tableObject.addProperty("title", table.getName().toUpperCase());
-        tableObject.addProperty("tooltip", table.getName().toUpperCase());
+        tableObject.addProperty("title", table.getName()
+                                              .toUpperCase());
+        tableObject.addProperty("tooltip", table.getName()
+                                                .toUpperCase());
         tableObject.addProperty("type", "PRIMARY");
     }
 

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
@@ -137,11 +137,8 @@ public class DataExportService {
                                             .get("schemas")
                                             .getAsJsonArray();
 
-                if (workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME)) {
-                    workspace = WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME);
-                } else {
-                    workspace = WorkspaceFacade.createWorkspace(schema.toLowerCase());
-                }
+                workspace = workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME) ? WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME)
+                        : WorkspaceFacade.createWorkspace(DEFAULT_WORKSPACE_NAME);
 
                 Project project = workspace.createProject(schema);
 
@@ -218,11 +215,8 @@ public class DataExportService {
         Project project;
         File file;
 
-        if (workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME)) {
-            workspace = WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME);
-        } else {
-            workspace = WorkspaceFacade.createWorkspace(schema);
-        }
+        workspace = workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME) ? WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME)
+                : WorkspaceFacade.createWorkspace(DEFAULT_WORKSPACE_NAME);
 
         project = workspace.createProject(schema);
         file = project.createFile(schema + ".schema", schemaMetadata.getBytes());
@@ -289,11 +283,8 @@ public class DataExportService {
 
             Workspace workspace;
 
-            if (workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME)) {
-                workspace = WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME);
-            } else {
-                workspace = WorkspaceFacade.createWorkspace(schema.toLowerCase());
-            }
+            workspace = workspaceService.existsWorkspace(DEFAULT_WORKSPACE_NAME) ? WorkspaceFacade.getWorkspace(DEFAULT_WORKSPACE_NAME)
+                    : WorkspaceFacade.createWorkspace(DEFAULT_WORKSPACE_NAME);
 
             Project project = workspace.createProject(schema);
 

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
@@ -251,7 +251,7 @@ public class DataExportService {
      * @param schema the schema
      */
 
-    public void exportSchemaModel(String datasource, String schema) {
+    public void exportSchemaAsModel(String datasource, String schema) {
         try {
             javax.sql.DataSource dataSource = datasourceManager.getDataSource(datasource);
 

--- a/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
+++ b/components/data/data-export/src/main/java/org/eclipse/dirigible/components/data/export/service/DataExportService.java
@@ -299,26 +299,48 @@ public class DataExportService {
         }
 
         tableObject.add("properties", tableColumns);
-        tableObject.addProperty("caption", "Manage entity " + table.getName());
-        tableObject.addProperty("dataName", table.getName()
-                                                 .toUpperCase());
+        populateTableProperties(tableObject, table);
 
         entitiesArray.add(tableObject);
+    }
+
+    private void populateTableProperties(JsonObject tableObject, Table table){
+        tableObject.addProperty("caption", "Manage entity " + table.getName());
+        tableObject.addProperty("dataCount", "SELECT COUNT(*) AS COUNT FROM \"${tablePrefix}_" + table.getName().toUpperCase() + "\"");
+        tableObject.addProperty("dataName", table.getName().toUpperCase());
+        tableObject.addProperty("dataQuery", "");
+        tableObject.addProperty("icon", "cubes");
+        tableObject.addProperty("layoutType", "MANAGE");
+        tableObject.addProperty("menuIndex", table.getName().toLowerCase());
+        tableObject.addProperty("menuKey", table.getName().toLowerCase());
+        tableObject.addProperty("menuLabel", table.getName().toLowerCase());
+        tableObject.addProperty("name", table.getName().toLowerCase());
+        tableObject.addProperty("navigationPath", "/Home");
+        tableObject.addProperty("perspectiveIcon", "/services/web/resources/unicons/arrows-resize-v.svg");  // should not be hardcoded
+        tableObject.addProperty("perspectiveName", table.getName().toLowerCase());
+        tableObject.addProperty("perspectiveOrder", "");
+        tableObject.addProperty("title", table.getName().toUpperCase());
+        tableObject.addProperty("tooltip", table.getName().toUpperCase());
+        tableObject.addProperty("type", "PRIMARY");
     }
 
     private JsonObject populateColumnData(TableColumn column) {
         JsonObject columnObject = new JsonObject();
         columnObject.addProperty("calculatedPropertyExpression", "");
-        columnObject.addProperty("dataAutoIncrement", column.isPrimaryKey());
+        columnObject.addProperty("dataAutoIncrement", String.valueOf(column.isPrimaryKey()));
         columnObject.addProperty("dataLength", column.getLength());
         columnObject.addProperty("dataName", column.getName()
                                                    .toUpperCase());
-        columnObject.addProperty("dataNullable", column.isNullable());
-        columnObject.addProperty("dataPrimaryKey", column.isPrimaryKey());
+        columnObject.addProperty("dataNullable", String.valueOf(column.isNullable()));
+        columnObject.addProperty("dataPrimaryKey", String.valueOf(column.isPrimaryKey()));
         columnObject.addProperty("dataType", column.getType());
-        columnObject.addProperty("dataUnique", column.isUnique());
-        columnObject.addProperty("isCalculatedProperty", "");
+        columnObject.addProperty("dataUnique", String.valueOf(column.isUnique()));
+        columnObject.addProperty("isCalculatedProperty", "false");
         columnObject.addProperty("name", column.getName());
+        columnObject.addProperty("widgetIsMajor", "true");
+        columnObject.addProperty("widgetLength", column.getLength());
+        columnObject.addProperty("widgetType", "TEXTBOX");
+
         return columnObject;
     }
 

--- a/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpointTest.java
+++ b/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/endpoint/DataExportEndpointTest.java
@@ -87,7 +87,7 @@ public class DataExportEndpointTest {
         mockMvc.perform(put("/services/data/project/csv/{datasource}/{schema}", "TestDB", "INFORMATION_SCHEMA").with(csrf()))
                .andDo(print())
                .andExpect(status().isOk());
-        Workspace workspace = workspaceService.getWorkspace("INFORMATION_SCHEMA");
+        Workspace workspace = workspaceService.getWorkspace("workspace");
         assertNotNull(workspace);
         Project project = workspace.getProject("INFORMATION_SCHEMA");
         assertNotNull(project);
@@ -103,7 +103,23 @@ public class DataExportEndpointTest {
         mockMvc.perform(put("/services/data/project/metadata/{datasource}/{schema}", "TestDB", "INFORMATION_SCHEMA").with(csrf()))
                .andDo(print())
                .andExpect(status().isOk());
-        Workspace workspace = workspaceService.getWorkspace("INFORMATION_SCHEMA");
+        Workspace workspace = workspaceService.getWorkspace("workspace");
+        assertNotNull(workspace);
+        Project project = workspace.getProject("INFORMATION_SCHEMA");
+        assertNotNull(project);
+    }
+
+    /**
+     * Export schema as model test.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void exportSchemaAsModelTest() throws Exception {
+        mockMvc.perform(put("/services/data/project/model/{datasource}/{schema}", "TestDB", "INFORMATION_SCHEMA").with(csrf()))
+               .andDo(print())
+               .andExpect(status().isOk());
+        Workspace workspace = workspaceService.getWorkspace("workspace");
         assertNotNull(workspace);
         Project project = workspace.getProject("INFORMATION_SCHEMA");
         assertNotNull(project);

--- a/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/service/DataExportServiceTest.java
+++ b/components/data/data-export/src/test/java/org/eclipse/dirigible/components/data/export/service/DataExportServiceTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.dirigible.components.data.export.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.sql.SQLException;
+import java.util.List;
 
 import org.eclipse.dirigible.components.data.sources.domain.DataSource;
 import org.eclipse.dirigible.components.data.sources.repository.DataSourceRepository;
@@ -20,6 +22,7 @@ import org.eclipse.dirigible.components.ide.workspace.domain.File;
 import org.eclipse.dirigible.components.ide.workspace.domain.Project;
 import org.eclipse.dirigible.components.ide.workspace.domain.Workspace;
 import org.eclipse.dirigible.components.ide.workspace.service.WorkspaceService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -76,6 +79,15 @@ public class DataExportServiceTest {
         datasourceRepository.save(datasource);
     }
 
+
+    /**
+     * Cleanup.
+     */
+    @AfterEach
+    public void cleanUp() {
+        datasourceRepository.deleteAll();
+    }
+
     /**
      * Export metadata as project test.
      *
@@ -84,11 +96,43 @@ public class DataExportServiceTest {
     @Test
     public void exportMetadataAsProjectTest() throws SQLException {
         String filePath = dataExportService.exportMetadataAsProject("TestDB", "INFORMATION_SCHEMA");
-        Workspace workspace = workspaceService.getWorkspace("INFORMATION_SCHEMA");
+        Workspace workspace = workspaceService.getWorkspace("workspace");
         Project project = workspace.getProject("INFORMATION_SCHEMA");
-        File file = project.getFiles()
-                           .get(0);
-        assertEquals(file.getWorkspacePath(), filePath);
+        List<File> files = project.getFiles();
+        File foundFile = null;
+
+        for (File file : files) {
+            if (file.getWorkspacePath()
+                    .equals(filePath)) {
+                foundFile = file;
+                break;
+            }
+        }
+
+        assertNotNull(foundFile);
+        assertEquals(foundFile.getWorkspacePath(), filePath);
+    }
+
+    /**
+     * Export schema as model test.
+     */
+    @Test
+    public void exportSchemaAsModelTest() {
+        dataExportService.exportSchemaAsModel("TestDB", "INFORMATION_SCHEMA");
+        Workspace workspace = workspaceService.getWorkspace("workspace");
+        Project project = workspace.getProject("INFORMATION_SCHEMA");
+        List<File> files = project.getFiles();
+        File foundFile = null;
+
+        for (File file : files) {
+            if (file.getName()
+                    .equals("INFORMATION_SCHEMA.model")) {
+                foundFile = file;
+                break;
+            }
+        }
+
+        assertNotNull(foundFile);
     }
 
     /**

--- a/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/explorer/explorer.js
+++ b/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/explorer/explorer.js
@@ -451,7 +451,7 @@ database.controller('DatabaseController', function ($scope, $http, messageHub) {
 							messageHub.postMessage('database.metadata.project.export.schema', sqlCommand);
 						}.bind(this)
 					};
-					ctxmenu.exportMetadataInProject = {
+					ctxmenu.exportTopologicalOrder = {
 						"separator_before": false,
 						"label": "Export Topological Order",
 						"action": function (data) {
@@ -459,6 +459,16 @@ database.controller('DatabaseController', function ($scope, $http, messageHub) {
 							let node = tree.get_node(data.reference);
 							let sqlCommand = node.original.text;
 							messageHub.postMessage('database.metadata.project.export.topology', sqlCommand);
+						}.bind(this)
+					};
+					ctxmenu.exportAsModel = {
+						"separator_before": false,
+						"label": "Export Schema as Model",
+						"action": function (data) {
+							let tree = $.jstree.reference(data.reference);
+							let node = tree.get_node(data.reference);
+							let sqlCommand = node.original.text;
+							messageHub.postMessage('database.metadata.project.export.model', sqlCommand);
 						}.bind(this)
 					};
 					ctxmenu.dropScript = {

--- a/components/ide/ide-ui-result/src/main/resources/META-INF/dirigible/ide-result/js/result.js
+++ b/components/ide/ide-ui-result/src/main/resources/META-INF/dirigible/ide-result/js/result.js
@@ -305,6 +305,27 @@ resultView.controller('DatabaseResultController', ['$scope', '$http', 'messageHu
         });
     }, true);
 
+    messageHub.onDidReceiveMessage("database.metadata.project.export.model", function (command) {
+        let schema = command.data;
+        let url = "/services/data/project/model/" + $scope.datasource + "/" +    schema;
+        $http({
+            method: 'PUT',
+            url: url,
+            headers: {
+                'X-Requested-With': 'Fetch',
+                'X-CSRF-Token': csrfToken
+            }
+        }).then(function (resourceURI) {
+            let fileURL = window.location.protocol + '//' + window.location.host + `/services/ide/workspaces/${schema}/${schema}`
+            let msg = `Created requested file in Project [${schema}] in Workspace [${schema}]. \n To access it it please go to: ${fileURL}`;
+            console.info(msg);
+            messageHub.showAlertSuccess('Export', msg);
+        }).catch(function (err) {
+            messageHub.showAlertError("Export error", "Error in exporting data in project");
+            console.error("Error in exporting data in project", err);
+        });
+    }, true);
+
     messageHub.onDidReceiveMessage("database.metadata.export.artifact", function (command) {
         let artifact = command.data.split('.');
         let url = "/services/data/definition/" + $scope.datasource + "/" + artifact[0] + "/" + artifact[1];

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
@@ -409,7 +409,7 @@ public class DataTypeUtils {
      */
     public static boolean isCharacterVarying(String dataType) {
         return DataType.CHARACTER_VARYING.toString()
-                .equals(dataType);
+                                         .equals(dataType);
     }
 
     /**

--- a/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
+++ b/modules/database/database-sql/src/main/java/org/eclipse/dirigible/database/sql/DataTypeUtils.java
@@ -402,6 +402,17 @@ public class DataTypeUtils {
     }
 
     /**
+     * Checks if is varchar.
+     *
+     * @param dataType the data type
+     * @return true, if is varchar
+     */
+    public static boolean isCharacterVarying(String dataType) {
+        return DataType.CHARACTER_VARYING.toString()
+                .equals(dataType);
+    }
+
+    /**
      * Checks if is nvarchar.
      *
      * @param dataType the data type


### PR DESCRIPTION
Right now the generate project needs to be edited a little because of the mandatory table prefix when generating an application. This will be fix with #3369 

Quick fix:
- in gen/dao/your_tables.js remove the prefix in the table string to be the same as the table in the datasource

fixes #3353, #3370
