### PR TITLE
skip misfired jobs executions

### DIFF
--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
@@ -95,10 +95,12 @@ class SynchronizationJob extends SystemJob {
      */
     @Override
     public void execute(JobExecutionContext context) {
-        logger.debug("Job [{}] fired @ [{}]", context.getJobDetail()
-                                                     .getKey()
-                                                     .getName(),
-                context.getFireTime());
+        if (logger.isDebugEnabled()) {
+            logger.debug("Job [{}] fired @ [{}]", context.getJobDetail()
+                                                         .getKey()
+                                                         .getName(),
+                    context.getFireTime());
+        }
 
         Runtime runtime = Runtime.getRuntime();
         long usedMemoryBefore = 0;

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
@@ -63,9 +63,9 @@ class SynchronizationJob extends SystemJob {
         int frequencyInSec = DirigibleConfig.SYNCHRONIZER_FREQUENCY.getIntValue();
         logger.info("Configuring trigger to fire every [{}] seconds", frequencyInSec);
 
-        return simpleSchedule().withIntervalInMilliseconds(100)
+        return simpleSchedule().withIntervalInSeconds(frequencyInSec)
                                .repeatForever()
-                               .withMisfireHandlingInstructionIgnoreMisfires();
+                               .withMisfireHandlingInstructionNextWithExistingCount();
     }
 
     /**

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
@@ -101,9 +101,9 @@ class SynchronizationJob extends SystemJob {
      */
     @Override
     public void execute(JobExecutionContext context) {
-        logger.info("Job {} fired @ {}", context.getJobDetail()
-                                                .getKey()
-                                                .getName(),
+        logger.debug("Job {} fired @ {}", context.getJobDetail()
+                                                 .getKey()
+                                                 .getName(),
                 context.getFireTime());
 
         executor.submit(() -> {

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
@@ -70,8 +70,8 @@ class SynchronizationJob extends SystemJob {
         logger.info("Configuring trigger to fire every [{}] seconds", frequencyInSec);
 
         return simpleSchedule().withIntervalInSeconds(frequencyInSec)
-                               .withMisfireHandlingInstructionNextWithExistingCount()
-                               .repeatForever();
+                               .repeatForever()
+                               .withMisfireHandlingInstructionNextWithExistingCount();
     }
 
     /**
@@ -101,9 +101,9 @@ class SynchronizationJob extends SystemJob {
      */
     @Override
     public void execute(JobExecutionContext context) {
-        logger.debug("Job {} fired @ {}", context.getJobDetail()
-                                                 .getKey()
-                                                 .getName(),
+        logger.info("Job {} fired @ {}", context.getJobDetail()
+                                                .getKey()
+                                                .getName(),
                 context.getFireTime());
 
         executor.submit(() -> {

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationJob.java
@@ -70,7 +70,7 @@ class SynchronizationJob extends SystemJob {
         logger.info("Configuring trigger to fire every [{}] seconds", frequencyInSec);
 
         return simpleSchedule().withIntervalInSeconds(frequencyInSec)
-                               .withMisfireHandlingInstructionIgnoreMisfires()
+                               .withMisfireHandlingInstructionNextWithExistingCount()
                                .repeatForever();
     }
 

--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/TenantProvisioningJob.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/provisioning/TenantProvisioningJob.java
@@ -71,7 +71,7 @@ class TenantProvisioningJob extends SystemJob {
 
         return simpleSchedule().withIntervalInSeconds(frequencyInSec)
                                .repeatForever()
-                               .withMisfireHandlingInstructionIgnoreMisfires();
+                               .withMisfireHandlingInstructionNextWithExistingCount();
     }
 
 }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/DirigibleJob.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/DirigibleJob.java
@@ -49,10 +49,32 @@ public abstract class DirigibleJob implements Job {
         return JobBuilder.newJob()
                          .ofType(this.getClass())
                          .storeDurably()
+                         .requestRecovery()
                          .withIdentity(key)
                          .withDescription(getJobDescription())
                          .build();
     }
+
+    /**
+     * Gets the job group.
+     *
+     * @return the job group
+     */
+    protected abstract Optional<String> getJobGroup();
+
+    /**
+     * Gets the job key.
+     *
+     * @return the job key
+     */
+    protected abstract String getJobKey();
+
+    /**
+     * Gets the job description.
+     *
+     * @return the job description
+     */
+    protected abstract String getJobDescription();
 
     /**
      * Gets the trigger group.
@@ -81,25 +103,4 @@ public abstract class DirigibleJob implements Job {
      * @return the schedule
      */
     protected abstract SimpleScheduleBuilder getSchedule();
-
-    /**
-     * Gets the job group.
-     *
-     * @return the job group
-     */
-    protected abstract Optional<String> getJobGroup();
-
-    /**
-     * Gets the job key.
-     *
-     * @return the job key
-     */
-    protected abstract String getJobKey();
-
-    /**
-     * Gets the job description.
-     *
-     * @return the job description
-     */
-    protected abstract String getJobDescription();
 }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzConfig.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/config/QuartzConfig.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 @Configuration
 class QuartzConfig {
 
+    private static final int STARTUP_DELAY_SECONDS = 10;
     /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(QuartzConfig.class);
 
@@ -56,7 +57,7 @@ class QuartzConfig {
         logger.debug("Starting Scheduler threads");
 
         // give some time for spring auto configurations to pass before starting
-        scheduler.startDelayed(10);
+        scheduler.startDelayed(STARTUP_DELAY_SECONDS);
 
         return scheduler;
     }
@@ -74,6 +75,9 @@ class QuartzConfig {
         SchedulerFactoryBean factory = new SchedulerFactoryBean();
         factory.setJobFactory(jobFactory);
         factory.setQuartzProperties(quartzProperties(systemDataSourceName));
+        // add startup delay - otherwise the scheduler triggers jobs execution
+        // before spring boot application full startup
+        factory.setStartupDelay(STARTUP_DELAY_SECONDS);
         return factory;
     }
 

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/init/JobsInitializer.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/init/JobsInitializer.java
@@ -67,10 +67,10 @@ class JobsInitializer implements ApplicationListener<ApplicationReadyEvent> {
             Trigger trigger = job.createTrigger();
             TriggerKey triggerKey = trigger.getKey();
 
-            JobKey jobKey = trigger.getJobKey();
-
             if (scheduler.checkExists(triggerKey)) {
                 scheduler.unscheduleJob(triggerKey);
+
+                JobKey jobKey = trigger.getJobKey();
                 scheduler.deleteJob(jobKey);
                 LOGGER.info("Unscheduled job: [{}]", job);
             }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/init/JobsInitializer.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/init/JobsInitializer.java
@@ -65,12 +65,12 @@ class JobsInitializer implements ApplicationListener<ApplicationReadyEvent> {
     private void rescheduleJob(DirigibleJob job) {
         try {
             Trigger trigger = job.createTrigger();
-            TriggerKey triggerKey = trigger.getKey();
 
-            if (scheduler.checkExists(triggerKey)) {
+            JobKey jobKey = trigger.getJobKey();
+            if (scheduler.checkExists(jobKey)) {
+                TriggerKey triggerKey = trigger.getKey();
                 scheduler.unscheduleJob(triggerKey);
 
-                JobKey jobKey = trigger.getJobKey();
                 scheduler.deleteJob(jobKey);
                 LOGGER.info("Unscheduled job: [{}]", job);
             }


### PR DESCRIPTION
- reschedule system jobs on startup to apply new changes if any
- skip system misfired job executions
- add quartz startup delay to prevent jobs execution before spring boot application startup 
- optimize SynchronizationJob
  - remove explicit calls for garbage collection - it causes Dirigible slow down when the job is executed frequently (for example every 100 millis)
  - remove ExecutorService since it not needed
  - optimize logging