### PR TITLE
[Schema] Support for different datasource for whole model

### DIFF
--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/domain/Schema.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/domain/Schema.java
@@ -46,9 +46,9 @@ public class Schema extends Artefact {
     private Long id;
 
     /** The dataSource */
-    @Column(name = "dataSource", nullable = false)
+    @Column(name = "datasource", nullable = false)
     @Expose
-    private String dataSource;
+    private String datasource;
 
     /** The tables. */
     @OneToMany(mappedBy = "schemaReference", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
@@ -167,12 +167,12 @@ public class Schema extends Artefact {
         return null;
     }
 
-    public String getDataSource() {
-        return dataSource;
+    public String getDatasource() {
+        return datasource;
     }
 
     public void setDataSource(String dataSource) {
-        this.dataSource = dataSource;
+        this.datasource = dataSource;
     }
 
     /**
@@ -182,7 +182,7 @@ public class Schema extends Artefact {
      */
     @Override
     public String toString() {
-        return "Schema [id=" + id + ", tables=" + tables + ", views=" + views + ", dataSource=" + dataSource + ", location=" + location
+        return "Schema [id=" + id + ", tables=" + tables + ", views=" + views + ", datasource=" + datasource + ", location=" + location
                 + ", name=" + name + ", type=" + type + ", description=" + description + ", key=" + key + ", dependencies=" + dependencies
                 + ", createdBy=" + createdBy + ", createdAt=" + createdAt + ", updatedBy=" + updatedBy + ", updatedAt=" + updatedAt + "]";
     }

--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/domain/Schema.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/domain/Schema.java
@@ -45,6 +45,11 @@ public class Schema extends Artefact {
     @Column(name = "SCHEMA_ID", nullable = false)
     private Long id;
 
+    /** The dataSource */
+    @Column(name = "dataSource", nullable = false)
+    @Expose
+    private String dataSource;
+
     /** The tables. */
     @OneToMany(mappedBy = "schemaReference", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @LazyCollection(LazyCollectionOption.FALSE)
@@ -58,7 +63,7 @@ public class Schema extends Artefact {
     private List<View> views = new ArrayList<View>();
 
     /**
-     * Instantiates a new table.
+     * Instantiates a new schema.
      *
      * @param location the location
      * @param name the name
@@ -162,6 +167,14 @@ public class Schema extends Artefact {
         return null;
     }
 
+    public String getDataSource() {
+        return dataSource;
+    }
+
+    public void setDataSource(String dataSource) {
+        this.dataSource = dataSource;
+    }
+
     /**
      * To string.
      *
@@ -169,9 +182,9 @@ public class Schema extends Artefact {
      */
     @Override
     public String toString() {
-        return "Schema [id=" + id + ", tables=" + tables + ", views=" + views + ", location=" + location + ", name=" + name + ", type="
-                + type + ", description=" + description + ", key=" + key + ", dependencies=" + dependencies + ", createdBy=" + createdBy
-                + ", createdAt=" + createdAt + ", updatedBy=" + updatedBy + ", updatedAt=" + updatedAt + "]";
+        return "Schema [id=" + id + ", tables=" + tables + ", views=" + views + ", dataSource=" + dataSource + ", location=" + location
+                + ", name=" + name + ", type=" + type + ", description=" + description + ", key=" + key + ", dependencies=" + dependencies
+                + ", createdBy=" + createdBy + ", createdAt=" + createdAt + ", updatedBy=" + updatedBy + ", updatedAt=" + updatedAt + "]";
     }
 
 }

--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
@@ -275,7 +275,7 @@ public class SchemasSynchronizer<A extends Artefact> implements Synchronizer<Sch
                                                                                                            .getClass()));
         }
 
-        try (Connection connection = datasourcesManager.getDataSource(schema.getDataSource())
+        try (Connection connection = datasourcesManager.getDataSource(schema.getDatasource())
                                                        .getConnection()) {
             switch (flow) {
                 case CREATE:
@@ -428,7 +428,7 @@ public class SchemasSynchronizer<A extends Artefact> implements Synchronizer<Sch
                                    .get("structures")
                                    .getAsJsonArray();
         String dataSource = root.getAsJsonObject()
-                                .get("dataSource")
+                                .get("datasource")
                                 .getAsString();
         result.setDataSource(dataSource);
         for (int i = 0; i < structures.size(); i++) {

--- a/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
+++ b/components/data/data-structures/src/main/java/org/eclipse/dirigible/components/data/structures/synchronizer/SchemasSynchronizer.java
@@ -63,25 +63,39 @@ import com.google.gson.JsonObject;
 @Order(SynchronizersOrder.SCHEMA)
 public class SchemasSynchronizer<A extends Artefact> implements Synchronizer<Schema> {
 
-    /** The Constant logger. */
+    /**
+     * The Constant logger.
+     */
     private static final Logger logger = LoggerFactory.getLogger(SchemasSynchronizer.class);
 
-    /** The Constant FILE_EXTENSION_SCHEMA. */
+    /**
+     * The Constant FILE_EXTENSION_SCHEMA.
+     */
     private static final String FILE_EXTENSION_SCHEMA = ".schema";
 
-    /** The schema service. */
+    /**
+     * The schema service.
+     */
     private SchemaService schemaService;
 
-    /** The table service. */
+    /**
+     * The table service.
+     */
     private TableService tableService;
 
-    /** The view service. */
+    /**
+     * The view service.
+     */
     private ViewService viewService;
 
-    /** The datasources manager. */
+    /**
+     * The datasources manager.
+     */
     private DataSourcesManager datasourcesManager;
 
-    /** The synchronization callback. */
+    /**
+     * The synchronization callback.
+     */
     private SynchronizerCallback callback;
 
     /**
@@ -253,17 +267,16 @@ public class SchemasSynchronizer<A extends Artefact> implements Synchronizer<Sch
     @Override
     public boolean complete(TopologyWrapper<Artefact> wrapper, ArtefactPhase flow) {
 
-        try (Connection connection = datasourcesManager.getDefaultDataSource()
+        Schema schema = null;
+        if (wrapper.getArtefact() instanceof Schema) {
+            schema = (Schema) wrapper.getArtefact();
+        } else {
+            throw new UnsupportedOperationException(String.format("Trying to process %s as Schema", wrapper.getArtefact()
+                                                                                                           .getClass()));
+        }
+
+        try (Connection connection = datasourcesManager.getDataSource(schema.getDataSource())
                                                        .getConnection()) {
-
-            Schema schema = null;
-            if (wrapper.getArtefact() instanceof Schema) {
-                schema = (Schema) wrapper.getArtefact();
-            } else {
-                throw new UnsupportedOperationException(String.format("Trying to process %s as Schema", wrapper.getArtefact()
-                                                                                                               .getClass()));
-            }
-
             switch (flow) {
                 case CREATE:
                     if (schema.getLifecycle()
@@ -414,6 +427,10 @@ public class SchemasSynchronizer<A extends Artefact> implements Synchronizer<Sch
                                    .getAsJsonObject()
                                    .get("structures")
                                    .getAsJsonArray();
+        String dataSource = root.getAsJsonObject()
+                                .get("dataSource")
+                                .getAsString();
+        result.setDataSource(dataSource);
         for (int i = 0; i < structures.size(); i++) {
             JsonObject structure = structures.get(i)
                                              .getAsJsonObject();

--- a/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
+++ b/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
@@ -93,5 +93,10 @@
 #end
 #end
         ]
-    }
+    },
+    #if($dataSource)
+    "dataSource": "${dataSource}"
+    #else
+    "dataSource": "DefaultDB"
+    #end
 }

--- a/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
+++ b/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/data/application.schema.template
@@ -95,8 +95,8 @@
         ]
     },
     #if($dataSource)
-    "dataSource": "${dataSource}"
+    "datasource": "${dataSource}"
     #else
-    "dataSource": "DefaultDB"
+    "datasource": "DefaultDB"
     #end
 }

--- a/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema
+++ b/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema
@@ -57,5 +57,6 @@
                 ]
             }
         ]
-    }
+    },
+    "dataSource": "DefaultDB"
 }

--- a/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema
+++ b/components/test-project/src/main/resources/META-INF/dirigible/test-project/schemas/test.schema
@@ -58,5 +58,5 @@
             }
         ]
     },
-    "dataSource": "DefaultDB"
+    "datasource": "DefaultDB"
 }


### PR DESCRIPTION
Part of:
- #3378 

The `.schema` file when generating application from `.model` now has `dataSource` _(`DefaultDB` is still default if no datasource is given as an input)_ and is taken in mind when doing CRUD operations from the EDM, eg - new entity will be created in the chosen dataSource instead of `DefaultDB`.

Next part will be to implement support for each entity to be able to have different datasource.