### PR TITLE
[EDM] Server side validations

### DIFF
--- a/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.extensionpoint.template
+++ b/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.extensionpoint.template
@@ -1,1 +1,4 @@
-{"location":"${projectName}/gen/dao/${perspectiveName}/${name}.extensionpoint","name":"${projectName}/${perspectiveName}/${name}","description":"Extension Point for ${projectName} ${perspectiveName} ${name}"}
+{
+    "name": "${projectName}-${perspectiveName}-${name}",
+    "description": "Extension Point for the ${projectName}-${perspectiveName}-${name} entity"
+}

--- a/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.ts.template
+++ b/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.ts.template
@@ -422,7 +422,7 @@ export class ${name}Repository {
     }
 
     private async triggerEvent(data: ${name}EntityEvent) {
-        const triggerExtensions = await extensions.loadExtensionModules("${projectName}/${perspectiveName}/${name}", ["trigger"]);
+        const triggerExtensions = await extensions.loadExtensionModules("${projectName}-${perspectiveName}-${name}", ["trigger"]);
         triggerExtensions.forEach(triggerExtension => {
             try {
                 triggerExtension.trigger(data);

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
@@ -6,12 +6,15 @@
 #end 
 #end
 import { Controller, Get, Post, Put, Delete, response } from "sdk/http"
+import { Extensions } from "sdk/extensions"
 import { ${name}Repository, ${name}EntityOptions } from "../../dao/${perspectiveName}/${name}Repository";
 import { HttpUtils } from "../utils/HttpUtils";
 #if($importsCode && $importsCode != "")
 // custom imports
 ${importsCode}
 #end
+
+const validationModules = await Extensions.loadExtensionModules("${projectName}-${perspectiveName}-${name}", ["validate"]);
 
 #if($isEntityPropertyPropertyEnabled)
 class ValidationError extends Error {
@@ -57,9 +60,7 @@ class ${name}Service {
     @Post("/")
     public create(entity: any) {
         try {
-#if($isEntityPropertyPropertyEnabled)
             this.validateEntity(entity);
-#end
             entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end = this.repository.create(entity);
             response.setHeader("Content-Location", "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts/" + entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end);
             response.setStatus(response.CREATED);
@@ -127,9 +128,7 @@ class ${name}Service {
     public update(entity: any, ctx: any) {
         try {
             entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end = ctx.pathParameters.id;
-#if($isEntityPropertyPropertyEnabled)
             this.validateEntity(entity);
-#end
             this.repository.update(entity);
             return entity;
         } catch (error: any) {
@@ -162,17 +161,27 @@ class ${name}Service {
             HttpUtils.sendInternalServerError(error.message);
         }
     }
-#if($isEntityPropertyPropertyEnabled)
 
     private validateEntity(entity: any): void {
 #foreach ($property in $properties)
-#if($property.widgetPattern && $property.widgetPattern != "")
-        isValid = isValid && entity.${property.name} && entity.${property.name}.match(/^${property.widgetPattern}${dollar}/) !== null;
-        if (entity.${property.name} === undefined || entity.${property.name}.match(/^${property.widgetPattern}${dollar}/) === null) {
-            throw new ValidationError(`The '${property.name}' values doesn't match the required pattern '${property.widgetPattern}'`);
+#if($property.isRequiredProperty)
+        if (entity.${property.name} === null || entity.${property.name} === undefined) {
+            throw new ValidationError(`The '${property.name}' property is required, provide a valid value`);
         }
-#end 
 #end
+#if($property.dataTypeTypescript == "string")
+        if (entity.${property.name}.length > ${property.dataLength}) {
+            throw new ValidationError(`The '${property.name}' exceeds the maximum length of [${property.dataLength}] characters`);
+        }
+#end
+#if($property.widgetPattern && $property.widgetPattern != "")
+        if (!RegExp(/${property.widgetPattern}/).test(entity.${property.name})) {
+            throw new ValidationError(`The value provided for the '${property.name}' property ('[${dollar}{entity.${property.name}}]') doesn't match the required pattern '${property.widgetPattern}'`);
+        }
+#end
+#end
+        for (const next of validationModules) {
+            next.validate(entity);
+        }
     }
-#end
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/index.html.template
@@ -248,7 +248,7 @@
 								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
-							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
+							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 						</div>
 					</fd-form-item>
 #elseif($property.widgetType == "TEL")
@@ -277,7 +277,7 @@
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -307,7 +307,7 @@
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -337,7 +337,7 @@
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -364,7 +364,7 @@
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/index.html.template
@@ -240,7 +240,7 @@
 								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
-							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
+							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 						</div>
 					</fd-form-item>
 #elseif($property.widgetType == "TEL")
@@ -269,7 +269,7 @@
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -299,7 +299,7 @@
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -329,7 +329,7 @@
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -356,7 +356,7 @@
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/index.html.template
@@ -225,7 +225,6 @@
 								ng-model="entity.${property.name}"
 								ng-minlength="${property.minLength} || 0"
 								ng-maxlength="${property.maxLength} || -1"
-								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
 							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
@@ -245,7 +244,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns:#if($property.inputRule == "")['^[0-9]{0,14}$']#else ['${property.inputRule}']#end }"
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -267,7 +265,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -289,7 +286,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
@@ -311,7 +307,6 @@
 	                                ng-model="entity.${property.name}"
 	                                ng-minlength="${property.minLength} || 0"
 	                                ng-maxlength="${property.maxLength} || -1"
-	                                dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/index.html.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/index.html.template
@@ -240,7 +240,7 @@
 								dg-input-rules="{ patterns: ['${property.inputRule}'] }"
 								placeholder="Enter ${property.widgetLabel}">
 							</fd-textarea>
-							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">Incorrect Input</fd-form-message>
+							<fd-form-message dg-type="error" ng-show="!forms.details['${property.name}'].$valid">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 						</div>
 					</fd-form-item>
 #elseif($property.widgetType == "TEL")
@@ -269,7 +269,7 @@
 	                                type="tel"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -299,7 +299,7 @@
 	                                type="url"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -329,7 +329,7 @@
 	                                type="email"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>
@@ -356,7 +356,7 @@
 	                                type="text"
 	                                placeholder="Enter ${property.widgetLabel}">
 	                            </fd-input>
-	                            <fd-form-message dg-type="error">Incorrect Input</fd-form-message>
+	                            <fd-form-message dg-type="error">The value doesn't match the required pattern '${property.inputRule}'</fd-form-message>
 	                        </fd-form-input-message-group>
 	                    </div>
                     </fd-form-item>


### PR DESCRIPTION
## Changes

- Add server side validation via extension point (in the REST API).
- One common extension point for both `trigger` (DAO) and `validate` (REST API) events.
- The extension point was renamed from `${projectName}/${perspectiveName}/${name}` to `${projectName}-${perspectiveName}-${name}` as the `/` symbol is invalid inside the Extensions editor.
- Enhanced validation messages both in the frontend and the backend.
- Add validations for `required` properties and for `data length` of string properties.
- Removes input rules (validation patterns) from the `Filter Dialogs`.

## Example

**validation/Student.ts**
```ts
import { StudentEntity } from "../gen/dao/entities/StudentRepository";

export const validate = (entity: StudentEntity) => {
    if (entity.Name && entity.Name.length > 13) {
        throw new Error('Validation failed because Name is longer than 13 symbols');
    }
}
```

**validation/Student.extension**
```json
{
    "module": "demo/validation/Student",
    "extensionPoint": "demo-entities-Student",
    "description": "Student Extension"
}
```

## Note

The value of the `module` in the extension definition is set to:

```json
"module": "demo/validation/Student"
```

 instead of 

```json
"module": "demo/validation/Student.ts"
```

Due to unknown reasons at the moment the `*.ts` extension is not loaded properly when there are `top-level awaits` in the code:

```ts
const validationModules = await Extensions.loadExtensionModules("demo-entities-Student", ["validate"]);
```

So either the module should be specified without providing the extension, or by setting `*.js` extension (`"module": "demo/validation/Student.js"`)

---

**The input validation patterns and server side validation is applied only in the REST API layer, direct usage of the DAO/Repository won't trigger the validations**

Fixes: #3304
