### PR TITLE
Multitenancy phase 3 - listeners

### DIFF
--- a/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
+++ b/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
@@ -39,14 +39,17 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to send the message
      */
     public static final void sendToQueue(String queue, String message) throws MessagingAPIException {
-        if (null == messageProducer) {
-            throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
-        }
-
+        validateClassIsInitialized(null == messageProducer);
         try {
             messageProducer.sendMessageToQueue(queue, message);
         } catch (RuntimeException | JMSException ex) {
             throw new MessagingAPIException("Failed to send message to queue [" + queue + "]", ex);
+        }
+    }
+
+    private static void validateClassIsInitialized(boolean messageProducer) {
+        if (messageProducer) {
+            throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
         }
     }
 
@@ -58,10 +61,7 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to send the message
      */
     public static final void sendToTopic(String topic, String message) {
-        if (null == messageProducer) {
-            throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
-        }
-
+        validateClassIsInitialized(null == messageProducer);
         try {
             messageProducer.sendMessageToTopic(topic, message);
         } catch (RuntimeException | JMSException ex) {
@@ -80,10 +80,7 @@ public class MessagingFacade {
      * @throws TimeoutException if timeout to get a message from the queue
      */
     public static final String receiveFromQueue(String queue, long timeout) throws MessagingAPIException {
-        if (null == messageConsumer) {
-            throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
-        }
-
+        validateClassIsInitialized(null == messageConsumer);
         try {
             return messageConsumer.receiveMessageFromQueue(queue, timeout);
         } catch (org.eclipse.dirigible.components.listeners.service.TimeoutException ex) {
@@ -103,10 +100,7 @@ public class MessagingFacade {
      * @throws TimeoutException if timeout to get a message from the topic
      */
     public static final String receiveFromTopic(String topic, long timeout) {
-        if (null == messageConsumer) {
-            throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
-        }
-
+        validateClassIsInitialized(null == messageConsumer);
         try {
             return messageConsumer.receiveMessageFromTopic(topic, timeout);
         } catch (org.eclipse.dirigible.components.listeners.service.TimeoutException ex) {

--- a/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
+++ b/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
@@ -39,7 +39,7 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to send the message
      */
     public static final void sendToQueue(String queue, String message) throws MessagingAPIException {
-        validateClassIsInitialized(null == messageProducer);
+        validateClassIsInitialized();
         try {
             messageProducer.sendMessageToQueue(queue, message);
         } catch (RuntimeException | JMSException ex) {
@@ -47,8 +47,8 @@ public class MessagingFacade {
         }
     }
 
-    private static void validateClassIsInitialized(boolean messageProducer) {
-        if (messageProducer) {
+    private static void validateClassIsInitialized() {
+        if (null == messageProducer) {
             throw new IllegalStateException("Class is not initialized yet. Cannot call this static method before the bean is initialized");
         }
     }
@@ -61,7 +61,7 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to send the message
      */
     public static final void sendToTopic(String topic, String message) {
-        validateClassIsInitialized(null == messageProducer);
+        validateClassIsInitialized();
         try {
             messageProducer.sendMessageToTopic(topic, message);
         } catch (RuntimeException | JMSException ex) {
@@ -80,7 +80,7 @@ public class MessagingFacade {
      * @throws TimeoutException if timeout to get a message from the queue
      */
     public static final String receiveFromQueue(String queue, long timeout) throws MessagingAPIException {
-        validateClassIsInitialized(null == messageConsumer);
+        validateClassIsInitialized();
         try {
             return messageConsumer.receiveMessageFromQueue(queue, timeout);
         } catch (org.eclipse.dirigible.components.listeners.service.TimeoutException ex) {
@@ -100,7 +100,7 @@ public class MessagingFacade {
      * @throws TimeoutException if timeout to get a message from the topic
      */
     public static final String receiveFromTopic(String topic, long timeout) {
-        validateClassIsInitialized(null == messageConsumer);
+        validateClassIsInitialized();
         try {
             return messageConsumer.receiveMessageFromTopic(topic, timeout);
         } catch (org.eclipse.dirigible.components.listeners.service.TimeoutException ex) {

--- a/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
+++ b/components/api/api-messaging/src/main/java/org/eclipse/dirigible/components/api/messaging/MessagingFacade.java
@@ -38,7 +38,7 @@ public class MessagingFacade {
      * @param message the message
      * @throws MessagingAPIException if fail to send the message
      */
-    public static final void sendToQueue(String queue, String message) throws MessagingAPIException {
+    public static void sendToQueue(String queue, String message) throws MessagingAPIException {
         validateClassIsInitialized();
         try {
             messageProducer.sendMessageToQueue(queue, message);
@@ -60,14 +60,13 @@ public class MessagingFacade {
      * @param message the message
      * @throws MessagingAPIException if fail to send the message
      */
-    public static final void sendToTopic(String topic, String message) {
+    public static void sendToTopic(String topic, String message) {
         validateClassIsInitialized();
         try {
             messageProducer.sendMessageToTopic(topic, message);
         } catch (RuntimeException | JMSException ex) {
             throw new MessagingAPIException("Failed to send message to topic [" + topic + "]", ex);
         }
-
     }
 
     /**
@@ -79,7 +78,7 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to receive a message from the queue
      * @throws TimeoutException if timeout to get a message from the queue
      */
-    public static final String receiveFromQueue(String queue, long timeout) throws MessagingAPIException {
+    public static String receiveFromQueue(String queue, long timeout) throws MessagingAPIException {
         validateClassIsInitialized();
         try {
             return messageConsumer.receiveMessageFromQueue(queue, timeout);
@@ -99,7 +98,7 @@ public class MessagingFacade {
      * @throws MessagingAPIException if fail to receive a message from the topic
      * @throws TimeoutException if timeout to get a message from the topic
      */
-    public static final String receiveFromTopic(String topic, long timeout) {
+    public static String receiveFromTopic(String topic, long timeout) {
         validateClassIsInitialized();
         try {
             return messageConsumer.receiveMessageFromTopic(topic, timeout);

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/CallableResultAndException.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/CallableResultAndException.java
@@ -11,7 +11,7 @@
 package org.eclipse.dirigible.components.base.tenant;
 
 @FunctionalInterface
-public interface CallableNoResultAndException {
+public interface CallableResultAndException<Result> {
 
-    void call() throws Exception;
+    Result call() throws Exception;
 }

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantContext.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantContext.java
@@ -37,6 +37,8 @@ public interface TenantContext {
 
     <Result> Result execute(Tenant tenant, CallableResultAndNoException<Result> callable);
 
+    <Result> Result execute(String tenantId, CallableResultAndNoException<Result> callable);
+
     /**
      * This method will execute callable.call() method on behalf of the specified tenant.
      *

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantContext.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantContext.java
@@ -35,32 +35,43 @@ public interface TenantContext {
      */
     Tenant getCurrentTenant();
 
-    <Result> Result execute(Tenant tenant, CallableResultAndNoException<Result> callable);
-
-    <Result> Result execute(String tenantId, CallableResultAndNoException<Result> callable);
+    /**
+     * This method will execute callable.call() method on behalf of the specified tenant.
+     *
+     * @param tenant the tenant
+     * @param callable the callable
+     * @param <Result> result type
+     * @return the result
+     * @throws Exception the exception which is thrown by the passed callable
+     */
+    <Result> Result executeWithPossibleException(Tenant tenant, CallableResultAndException<Result> callable) throws Exception;
 
     /**
      * This method will execute callable.call() method on behalf of the specified tenant.
      *
      * @param tenant the tenant
      * @param callable the callable
-     * @throws Exception the exception which is thrown by the passed callable
+     * @param <Result> result type
+     * @return the result
      */
-    void execute(Tenant tenant, CallableNoResultAndException callable) throws Exception;
+    <Result> Result execute(Tenant tenant, CallableResultAndNoException<Result> callable);
 
     /**
-     * This method will execute callable.call() for each provisioned tenant.
+     * This method will execute callable.call() method on behalf of the specified tenant id.
      *
-     * @param tenant the tenant
+     * @param tenantId the tenant id
      * @param callable the callable
-     * @throws Exception the exception which is thrown by the passed callable
+     * @param <Result> result type
+     * @return the result
+     * @throws TenantNotFoundException in case the provided tenant id doesn't exist
      */
+    <Result> Result execute(String tenantId, CallableResultAndNoException<Result> callable) throws TenantNotFoundException;
 
     /**
      * This method will execute callable.call() for each provisioned tenant.
      *
-     * @param <Result>
-     * @param callable
+     * @param <Result> result type
+     * @param callable the callable
      * @return the results of the tenant executions
      */
     <Result> List<TenantResult<Result>> executeForEachTenant(CallableResultAndNoException<Result> callable);

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantNotFoundException.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/TenantNotFoundException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible
+ * contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.tenant;
+
+public class TenantNotFoundException extends RuntimeException {
+
+    public TenantNotFoundException(String tenantId) {
+        super("Tenant with id [" + tenantId + "] was not found.");
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
@@ -61,6 +61,8 @@ class AsynchronousMessageListener implements MessageListener {
         }
         try {
             String tenantId = tenantPropertyManager.getCurrentTenantId(message);
+            LOGGER.debug("Processing message WITH context for tenant [{}].", tenantId);
+
             tenantContext.execute(tenantId, () -> {
                 executeOnMessageHandler(textMsg);
                 return null;

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
@@ -32,17 +32,17 @@ class AsynchronousMessageListener implements MessageListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(AsynchronousMessageListener.class);
 
     /** The listener. */
-    private final Listener listener;
+    private final ListenerDescriptor listenerDescriptor;
     private final TenantPropertyManager tenantPropertyManager;
     private final TenantContext tenantContext;
 
     /**
      * Instantiates a new asynchronous message listener.
      *
-     * @param listener the listener
+     * @param listenerDescriptor the listener
      */
-    AsynchronousMessageListener(Listener listener, TenantPropertyManager tenantPropertyManager, TenantContext tenantContext) {
-        this.listener = listener;
+    AsynchronousMessageListener(ListenerDescriptor listenerDescriptor, TenantPropertyManager tenantPropertyManager, TenantContext tenantContext) {
+        this.listenerDescriptor = listenerDescriptor;
         this.tenantPropertyManager = tenantPropertyManager;
         this.tenantContext = tenantContext;
     }
@@ -54,9 +54,9 @@ class AsynchronousMessageListener implements MessageListener {
      */
     @Override
     public void onMessage(Message message) {
-        LOGGER.trace("Start processing a received message in [{}] by [{}] ...", listener.getDestination(), listener.getHandlerPath());
+        LOGGER.trace("Start processing a received message in [{}] by [{}] ...", listenerDescriptor.getDestination(), listenerDescriptor.getHandlerPath());
         if (!(message instanceof TextMessage textMsg)) {
-            String msg = String.format("Invalid message [%s] has been received in destination [%s]", message, listener.getDestination());
+            String msg = String.format("Invalid message [%s] has been received in destination [%s]", message, listenerDescriptor.getDestination());
             throw new IllegalStateException(msg);
         }
         try {
@@ -67,7 +67,7 @@ class AsynchronousMessageListener implements MessageListener {
                 executeOnMessageHandler(textMsg);
                 return null;
             });
-            LOGGER.trace("Done processing the received message in [{}] by [{}]", listener.getDestination(), listener.getHandlerPath());
+            LOGGER.trace("Done processing the received message in [{}] by [{}]", listenerDescriptor.getDestination(), listenerDescriptor.getHandlerPath());
         } catch (Exception e) {
             throw new IllegalStateException("Failed to handle message: " + message, e);
         }
@@ -81,7 +81,7 @@ class AsynchronousMessageListener implements MessageListener {
     private void executeOnMessageHandler(TextMessage textMsg) {
         String extractedMsg = extractMessage(textMsg);
         try (DirigibleJavascriptCodeRunner runner = createJSCodeRunner()) {
-            String handlerPath = listener.getHandlerPath();
+            String handlerPath = listenerDescriptor.getHandlerPath();
             Module module = runner.run(handlerPath);
             runner.runMethod(module, "onMessage", extractedMsg);
         }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListener.java
@@ -41,7 +41,8 @@ class AsynchronousMessageListener implements MessageListener {
      *
      * @param listenerDescriptor the listener
      */
-    AsynchronousMessageListener(ListenerDescriptor listenerDescriptor, TenantPropertyManager tenantPropertyManager, TenantContext tenantContext) {
+    AsynchronousMessageListener(ListenerDescriptor listenerDescriptor, TenantPropertyManager tenantPropertyManager,
+            TenantContext tenantContext) {
         this.listenerDescriptor = listenerDescriptor;
         this.tenantPropertyManager = tenantPropertyManager;
         this.tenantContext = tenantContext;
@@ -54,9 +55,11 @@ class AsynchronousMessageListener implements MessageListener {
      */
     @Override
     public void onMessage(Message message) {
-        LOGGER.trace("Start processing a received message in [{}] by [{}] ...", listenerDescriptor.getDestination(), listenerDescriptor.getHandlerPath());
+        LOGGER.trace("Start processing a received message in [{}] by [{}] ...", listenerDescriptor.getDestination(),
+                listenerDescriptor.getHandlerPath());
         if (!(message instanceof TextMessage textMsg)) {
-            String msg = String.format("Invalid message [%s] has been received in destination [%s]", message, listenerDescriptor.getDestination());
+            String msg = String.format("Invalid message [%s] has been received in destination [%s]", message,
+                    listenerDescriptor.getDestination());
             throw new IllegalStateException(msg);
         }
         try {
@@ -67,7 +70,8 @@ class AsynchronousMessageListener implements MessageListener {
                 executeOnMessageHandler(textMsg);
                 return null;
             });
-            LOGGER.trace("Done processing the received message in [{}] by [{}]", listenerDescriptor.getDestination(), listenerDescriptor.getHandlerPath());
+            LOGGER.trace("Done processing the received message in [{}] by [{}]", listenerDescriptor.getDestination(),
+                    listenerDescriptor.getHandlerPath());
         } catch (Exception e) {
             throw new IllegalStateException("Failed to handle message: " + message, e);
         }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerFactory.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerFactory.java
@@ -24,7 +24,7 @@ class AsynchronousMessageListenerFactory {
         this.tenantContext = tenantContext;
     }
 
-    AsynchronousMessageListener create(Listener listener) {
-        return new AsynchronousMessageListener(listener, tenantPropertyManager, tenantContext);
+    AsynchronousMessageListener create(ListenerDescriptor listenerDescriptor) {
+        return new AsynchronousMessageListener(listenerDescriptor, tenantPropertyManager, tenantContext);
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerFactory.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Eclipse Dirigible
+ * contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.listeners.service;
+
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.springframework.stereotype.Component;
+
+@Component
+class AsynchronousMessageListenerFactory {
+
+    private final TenantPropertyManager tenantPropertyManager;
+    private final TenantContext tenantContext;
+
+    AsynchronousMessageListenerFactory(TenantPropertyManager tenantPropertyManager, TenantContext tenantContext) {
+        this.tenantPropertyManager = tenantPropertyManager;
+        this.tenantContext = tenantContext;
+    }
+
+    AsynchronousMessageListener create(Listener listener) {
+        return new AsynchronousMessageListener(listener, tenantPropertyManager, tenantContext);
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
@@ -1,28 +1,20 @@
 package org.eclipse.dirigible.components.listeners.service;
 
-import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 @Component
 class DestinationNameManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DestinationNameManager.class);
-    private static final String TENANT_JOB_NAME_REGEX = "(.+)###.+";
-    private static final Pattern TENANT_DESTINATION_NAME_PATTERN = Pattern.compile(TENANT_JOB_NAME_REGEX);
 
     private final TenantContext tenantContext;
-    private final Tenant defaultTenant;
 
-    DestinationNameManager(TenantContext tenantContext, @DefaultTenant Tenant defaultTenant) {
+    DestinationNameManager(TenantContext tenantContext) {
         this.tenantContext = tenantContext;
-        this.defaultTenant = defaultTenant;
     }
 
     String toTenantName(String destinationName) {
@@ -33,10 +25,5 @@ class DestinationNameManager {
         }
         Tenant currentTenant = tenantContext.getCurrentTenant();
         return currentTenant.isDefault() ? destinationName : currentTenant.getId() + "###" + destinationName;
-    }
-
-    String extractTenantId(String tenantDestinationName) {
-        Matcher matcher = TENANT_DESTINATION_NAME_PATTERN.matcher(tenantDestinationName);
-        return matcher.matches() ? matcher.group(1) : defaultTenant.getId();
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
@@ -3,6 +3,8 @@ package org.eclipse.dirigible.components.listeners.service;
 import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.regex.Matcher;
@@ -11,6 +13,7 @@ import java.util.regex.Pattern;
 @Component
 class DestinationNameManager {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DestinationNameManager.class);
     private static final String TENANT_JOB_NAME_REGEX = "(.+)###.+";
     private static final Pattern TENANT_DESTINATION_NAME_PATTERN = Pattern.compile(TENANT_JOB_NAME_REGEX);
 
@@ -23,6 +26,11 @@ class DestinationNameManager {
     }
 
     String toTenantName(String destinationName) {
+        if (tenantContext.isNotInitialized()) {
+            LOGGER.debug("Tenant context is NOT initialized. Will return destination name as it is. Destination name [{}]",
+                    destinationName);
+            return destinationName;
+        }
         Tenant currentTenant = tenantContext.getCurrentTenant();
         return currentTenant.isDefault() ? destinationName : currentTenant.getId() + "###" + destinationName;
     }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/DestinationNameManager.java
@@ -1,0 +1,34 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+class DestinationNameManager {
+
+    private static final String TENANT_JOB_NAME_REGEX = "(.+)###.+";
+    private static final Pattern TENANT_DESTINATION_NAME_PATTERN = Pattern.compile(TENANT_JOB_NAME_REGEX);
+
+    private final TenantContext tenantContext;
+    private final Tenant defaultTenant;
+
+    DestinationNameManager(TenantContext tenantContext, @DefaultTenant Tenant defaultTenant) {
+        this.tenantContext = tenantContext;
+        this.defaultTenant = defaultTenant;
+    }
+
+    String toTenantName(String destinationName) {
+        Tenant currentTenant = tenantContext.getCurrentTenant();
+        return currentTenant.isDefault() ? destinationName : currentTenant.getId() + "###" + destinationName;
+    }
+
+    String extractTenantId(String tenantDestinationName) {
+        Matcher matcher = TENANT_DESTINATION_NAME_PATTERN.matcher(tenantDestinationName);
+        return matcher.matches() ? matcher.group(1) : defaultTenant.getId();
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/Listener.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/Listener.java
@@ -1,0 +1,70 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+import org.eclipse.dirigible.components.base.spring.BeanProvider;
+import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
+
+import java.util.Objects;
+
+class Listener {
+    private final ListenerType type;
+    private final String destination;
+    private final String handlerPath;
+
+    Listener(ListenerType type, String destination, String handlerPath) {
+        this.type = type;
+        this.destination = destination;
+        this.handlerPath = handlerPath;
+    }
+
+    ListenerType getType() {
+        return type;
+    }
+
+    String getDestination() {
+        return destination;
+    }
+
+    String getHandlerPath() {
+        return handlerPath;
+    }
+
+    @Override
+    public String toString() {
+        return "Listener{" + "type=" + type + ", destination='" + destination + '\'' + ", handlerPath='" + handlerPath + '\'' + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Listener listener = (Listener) o;
+        return type == listener.type && Objects.equals(destination, listener.destination)
+                && Objects.equals(handlerPath, listener.handlerPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, destination, handlerPath);
+    }
+
+    static Listener fromEntity(org.eclipse.dirigible.components.listeners.domain.Listener entity) {
+        ListenerType type = fromEntityType(entity.getKind());
+
+        DestinationNameManager destinationNameManager = BeanProvider.getBean(DestinationNameManager.class);
+        String destination = destinationNameManager.toTenantName(entity.getName());
+        return new Listener(type, destination, entity.getHandler());
+    }
+
+    private static ListenerType fromEntityType(ListenerKind kind) {
+        if (null == kind) {
+            throw new IllegalArgumentException("Listener kind cannot be null");
+        }
+        return switch (kind) {
+            case QUEUE -> ListenerType.QUEUE;
+            case TOPIC -> ListenerType.TOPIC;
+            default -> throw new IllegalArgumentException("Unsupported listener kind: " + kind);
+        };
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/Listener.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/Listener.java
@@ -1,8 +1,5 @@
 package org.eclipse.dirigible.components.listeners.service;
 
-import org.eclipse.dirigible.components.base.spring.BeanProvider;
-import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
-
 import java.util.Objects;
 
 class Listener {
@@ -47,24 +44,5 @@ class Listener {
     @Override
     public int hashCode() {
         return Objects.hash(type, destination, handlerPath);
-    }
-
-    static Listener fromEntity(org.eclipse.dirigible.components.listeners.domain.Listener entity) {
-        ListenerType type = fromEntityType(entity.getKind());
-
-        DestinationNameManager destinationNameManager = BeanProvider.getBean(DestinationNameManager.class);
-        String destination = destinationNameManager.toTenantName(entity.getName());
-        return new Listener(type, destination, entity.getHandler());
-    }
-
-    private static ListenerType fromEntityType(ListenerKind kind) {
-        if (null == kind) {
-            throw new IllegalArgumentException("Listener kind cannot be null");
-        }
-        return switch (kind) {
-            case QUEUE -> ListenerType.QUEUE;
-            case TOPIC -> ListenerType.TOPIC;
-            default -> throw new IllegalArgumentException("Unsupported listener kind: " + kind);
-        };
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
@@ -12,11 +12,11 @@ class ListenerCreator {
         this.destinationNameManager = destinationNameManager;
     }
 
-    Listener fromEntity(org.eclipse.dirigible.components.listeners.domain.Listener entity) {
+    ListenerDescriptor fromEntity(org.eclipse.dirigible.components.listeners.domain.Listener entity) {
         ListenerType type = fromEntityType(entity.getKind());
 
         String destination = destinationNameManager.toTenantName(entity.getName());
-        return new Listener(type, destination, entity.getHandler());
+        return new ListenerDescriptor(type, destination, entity.getHandler());
     }
 
     private ListenerType fromEntityType(ListenerKind kind) {

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerCreator.java
@@ -1,0 +1,32 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
+import org.springframework.stereotype.Component;
+
+@Component
+class ListenerCreator {
+
+    private final DestinationNameManager destinationNameManager;
+
+    ListenerCreator(DestinationNameManager destinationNameManager) {
+        this.destinationNameManager = destinationNameManager;
+    }
+
+    Listener fromEntity(org.eclipse.dirigible.components.listeners.domain.Listener entity) {
+        ListenerType type = fromEntityType(entity.getKind());
+
+        String destination = destinationNameManager.toTenantName(entity.getName());
+        return new Listener(type, destination, entity.getHandler());
+    }
+
+    private ListenerType fromEntityType(ListenerKind kind) {
+        if (null == kind) {
+            throw new IllegalArgumentException("Listener kind cannot be null");
+        }
+        return switch (kind) {
+            case QUEUE -> ListenerType.QUEUE;
+            case TOPIC -> ListenerType.TOPIC;
+            default -> throw new IllegalArgumentException("Unsupported listener kind: " + kind);
+        };
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerDescriptor.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerDescriptor.java
@@ -2,12 +2,12 @@ package org.eclipse.dirigible.components.listeners.service;
 
 import java.util.Objects;
 
-class Listener {
+class ListenerDescriptor {
     private final ListenerType type;
     private final String destination;
     private final String handlerPath;
 
-    Listener(ListenerType type, String destination, String handlerPath) {
+    ListenerDescriptor(ListenerType type, String destination, String handlerPath) {
         this.type = type;
         this.destination = destination;
         this.handlerPath = handlerPath;
@@ -36,9 +36,9 @@ class Listener {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        Listener listener = (Listener) o;
-        return type == listener.type && Objects.equals(destination, listener.destination)
-                && Objects.equals(handlerPath, listener.handlerPath);
+        ListenerDescriptor listenerDescriptor = (ListenerDescriptor) o;
+        return type == listenerDescriptor.type && Objects.equals(destination, listenerDescriptor.destination)
+                && Objects.equals(handlerPath, listenerDescriptor.handlerPath);
     }
 
     @Override

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactory.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactory.java
@@ -34,10 +34,10 @@ public class ListenerManagerFactory {
     /**
      * Creates the.
      *
-     * @param listener the listener
+     * @param listenerDescriptor the listener
      * @return the listener manager
      */
-    public ListenerManager create(Listener listener) {
-        return new ListenerManager(listener, connectionArtifactsFactory, asynchronousMessageListenerFactory);
+    public ListenerManager create(ListenerDescriptor listenerDescriptor) {
+        return new ListenerManager(listenerDescriptor, connectionArtifactsFactory, asynchronousMessageListenerFactory);
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactory.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactory.java
@@ -11,7 +11,6 @@
 package org.eclipse.dirigible.components.listeners.service;
 
 import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
-import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -23,15 +22,13 @@ public class ListenerManagerFactory {
 
     /** The connection artifacts factory. */
     private final ActiveMQConnectionArtifactsFactory connectionArtifactsFactory;
+    private final AsynchronousMessageListenerFactory asynchronousMessageListenerFactory;
 
-    /**
-     * Instantiates a new listener manager factory.
-     *
-     * @param connectionArtifactsFactory the connection artifacts factory
-     */
     @Autowired
-    public ListenerManagerFactory(ActiveMQConnectionArtifactsFactory connectionArtifactsFactory) {
+    public ListenerManagerFactory(ActiveMQConnectionArtifactsFactory connectionArtifactsFactory,
+            AsynchronousMessageListenerFactory asynchronousMessageListenerFactory) {
         this.connectionArtifactsFactory = connectionArtifactsFactory;
+        this.asynchronousMessageListenerFactory = asynchronousMessageListenerFactory;
     }
 
     /**
@@ -41,6 +38,6 @@ public class ListenerManagerFactory {
      * @return the listener manager
      */
     public ListenerManager create(Listener listener) {
-        return new ListenerManager(listener, connectionArtifactsFactory);
+        return new ListenerManager(listener, connectionArtifactsFactory, asynchronousMessageListenerFactory);
     }
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerType.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenerType.java
@@ -1,0 +1,6 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+enum ListenerType {
+
+    QUEUE, TOPIC
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class ListenersManager {
 
     /** The listeners. */
-    static final Map<Listener, ListenerManager> LISTENERS = Collections.synchronizedMap(new HashMap<>());
+    static final Map<ListenerDescriptor, ListenerManager> LISTENERS = Collections.synchronizedMap(new HashMap<>());
 
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(ListenersManager.class);
@@ -61,32 +61,32 @@ public class ListenersManager {
      * @param listenerEntity the listener
      */
     public void startListener(org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity) {
-        Listener listener = listenerCreator.fromEntity(listenerEntity);
-        if (LISTENERS.containsKey(listener)) {
-            LOGGER.warn("Message consumer for listener [{}] already running!", listener);
+        ListenerDescriptor listenerDescriptor = listenerCreator.fromEntity(listenerEntity);
+        if (LISTENERS.containsKey(listenerDescriptor)) {
+            LOGGER.warn("Message consumer for listener [{}] already running!", listenerDescriptor);
             return;
 
         }
-        if (isMissingHandler(listener)) {
-            LOGGER.error("Listener {} cannot be started, because the handler does not exist!", listener);
+        if (isMissingHandler(listenerDescriptor)) {
+            LOGGER.error("Listener {} cannot be started, because the handler does not exist!", listenerDescriptor);
             return;
         }
-        ListenerManager listenerManager = messageListenerManagerFactory.create(listener);
+        ListenerManager listenerManager = messageListenerManagerFactory.create(listenerDescriptor);
         listenerManager.startListener();
 
-        LISTENERS.put(listener, listenerManager);
-        LOGGER.info("Listener [{}] started.", listener);
+        LISTENERS.put(listenerDescriptor, listenerManager);
+        LOGGER.info("Listener [{}] started.", listenerDescriptor);
     }
 
     /**
      * Checks if is missing handler.
      *
-     * @param listener the listener
+     * @param listenerDescriptor the listener
      * @return true, if is missing handler
      */
-    private boolean isMissingHandler(Listener listener) {
+    private boolean isMissingHandler(ListenerDescriptor listenerDescriptor) {
         IResource resource = repository.getResource(
-                IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + listener.getHandlerPath());
+                IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + listenerDescriptor.getHandlerPath());
         return !resource.exists();
     }
 
@@ -110,13 +110,13 @@ public class ListenersManager {
      * @param listenerEntity the listener
      */
     public void stopListener(org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity) {
-        Listener listener = listenerCreator.fromEntity(listenerEntity);
-        ListenerManager listenerManager = LISTENERS.get(listener);
+        ListenerDescriptor listenerDescriptor = listenerCreator.fromEntity(listenerEntity);
+        ListenerManager listenerManager = LISTENERS.get(listenerDescriptor);
         if (listenerManager != null) {
             listenerManager.stopListener();
-            LISTENERS.remove(listener);
+            LISTENERS.remove(listenerDescriptor);
         } else {
-            LOGGER.warn("There is NO configured listener for [{}]", listener);
+            LOGGER.warn("There is NO configured listener for [{}]", listenerDescriptor);
         }
     }
 

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/ListenersManager.java
@@ -10,13 +10,6 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static java.text.MessageFormat.format;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
@@ -25,23 +18,29 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The Class ListenersManager.
  */
 @Component("ListenersManager")
 public class ListenersManager {
 
+    /** The listeners. */
+    static final Map<Listener, ListenerManager> LISTENERS = Collections.synchronizedMap(new HashMap<>());
+
     /** The Constant LOGGER. */
     private static final Logger LOGGER = LoggerFactory.getLogger(ListenersManager.class);
-
-    /** The listeners. */
-    static Map<String, ListenerManager> LISTENERS = Collections.synchronizedMap(new HashMap<>());
 
     /** The repository. */
     private final IRepository repository;
 
     /** The message listener manager factory. */
     private final ListenerManagerFactory messageListenerManagerFactory;
+
+    private final ListenerCreator listenerCreator;
 
     /**
      * Instantiates a new listeners manager.
@@ -50,43 +49,44 @@ public class ListenersManager {
      * @param messageListenerManagerFactory the message listener manager factory
      */
     @Autowired
-    public ListenersManager(IRepository repository, ListenerManagerFactory messageListenerManagerFactory) {
+    public ListenersManager(IRepository repository, ListenerManagerFactory messageListenerManagerFactory, ListenerCreator listenerCreator) {
         this.repository = repository;
         this.messageListenerManagerFactory = messageListenerManagerFactory;
+        this.listenerCreator = listenerCreator;
     }
 
     /**
      * Start listener.
      *
-     * @param listener the listener
+     * @param listenerEntity the listener
      */
-    public void startListener(Listener listener) {
-        if (LISTENERS.containsKey(listener.getLocation())) {
-            LOGGER.warn(format("Message consumer for listener at [{0}] already running!", listener.getLocation()));
+    public void startListener(org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity) {
+        Listener listener = listenerCreator.fromEntity(listenerEntity);
+        if (LISTENERS.containsKey(listener)) {
+            LOGGER.warn("Message consumer for listener [{}] already running!", listener);
             return;
 
         }
-        if (isMissingListener(listener)) {
-            LOGGER.error("Listener {} cannot be started, because the handler {} does not exist!", listener.getLocation(),
-                    listener.getHandler());
+        if (isMissingHandler(listener)) {
+            LOGGER.error("Listener {} cannot be started, because the handler does not exist!", listener);
             return;
         }
         ListenerManager listenerManager = messageListenerManagerFactory.create(listener);
         listenerManager.startListener();
 
-        LISTENERS.put(listener.getLocation(), listenerManager);
-        LOGGER.info("Listener started: " + listener.getLocation());
+        LISTENERS.put(listener, listenerManager);
+        LOGGER.info("Listener [{}] started.", listener);
     }
 
     /**
-     * Checks if is missing listener.
+     * Checks if is missing handler.
      *
      * @param listener the listener
-     * @return true, if is missing listener
+     * @return true, if is missing handler
      */
-    private boolean isMissingListener(Listener listener) {
-        IResource resource =
-                repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + listener.getHandler());
+    private boolean isMissingHandler(Listener listener) {
+        IResource resource = repository.getResource(
+                IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + listener.getHandlerPath());
         return !resource.exists();
     }
 
@@ -96,31 +96,27 @@ public class ListenersManager {
     public synchronized void stopListeners() {
         LOGGER.info("Stopping all background listeners...");
 
-        Iterator<Entry<String, ListenerManager>> iterator = LISTENERS.entrySet()
-                                                                     .iterator();
-        while (iterator.hasNext()) {
-            Entry<String, ListenerManager> entry = iterator.next();
-            ListenerManager listenerManager = entry.getValue();
-            if (listenerManager != null) {
-                listenerManager.stopListener();
+        LISTENERS.forEach((l, m) -> {
+            if (null != m) {
+                m.stopListener();
             }
-            iterator.remove();
-        }
+        });
+        LISTENERS.clear();
     }
 
     /**
      * Stop listener.
      *
-     * @param listener the listener
+     * @param listenerEntity the listener
      */
-    public void stopListener(Listener listener) {
-        String listenerLocation = listener.getLocation();
-        ListenerManager listenerManager = LISTENERS.get(listenerLocation);
+    public void stopListener(org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity) {
+        Listener listener = listenerCreator.fromEntity(listenerEntity);
+        ListenerManager listenerManager = LISTENERS.get(listener);
         if (listenerManager != null) {
             listenerManager.stopListener();
-            LISTENERS.remove(listenerLocation);
+            LISTENERS.remove(listener);
         } else {
-            LOGGER.warn("There is NO configured listener for [{}]", listenerLocation);
+            LOGGER.warn("There is NO configured listener for [{}]", listener);
         }
     }
 

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/MessageProducer.java
@@ -10,16 +10,12 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
+import jakarta.jms.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import jakarta.jms.DeliveryMode;
-import jakarta.jms.Destination;
-import jakarta.jms.JMSException;
-import jakarta.jms.Session;
-import jakarta.jms.TextMessage;
 
 /**
  * The Class MessageProducer.
@@ -32,15 +28,15 @@ public class MessageProducer {
 
     /** The session. */
     private final Session session;
+    private final DestinationNameManager destinationNameManager;
+    private final TenantPropertyManager tenantPropertyManager;
 
-    /**
-     * Instantiates a new message producer.
-     *
-     * @param session the session
-     */
     @Autowired
-    public MessageProducer(@Qualifier("ActiveMQSession") Session session) {
+    MessageProducer(@Qualifier("ActiveMQSession") Session session, DestinationNameManager destinationNameManager,
+            TenantPropertyManager tenantPropertyManager) {
         this.session = session;
+        this.destinationNameManager = destinationNameManager;
+        this.tenantPropertyManager = tenantPropertyManager;
     }
 
     /**
@@ -51,19 +47,8 @@ public class MessageProducer {
      * @throws JMSException the JMS exception
      */
     public void sendMessageToTopic(String topic, String message) throws JMSException {
-        Destination destination = session.createTopic(topic);
-        sendMessage(message, destination);
-    }
-
-    /**
-     * Send message to queue.
-     *
-     * @param queue the queue
-     * @param message the message
-     * @throws JMSException the JMS exception
-     */
-    public void sendMessageToQueue(String queue, String message) throws JMSException {
-        Destination destination = session.createQueue(queue);
+        String destinationName = destinationNameManager.toTenantName(topic);
+        Destination destination = session.createTopic(destinationName);
         sendMessage(message, destination);
     }
 
@@ -79,10 +64,24 @@ public class MessageProducer {
             producer.setDeliveryMode(DeliveryMode.PERSISTENT);
 
             TextMessage textMessage = session.createTextMessage(message);
+            tenantPropertyManager.setCurrentTenant(textMessage);
 
             producer.send(textMessage);
             LOGGER.trace("Message sent in [{}]", destination);
         }
+    }
+
+    /**
+     * Send message to queue.
+     *
+     * @param queue the queue
+     * @param message the message
+     * @throws JMSException the JMS exception
+     */
+    public void sendMessageToQueue(String queue, String message) throws JMSException {
+        String destinationName = destinationNameManager.toTenantName(queue);
+        Destination destination = session.createQueue(destinationName);
+        sendMessage(message, destination);
     }
 
 }

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
@@ -1,0 +1,38 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.springframework.stereotype.Component;
+
+@Component
+class TenantPropertyManager {
+
+    private static final String TENANT_ID_PARAM_NAME = "tenant_id";
+
+    private final TenantContext tenantContext;
+
+    TenantPropertyManager(TenantContext tenantContext) {
+        this.tenantContext = tenantContext;
+    }
+
+    void setCurrentTenant(Message message) throws JMSException {
+        Tenant currentTenant = tenantContext.getCurrentTenant();
+        message.setObjectProperty(TENANT_ID_PARAM_NAME, currentTenant.getId());
+    }
+
+    String getCurrentTenantId(Message message) throws JMSException {
+        Object tenantId = message.getObjectProperty(TENANT_ID_PARAM_NAME);
+        if (null == tenantId) {
+            throw new IllegalArgumentException(
+                    "There is no tenant id parameter with name [" + TENANT_ID_PARAM_NAME + "] in message: " + message);
+        }
+        if (tenantId instanceof String tenantIdString) {
+            return tenantIdString;
+        } else {
+            throw new IllegalArgumentException(
+                    "Invalid tenant id param [{" + tenantId + "}] with name [" + TENANT_ID_PARAM_NAME + "] in message: " + message);
+        }
+    }
+}

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/service/TenantPropertyManager.java
@@ -2,31 +2,43 @@ package org.eclipse.dirigible.components.listeners.service;
 
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
 import org.eclipse.dirigible.components.base.tenant.Tenant;
 import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 class TenantPropertyManager {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TenantPropertyManager.class);
     private static final String TENANT_ID_PARAM_NAME = "tenant_id";
 
     private final TenantContext tenantContext;
+    private final Tenant defualtTenant;
 
-    TenantPropertyManager(TenantContext tenantContext) {
+    TenantPropertyManager(TenantContext tenantContext, @DefaultTenant Tenant defualtTenant) {
         this.tenantContext = tenantContext;
+        this.defualtTenant = defualtTenant;
     }
 
     void setCurrentTenant(Message message) throws JMSException {
-        Tenant currentTenant = tenantContext.getCurrentTenant();
-        message.setObjectProperty(TENANT_ID_PARAM_NAME, currentTenant.getId());
+        String tenantId = getCurrentTenantId();
+        LOGGER.debug("Will set tenant id [{}].", tenantId);
+        message.setObjectProperty(TENANT_ID_PARAM_NAME, getCurrentTenantId());
+    }
+
+    private String getCurrentTenantId() {
+        return tenantContext.isNotInitialized() ? defualtTenant.getId()
+                : tenantContext.getCurrentTenant()
+                               .getId();
     }
 
     String getCurrentTenantId(Message message) throws JMSException {
         Object tenantId = message.getObjectProperty(TENANT_ID_PARAM_NAME);
         if (null == tenantId) {
-            throw new IllegalArgumentException(
-                    "There is no tenant id parameter with name [" + TENANT_ID_PARAM_NAME + "] in message: " + message);
+            throw new IllegalArgumentException("Tenant id parameter [" + TENANT_ID_PARAM_NAME + "] cannot be null in message: " + message);
         }
         if (tenantId instanceof String tenantIdString) {
             return tenantIdString;

--- a/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/synchronizer/ListenerSynchronizer.java
+++ b/components/engine/engine-listeners/src/main/java/org/eclipse/dirigible/components/listeners/synchronizer/ListenerSynchronizer.java
@@ -19,7 +19,7 @@ import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
 import org.eclipse.dirigible.components.base.artefact.ArtefactService;
 import org.eclipse.dirigible.components.base.artefact.topology.TopologyWrapper;
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
-import org.eclipse.dirigible.components.base.synchronizer.BaseSynchronizer;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantBaseSynchronizer;
 import org.eclipse.dirigible.components.base.synchronizer.SynchronizerCallback;
 import org.eclipse.dirigible.components.base.synchronizer.SynchronizersOrder;
 import org.eclipse.dirigible.components.listeners.domain.Listener;
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @Order(SynchronizersOrder.LISTENER)
-public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
+public class ListenerSynchronizer extends MultitenantBaseSynchronizer<Listener, Long> {
 
     /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(ListenerSynchronizer.class);
@@ -149,9 +149,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
                         getService().save(listener);
                         callback.registerState(this, wrapper, ArtefactLifecycle.CREATED, "");
                     } catch (Exception e) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error(e.getMessage(), e);
-                        }
+                        logger.error(e.getMessage(), e);
                         callback.addError(e.getMessage());
                         callback.registerState(this, wrapper, ArtefactLifecycle.CREATED, e.getMessage());
                     }
@@ -168,9 +166,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
                         getService().save(listener);
                         callback.registerState(this, wrapper, ArtefactLifecycle.UPDATED, "");
                     } catch (Exception e) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error(e.getMessage(), e);
-                        }
+                        logger.error(e.getMessage(), e);
                         callback.addError(e.getMessage());
                         callback.registerState(this, wrapper, ArtefactLifecycle.DELETED, e.getMessage());
                     }
@@ -188,9 +184,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
                         getService().delete(listener);
                         callback.registerState(this, wrapper, ArtefactLifecycle.DELETED, "");
                     } catch (Exception e) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error(e.getMessage(), e);
-                        }
+                        logger.error(e.getMessage(), e);
                         callback.addError(e.getMessage());
                         callback.registerState(this, wrapper, ArtefactLifecycle.DELETED, e.getMessage());
                     }
@@ -203,9 +197,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
                         listener.setRunning(true);
                         getService().save(listener);
                     } catch (Exception e) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error(e.getMessage(), e);
-                        }
+                        logger.error(e.getMessage(), e);
                         callback.addError(e.getMessage());
                         callback.registerState(this, wrapper, ArtefactLifecycle.CREATED, "");
                     }
@@ -218,9 +210,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
                         listener.setRunning(false);
                         getService().save(listener);
                     } catch (Exception e) {
-                        if (logger.isErrorEnabled()) {
-                            logger.error(e.getMessage(), e);
-                        }
+                        logger.error(e.getMessage(), e);
                         callback.addError(e.getMessage());
                         callback.registerState(this, wrapper, ArtefactLifecycle.CREATED, "");
                     }
@@ -242,9 +232,7 @@ public class ListenerSynchronizer extends BaseSynchronizer<Listener, Long> {
             listenersManager.stopListener(listener);
             getService().delete(listener);
         } catch (Exception e) {
-            if (logger.isErrorEnabled()) {
-                logger.error(e.getMessage(), e);
-            }
+            logger.error(e.getMessage(), e);
             callback.addError(e.getMessage());
             callback.registerState(this, listener, ArtefactLifecycle.DELETED, e.getMessage());
         }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/endpoint/ListenerEndpointTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/endpoint/ListenerEndpointTest.java
@@ -10,9 +10,9 @@
  */
 package org.eclipse.dirigible.components.listeners.endpoint;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
 import org.eclipse.dirigible.components.listeners.repository.ListenerRepository;
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
@@ -33,6 +34,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * The Class ListenerEndpointTest.
@@ -46,21 +51,33 @@ import org.springframework.web.context.WebApplicationContext;
 @DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 public class ListenerEndpointTest {
 
-    /** The listener service. */
-    @Autowired
-    private ListenerService listenerService;
-
-    /** The listener repository. */
-    @Autowired
-    private ListenerRepository listenerRepository;
-
-    /** The mock mvc. */
-    @Autowired
-    private MockMvc mockMvc;
-
     /** The wac. */
     @Autowired
     protected WebApplicationContext wac;
+    /** The listener service. */
+    @Autowired
+    private ListenerService listenerService;
+    /** The listener repository. */
+    @Autowired
+    private ListenerRepository listenerRepository;
+    /** The mock mvc. */
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private TenantContext tenantContext;
+
+    @MockBean
+    @DefaultTenant
+    private Tenant tenant;
+
+
+    /**
+     * The Class TestConfiguration.
+     */
+    @SpringBootApplication
+    static class TestConfiguration {
+        // it is needed
+    }
 
     /**
      * Setup.
@@ -92,13 +109,5 @@ public class ListenerEndpointTest {
         mockMvc.perform(get("/services/listeners"))
                .andDo(print())
                .andExpect(status().is2xxSuccessful());
-    }
-
-    /**
-     * The Class TestConfiguration.
-     */
-    @SpringBootApplication
-    static class TestConfiguration {
-        // it is needed
     }
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/repository/ListenerRepositoryTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/repository/ListenerRepositoryTest.java
@@ -10,11 +10,10 @@
  */
 package org.eclipse.dirigible.components.listeners.repository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import java.util.List;
-import java.util.Optional;
 import jakarta.persistence.EntityManager;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
 import org.junit.jupiter.api.AfterEach;
@@ -25,10 +24,17 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * The Class ListenerRepositoryTest.
@@ -47,7 +53,22 @@ public class ListenerRepositoryTest {
 
     /** The entity manager. */
     @Autowired
-    EntityManager entityManager;
+    private EntityManager entityManager;
+
+    @MockBean
+    private TenantContext tenantContext;
+
+    @MockBean
+    @DefaultTenant
+    private Tenant tenant;
+
+
+    /**
+     * The Class TestConfiguration.
+     */
+    @SpringBootApplication
+    static class TestConfiguration {
+    }
 
     /**
      * Setup.
@@ -105,12 +126,5 @@ public class ListenerRepositoryTest {
         Listener listener = entityManager.getReference(Listener.class, id);
         assertNotNull(listener);
         assertEquals("/a/b/c/l1.listener", listener.getLocation());
-    }
-
-    /**
-     * The Class TestConfiguration.
-     */
-    @SpringBootApplication
-    static class TestConfiguration {
     }
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerTest.java
@@ -10,30 +10,26 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static org.junit.Assert.assertThrows;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import jakarta.jms.BytesMessage;
 import jakarta.jms.JMSException;
 import jakarta.jms.TextMessage;
-import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner;
 import org.eclipse.dirigible.graalium.core.javascript.modules.Module;
-import org.graalvm.polyglot.Value;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
+
 /**
  * The Class BackgroundMessageListenerTest.
  */
 @SuppressWarnings("resource")
 @ExtendWith(MockitoExtension.class)
-class MessageListenerTest {
+class AsynchronousMessageListenerTest {
 
     /** The Constant MESSAGE. */
     private static final String MESSAGE = "This is a test message";
@@ -41,8 +37,10 @@ class MessageListenerTest {
     /** The Constant HANDLER. */
     private static final String HANDLER = "test-handler";
 
+    private static final String TENANT_ID = "1e7252b1-3bca-4285-bd4e-60e19886d063";
+
     /** The background message listener. */
-    private AsynchronousMessageListener backgroundMessageListener;
+    private AsynchronousMessageListener asyncMessageListener;
 
     /** The js code runner. */
     @Mock
@@ -64,16 +62,15 @@ class MessageListenerTest {
     @Mock
     private Module module;
 
-    /** The value. */
     @Mock
-    private Value value;
+    private TenantPropertyManager tenantPropertyManager;
 
     /**
      * Sets the up.
      */
     @BeforeEach
     void setUp() {
-        backgroundMessageListener = spy(new AsynchronousMessageListener(listener));
+        asyncMessageListener = spy(new AsynchronousMessageListener(listener, tenantPropertyManager, new TestTenantContext()));
     }
 
     /**
@@ -83,16 +80,16 @@ class MessageListenerTest {
      */
     @Test
     void testOnMessage() throws JMSException {
-        doReturn(jsCodeRunner).when(backgroundMessageListener)
+        when(tenantPropertyManager.getCurrentTenantId(textMessage)).thenReturn(TENANT_ID);
+        doReturn(jsCodeRunner).when(asyncMessageListener)
                               .createJSCodeRunner();
-        when(listener.getHandler()).thenReturn(HANDLER);
+        when(listener.getHandlerPath()).thenReturn(HANDLER);
         when(textMessage.getText()).thenReturn(MESSAGE);
         when(jsCodeRunner.run(HANDLER)).thenReturn(module);
 
-        backgroundMessageListener.onMessage(textMessage);
+        asyncMessageListener.onMessage(textMessage);
 
         verify(jsCodeRunner).runMethod(module, "onMessage", MESSAGE);
-
     }
 
     /**
@@ -104,7 +101,7 @@ class MessageListenerTest {
     void testOnMessageFailedToExtractMessage() throws JMSException {
         when(textMessage.getText()).thenThrow(JMSException.class);
 
-        assertThrows(IllegalStateException.class, () -> backgroundMessageListener.onMessage(textMessage));
+        assertThrows(IllegalStateException.class, () -> asyncMessageListener.onMessage(textMessage));
     }
 
     /**
@@ -112,7 +109,7 @@ class MessageListenerTest {
      */
     @Test
     void testOnMessageWithUnsupportedMessage() {
-        assertThrows(IllegalStateException.class, () -> backgroundMessageListener.onMessage(bytesMessage));
+        assertThrows(IllegalStateException.class, () -> asyncMessageListener.onMessage(bytesMessage));
     }
 
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/AsynchronousMessageListenerTest.java
@@ -52,7 +52,7 @@ class AsynchronousMessageListenerTest {
 
     /** The listener. */
     @Mock
-    private Listener listener;
+    private ListenerDescriptor listenerDescriptor;
 
     /** The bytes message. */
     @Mock
@@ -70,7 +70,7 @@ class AsynchronousMessageListenerTest {
      */
     @BeforeEach
     void setUp() {
-        asyncMessageListener = spy(new AsynchronousMessageListener(listener, tenantPropertyManager, new TestTenantContext()));
+        asyncMessageListener = spy(new AsynchronousMessageListener(listenerDescriptor, tenantPropertyManager, new TestTenantContext()));
     }
 
     /**
@@ -83,7 +83,7 @@ class AsynchronousMessageListenerTest {
         when(tenantPropertyManager.getCurrentTenantId(textMessage)).thenReturn(TENANT_ID);
         doReturn(jsCodeRunner).when(asyncMessageListener)
                               .createJSCodeRunner();
-        when(listener.getHandlerPath()).thenReturn(HANDLER);
+        when(listenerDescriptor.getHandlerPath()).thenReturn(HANDLER);
         when(textMessage.getText()).thenReturn(MESSAGE);
         when(jsCodeRunner.run(HANDLER)).thenReturn(module);
 

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactoryTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactoryTest.java
@@ -37,14 +37,14 @@ class ListenerManagerFactoryTest {
 
     /** The listener. */
     @Mock
-    private Listener listener;
+    private ListenerDescriptor listenerDescriptor;
 
     /**
      * Test create.
      */
     @Test
     void testCreate() {
-        ListenerManager manager = factory.create(listener);
+        ListenerManager manager = factory.create(listenerDescriptor);
 
         assertThat(manager).isNotNull();
     }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactoryTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerFactoryTest.java
@@ -10,24 +10,26 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.eclipse.dirigible.components.listeners.config.ActiveMQConnectionArtifactsFactory;
-import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * The Class BackgroundListenerManagerFactoryTest.
  */
 @ExtendWith(MockitoExtension.class)
 class ListenerManagerFactoryTest {
-
     /** The factory. */
     @InjectMocks
     private ListenerManagerFactory factory;
+
+    @Mock
+    private AsynchronousMessageListenerFactory asynchronousMessageListenerFactory;
 
     /** The connection artifacts factory. */
     @Mock

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenerManagerTest.java
@@ -45,7 +45,7 @@ class ListenerManagerTest {
 
     /** The listener. */
     @Mock
-    private Listener listener;
+    private ListenerDescriptor listenerDescriptor;
 
     /** The connection artifacts factory. */
     @Mock
@@ -87,7 +87,7 @@ class ListenerManagerTest {
 
     @BeforeEach
     void setUp() {
-        lenient().when(asynchronousMessageListenerFactory.create(listener))
+        lenient().when(asynchronousMessageListenerFactory.create(listenerDescriptor))
                  .thenReturn(asynchronousMessageListener);
     }
 
@@ -109,7 +109,7 @@ class ListenerManagerTest {
      */
     @Test
     void testStartListenerForUnsupportedListenerType() {
-        when(listener.getType()).thenReturn(null);
+        when(listenerDescriptor.getType()).thenReturn(null);
 
         assertThrows(IllegalArgumentException.class, () -> manager.startListener());
     }
@@ -122,8 +122,8 @@ class ListenerManagerTest {
     @Test
     void testStartListenerForQueue() throws JMSException {
         mockConnectionAndSession();
-        when(listener.getType()).thenReturn(ListenerType.QUEUE);
-        when(listener.getDestination()).thenReturn(QUEUE);
+        when(listenerDescriptor.getType()).thenReturn(ListenerType.QUEUE);
+        when(listenerDescriptor.getDestination()).thenReturn(QUEUE);
 
         when(session.createQueue(QUEUE)).thenReturn(queue);
         when(session.createConsumer(queue)).thenReturn(consumer);
@@ -204,8 +204,8 @@ class ListenerManagerTest {
     @Test
     void testStartListenerForTopic() throws JMSException {
         mockConnectionAndSession();
-        when(listener.getType()).thenReturn(ListenerType.TOPIC);
-        when(listener.getDestination()).thenReturn(TOPIC);
+        when(listenerDescriptor.getType()).thenReturn(ListenerType.TOPIC);
+        when(listenerDescriptor.getDestination()).thenReturn(TOPIC);
 
         when(session.createTopic(TOPIC)).thenReturn(topic);
         when(session.createConsumer(topic)).thenReturn(consumer);

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenersManagerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenersManagerTest.java
@@ -10,12 +10,6 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.IResource;
@@ -25,6 +19,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
 
 /**
  * The Class BackgroundListenersManagerTest.
@@ -50,13 +46,16 @@ class ListenersManagerTest {
     @Mock
     private ListenerManagerFactory messageListenerManagerFactory;
 
-    /** The listener. */
+    /** The listenerEntity. */
     @Mock
-    private Listener listener;
+    private org.eclipse.dirigible.components.listeners.domain.Listener listenerEntity;
 
     /** The resource. */
     @Mock
     private IResource resource;
+
+    @Mock
+    private ListenerCreator listenerCreator;
 
     /** The listener manager. */
     @Mock
@@ -66,24 +65,30 @@ class ListenersManagerTest {
     @Mock
     private ListenerManager listenerManager2;
 
+    @Mock
+    private Listener listener;
+
+    @Mock
+    private Listener listener2;
+
     /**
      * Sets the up.
      */
     @BeforeEach
     void setUp() {
         ListenersManager.LISTENERS.clear();
-        lenient().when(listener.getLocation())
-                 .thenReturn(LISTNER_LOCATION);
+        lenient().when(listenerCreator.fromEntity(listenerEntity))
+                 .thenReturn(listener);
     }
 
     /**
      * Test start listener on try to start the listner again.
      */
     @Test
-    void testStartListenerOnTryToStartTheListnerAgain() {
+    void testStartListenerOnTryToStartTheListenerAgain() {
         testStartListenerOnExistingListener();
 
-        listenersManager.startListener(listener);
+        listenersManager.startListener(listenerEntity);
 
         verifyNoMoreInteractions(listenerManager);
     }
@@ -93,13 +98,13 @@ class ListenersManagerTest {
      */
     @Test
     void testStartListenerOnExistingListener() {
-        when(listener.getHandler()).thenReturn(HANDLER);
-        when(repository.getResource(
-                    IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(resource);
+        when(listener.getHandlerPath()).thenReturn(HANDLER);
+        when(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(
+                resource);
         when(resource.exists()).thenReturn(true);
         when(messageListenerManagerFactory.create(listener)).thenReturn(listenerManager);
 
-        listenersManager.startListener(listener);
+        listenersManager.startListener(listenerEntity);
 
         verify(listenerManager).startListener();
     }
@@ -109,12 +114,12 @@ class ListenersManagerTest {
      */
     @Test
     void testStartListenerOnMissingListener() {
-        when(listener.getHandler()).thenReturn(HANDLER);
-        when(repository.getResource(
-                IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(resource);
+        when(listener.getHandlerPath()).thenReturn(HANDLER);
+        when(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(
+                resource);
         when(resource.exists()).thenReturn(false);
 
-        listenersManager.startListener(listener);
+        listenersManager.startListener(listenerEntity);
 
         verifyNoInteractions(messageListenerManagerFactory);
     }
@@ -124,10 +129,10 @@ class ListenersManagerTest {
      */
     @Test
     void testStopListener() {
-        ListenersManager.LISTENERS.put(LISTNER_LOCATION, listenerManager);
+        ListenersManager.LISTENERS.put(listener, listenerManager);
 
-        listenersManager.stopListener(listener);
-        listenersManager.stopListener(listener);
+        listenersManager.stopListener(listenerEntity);
+        listenersManager.stopListener(listenerEntity);
 
         // stop is called only once
         verify(listenerManager).stopListener();
@@ -138,8 +143,8 @@ class ListenersManagerTest {
      */
     @Test
     void testStopListeners() {
-        ListenersManager.LISTENERS.put(LISTNER_LOCATION, listenerManager);
-        ListenersManager.LISTENERS.put("my-listener2", listenerManager2);
+        ListenersManager.LISTENERS.put(listener, listenerManager);
+        ListenersManager.LISTENERS.put(listener2, listenerManager2);
 
         listenersManager.stopListeners();
         listenersManager.stopListeners();

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenersManagerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/ListenersManagerTest.java
@@ -66,10 +66,10 @@ class ListenersManagerTest {
     private ListenerManager listenerManager2;
 
     @Mock
-    private Listener listener;
+    private ListenerDescriptor listenerDescriptor;
 
     @Mock
-    private Listener listener2;
+    private ListenerDescriptor listenerDescriptor2;
 
     /**
      * Sets the up.
@@ -78,7 +78,7 @@ class ListenersManagerTest {
     void setUp() {
         ListenersManager.LISTENERS.clear();
         lenient().when(listenerCreator.fromEntity(listenerEntity))
-                 .thenReturn(listener);
+                 .thenReturn(listenerDescriptor);
     }
 
     /**
@@ -98,11 +98,11 @@ class ListenersManagerTest {
      */
     @Test
     void testStartListenerOnExistingListener() {
-        when(listener.getHandlerPath()).thenReturn(HANDLER);
+        when(listenerDescriptor.getHandlerPath()).thenReturn(HANDLER);
         when(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(
                 resource);
         when(resource.exists()).thenReturn(true);
-        when(messageListenerManagerFactory.create(listener)).thenReturn(listenerManager);
+        when(messageListenerManagerFactory.create(listenerDescriptor)).thenReturn(listenerManager);
 
         listenersManager.startListener(listenerEntity);
 
@@ -114,7 +114,7 @@ class ListenersManagerTest {
      */
     @Test
     void testStartListenerOnMissingListener() {
-        when(listener.getHandlerPath()).thenReturn(HANDLER);
+        when(listenerDescriptor.getHandlerPath()).thenReturn(HANDLER);
         when(repository.getResource(IRepositoryStructure.PATH_REGISTRY_PUBLIC + IRepositoryStructure.SEPARATOR + HANDLER)).thenReturn(
                 resource);
         when(resource.exists()).thenReturn(false);
@@ -129,7 +129,7 @@ class ListenersManagerTest {
      */
     @Test
     void testStopListener() {
-        ListenersManager.LISTENERS.put(listener, listenerManager);
+        ListenersManager.LISTENERS.put(listenerDescriptor, listenerManager);
 
         listenersManager.stopListener(listenerEntity);
         listenersManager.stopListener(listenerEntity);
@@ -143,8 +143,8 @@ class ListenersManagerTest {
      */
     @Test
     void testStopListeners() {
-        ListenersManager.LISTENERS.put(listener, listenerManager);
-        ListenersManager.LISTENERS.put(listener2, listenerManager2);
+        ListenersManager.LISTENERS.put(listenerDescriptor, listenerManager);
+        ListenersManager.LISTENERS.put(listenerDescriptor2, listenerManager2);
 
         listenersManager.stopListeners();
         listenersManager.stopListeners();

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageConsumerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageConsumerTest.java
@@ -10,20 +10,18 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.mockito.Mockito.when;
-import jakarta.jms.BytesMessage;
-import jakarta.jms.JMSException;
-import jakarta.jms.Queue;
-import jakarta.jms.Session;
-import jakarta.jms.TextMessage;
-import jakarta.jms.Topic;
+import jakarta.jms.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.IllegalStateException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.when;
 
 /**
  * The Class MessageConsumerTest.
@@ -35,6 +33,8 @@ class MessageConsumerTest {
     /** The Constant QUEUE. */
     private static final String QUEUE = "test-queue";
 
+    private static final String TENANT_QUEUE = "1e7252b1-3bca-4285-bd4e-60e19886d063###test-queue";
+
     /** The Constant TIMEOUT. */
     private static final long TIMEOUT = 100L;
 
@@ -43,6 +43,8 @@ class MessageConsumerTest {
 
     /** The Constant TOPIC. */
     private static final String TOPIC = "test-topic";
+
+    private static final String TENANT_TOPIC = "1e7252b1-3bca-4285-bd4e-60e19886d063###test-topic";
 
     /** The consumer. */
     @InjectMocks
@@ -72,6 +74,9 @@ class MessageConsumerTest {
     @Mock
     private BytesMessage byteMessage;
 
+    @Mock
+    private DestinationNameManager destinationNameManager;
+
     /**
      * Test receive message from queue.
      *
@@ -80,7 +85,8 @@ class MessageConsumerTest {
      */
     @Test
     void testReceiveMessageFromQueue() throws TimeoutException, JMSException {
-        when(session.createQueue(QUEUE)).thenReturn(queue);
+        when(destinationNameManager.toTenantName(QUEUE)).thenReturn(TENANT_QUEUE);
+        when(session.createQueue(TENANT_QUEUE)).thenReturn(queue);
         when(session.createConsumer(queue)).thenReturn(jsmConsumer);
         when(jsmConsumer.receive(TIMEOUT)).thenReturn(txtMessage);
         when(txtMessage.getText()).thenReturn(MESSAGE);
@@ -98,11 +104,12 @@ class MessageConsumerTest {
      */
     @Test
     void testReceiveMessageFromQueueOnTimeout() throws TimeoutException, JMSException {
-        when(session.createQueue(QUEUE)).thenReturn(queue);
+        when(destinationNameManager.toTenantName(QUEUE)).thenReturn(TENANT_QUEUE);
+        when(session.createQueue(TENANT_QUEUE)).thenReturn(queue);
         when(session.createConsumer(queue)).thenReturn(jsmConsumer);
         when(jsmConsumer.receive(TIMEOUT)).thenReturn(null);
 
-        assertThrows(TimeoutException.class, ()->  consumer.receiveMessageFromQueue(QUEUE, TIMEOUT));
+        assertThrows(TimeoutException.class, () -> consumer.receiveMessageFromQueue(QUEUE, TIMEOUT));
     }
 
     /**
@@ -113,11 +120,12 @@ class MessageConsumerTest {
      */
     @Test
     void testReceiveMessageFromQueueOnUnsupportedMessageIsReceived() throws TimeoutException, JMSException {
-        when(session.createQueue(QUEUE)).thenReturn(queue);
+        when(destinationNameManager.toTenantName(QUEUE)).thenReturn(TENANT_QUEUE);
+        when(session.createQueue(TENANT_QUEUE)).thenReturn(queue);
         when(session.createConsumer(queue)).thenReturn(jsmConsumer);
         when(jsmConsumer.receive(TIMEOUT)).thenReturn(byteMessage);
 
-        assertThrows(IllegalStateException.class, ()->  consumer.receiveMessageFromQueue(QUEUE, TIMEOUT));
+        assertThrows(IllegalStateException.class, () -> consumer.receiveMessageFromQueue(QUEUE, TIMEOUT));
     }
 
     /**
@@ -127,7 +135,8 @@ class MessageConsumerTest {
      */
     @Test
     void testReceiveMessageFromTopic() throws JMSException {
-        when(session.createTopic(TOPIC)).thenReturn(topic);
+        when(destinationNameManager.toTenantName(TOPIC)).thenReturn(TENANT_TOPIC);
+        when(session.createTopic(TENANT_TOPIC)).thenReturn(topic);
         when(session.createConsumer(topic)).thenReturn(jsmConsumer);
         when(jsmConsumer.receive(TIMEOUT)).thenReturn(txtMessage);
         when(txtMessage.getText()).thenReturn(MESSAGE);
@@ -144,11 +153,12 @@ class MessageConsumerTest {
      */
     @Test
     void testReceiveMessageFromTopicOnTimeout() throws JMSException {
-        when(session.createTopic(TOPIC)).thenReturn(topic);
+        when(destinationNameManager.toTenantName(TOPIC)).thenReturn(TENANT_TOPIC);
+        when(session.createTopic(TENANT_TOPIC)).thenReturn(topic);
         when(session.createConsumer(topic)).thenReturn(jsmConsumer);
         when(jsmConsumer.receive(TIMEOUT)).thenReturn(null);
 
-        assertThrows(TimeoutException.class, ()->  consumer.receiveMessageFromTopic(TOPIC, TIMEOUT));
+        assertThrows(TimeoutException.class, () -> consumer.receiveMessageFromTopic(TOPIC, TIMEOUT));
     }
 
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageProducerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/MessageProducerTest.java
@@ -10,18 +10,15 @@
  */
 package org.eclipse.dirigible.components.listeners.service;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import jakarta.jms.JMSException;
-import jakarta.jms.Queue;
-import jakarta.jms.Session;
-import jakarta.jms.TextMessage;
-import jakarta.jms.Topic;
+import jakarta.jms.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * The Class MessageProducerTest.
@@ -32,36 +29,37 @@ class MessageProducerTest {
 
     /** The Constant QUEUE. */
     private static final String QUEUE = "test-queue";
+    private static final String TENANT_QUEUE = "1e7252b1-3bca-4285-bd4e-60e19886d063###test-queue";
 
     /** The Constant MESSAGE. */
     private static final String MESSAGE = "This is a test message";
 
     /** The Constant TOPIC. */
     private static final String TOPIC = "test-topic";
+    private static final String TENANT_TOPIC = "1e7252b1-3bca-4285-bd4e-60e19886d063###test-topic";
 
     /** The producer. */
     @InjectMocks
     private MessageProducer producer;
-
     /** The session. */
     @Mock
     private Session session;
-
     /** The jsm producer. */
     @Mock
     private jakarta.jms.MessageProducer jsmProducer;
-
     /** The queue. */
     @Mock
     private Queue queue;
-
     /** The topic. */
     @Mock
     private Topic topic;
-
     /** The txt message. */
     @Mock
     private TextMessage txtMessage;
+    @Mock
+    private DestinationNameManager destinationNameManager;
+    @Mock
+    private TenantPropertyManager tenantPropertyManager;
 
     /**
      * Test send message to topic.
@@ -70,13 +68,15 @@ class MessageProducerTest {
      */
     @Test
     void testSendMessageToTopic() throws JMSException {
-        when(session.createTopic(TOPIC)).thenReturn(topic);
+        when(destinationNameManager.toTenantName(TOPIC)).thenReturn(TENANT_TOPIC);
+        when(session.createTopic(TENANT_TOPIC)).thenReturn(topic);
         when(session.createProducer(topic)).thenReturn(jsmProducer);
         when(session.createTextMessage(MESSAGE)).thenReturn(txtMessage);
 
         producer.sendMessageToTopic(TOPIC, MESSAGE);
 
         verify(jsmProducer).send(txtMessage);
+        verify(tenantPropertyManager).setCurrentTenant(txtMessage);
     }
 
     /**
@@ -86,13 +86,15 @@ class MessageProducerTest {
      */
     @Test
     void testSendMessageToQueue() throws JMSException {
-        when(session.createQueue(QUEUE)).thenReturn(queue);
+        when(destinationNameManager.toTenantName(QUEUE)).thenReturn(TENANT_QUEUE);
+        when(session.createQueue(TENANT_QUEUE)).thenReturn(queue);
         when(session.createProducer(queue)).thenReturn(jsmProducer);
         when(session.createTextMessage(MESSAGE)).thenReturn(txtMessage);
 
         producer.sendMessageToQueue(QUEUE, MESSAGE);
 
         verify(jsmProducer).send(txtMessage);
+        verify(tenantPropertyManager).setCurrentTenant(txtMessage);
     }
 
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/TestTenantContext.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/TestTenantContext.java
@@ -95,15 +95,15 @@ public class TestTenantContext implements TenantContext {
     }
 
     @Override
-    public void execute(Tenant tenant, CallableNoResultAndException callable) throws Exception {
-        callable.call();
+    public <Result> Result executeWithPossibleException(Tenant tenant, CallableResultAndException<Result> callable) throws Exception {
+        return callable.call();
     }
 
     @Override
     public <Result> List<TenantResult<Result>> executeForEachTenant(CallableResultAndNoException<Result> callable) {
         Result result = callable.call();
         Tenant tenant = new TestTenant(TENANT_ID, TENANT_NAME, TENANT_SUBDOMAIN, DEFUALT_TENANT);
-        TenantResult<Result> tr = new TestTenantResult<Result>(tenant, result);
+        TenantResult<Result> tr = new TestTenantResult<>(tenant, result);
         return List.of(tr);
     }
 }

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/TestTenantContext.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/service/TestTenantContext.java
@@ -1,0 +1,109 @@
+package org.eclipse.dirigible.components.listeners.service;
+
+import org.eclipse.dirigible.components.base.tenant.*;
+
+import java.util.List;
+
+public class TestTenantContext implements TenantContext {
+
+    private static final String TENANT_ID = "1e7252b1-3bca-4285-bd4e-60e19886d063";
+    private static final String TENANT_NAME = "test-tenant";
+    private static final String TENANT_SUBDOMAIN = "test";
+    private static final boolean DEFUALT_TENANT = false;
+
+
+    private static class TestTenantResult<Result> implements TenantResult<Result> {
+
+        private final Tenant tenant;
+
+        private final Result result;
+
+        public TestTenantResult(Tenant tenant, Result result) {
+            this.tenant = tenant;
+            this.result = result;
+        }
+
+        @Override
+        public Tenant getTenant() {
+            return tenant;
+        }
+
+        @Override
+        public Result getResult() {
+            return result;
+        }
+    }
+
+
+    private static class TestTenant implements Tenant {
+        private final String id;
+        private final String name;
+        private final String subdomain;
+        private final boolean defaultTenant;
+
+        public TestTenant(String id, String name, String subdomain, boolean defaultTenant) {
+            this.id = id;
+            this.name = name;
+            this.subdomain = subdomain;
+            this.defaultTenant = defaultTenant;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public boolean isDefault() {
+            return defaultTenant;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getSubdomain() {
+            return subdomain;
+        }
+    }
+
+    @Override
+    public boolean isNotInitialized() {
+        return false;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return false;
+    }
+
+    @Override
+    public Tenant getCurrentTenant() {
+        return null;
+    }
+
+    @Override
+    public <Result> Result execute(Tenant tenant, CallableResultAndNoException<Result> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public <Result> Result execute(String tenantId, CallableResultAndNoException<Result> callable) {
+        return callable.call();
+    }
+
+    @Override
+    public void execute(Tenant tenant, CallableNoResultAndException callable) throws Exception {
+        callable.call();
+    }
+
+    @Override
+    public <Result> List<TenantResult<Result>> executeForEachTenant(CallableResultAndNoException<Result> callable) {
+        Result result = callable.call();
+        Tenant tenant = new TestTenant(TENANT_ID, TENANT_NAME, TENANT_SUBDOMAIN, DEFUALT_TENANT);
+        TenantResult<Result> tr = new TestTenantResult<Result>(tenant, result);
+        return List.of(tr);
+    }
+}

--- a/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/synchronizer/ListenerSynchronizerTest.java
+++ b/components/engine/engine-listeners/src/test/java/org/eclipse/dirigible/components/listeners/synchronizer/ListenerSynchronizerTest.java
@@ -10,12 +10,9 @@
  */
 package org.eclipse.dirigible.components.listeners.synchronizer;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import java.nio.file.Path;
-import java.text.ParseException;
-import java.util.List;
+import org.eclipse.dirigible.components.base.tenant.DefaultTenant;
+import org.eclipse.dirigible.components.base.tenant.Tenant;
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.listeners.domain.Listener;
 import org.eclipse.dirigible.components.listeners.domain.ListenerKind;
 import org.eclipse.dirigible.components.listeners.repository.ListenerRepository;
@@ -26,9 +23,16 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * The Class BackgroundListenerSynchronizerTest.
@@ -47,6 +51,22 @@ public class ListenerSynchronizerTest {
     /** The listener repository. */
     @Autowired
     private ListenerRepository listenerRepository;
+
+    @MockBean
+    private TenantContext tenantContext;
+
+    @MockBean
+    @DefaultTenant
+    private Tenant tenant;
+
+
+    /**
+     * The Class TestConfiguration.
+     */
+    @SpringBootApplication
+    static class TestConfiguration {
+        // it is needed
+    }
 
     /**
      * Cleanup.
@@ -86,13 +106,5 @@ public class ListenerSynchronizerTest {
         assertNotNull(list);
         assertEquals("/test/test.listener", list.get(0)
                                                 .getLocation());
-    }
-
-    /**
-     * The Class TestConfiguration.
-     */
-    @SpringBootApplication
-    static class TestConfiguration {
-        // it is needed
     }
 }


### PR DESCRIPTION
Implementation of https://github.com/eclipse/dirigible/discussions/3423 [phase 3]
Add multitenancy support for listeners (`*.listener`) and messaging API.
- send messaging to dedicated topic/queue depending on the current tenant
   - for the default tenant topic/queue name is used as it is
   - for non defualt tenant - a prefix with the current tenant id is added to the topic/queue name
   - an example for topic with name `myTopic`
      - for the default tenant the name will be `myTopic`
      - for a tenant with id `148e34d8-47ff-4e53-9f74-f0100202fdbf` the name will be `148e34d8-47ff-4e53-9f74-f0100202fdbf###myTopic`
- execute listener handlers in the corresponding tenant context
- register a dedicated  message handlers for all provisioned tenants

Example logs for executing [this](https://github.com/iliyan-velichkov/dirigible-test-project/blob/master/dirigible-test-project/listeners/entity/book-entity-events.listener) test listener on creating new Book from the UI.
![image](https://github.com/eclipse/dirigible/assets/5058839/2bfe8f07-4a2d-4a5f-9191-ef60c1409ad6)

   