### PR TITLE
[IDE] Transpile TypeScript files on save

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
@@ -14,7 +14,20 @@
  */
 
 const CommandFacade = Java.type("org.eclipse.dirigible.components.api.platform.CommandFacade");
+const ProcessExecutionOptions = Java.type("org.eclipse.dirigible.commons.process.execution.ProcessExecutionOptions");
 
-export function execute(command, add, remove) {
-	return CommandFacade.execute(command, add, remove);
+interface ProcessExecutionOptions {
+	workingDirectory: string
+}
+
+interface EnvironmentVariables {
+	[key: string]: string
+}
+
+export function execute(command: string, options?: ProcessExecutionOptions, add?: EnvironmentVariables, remove?: string[]) {
+	const processExecutionOptions = new ProcessExecutionOptions();
+	if (options) {
+		processExecutionOptions.setWorkingDirectory(options.workingDirectory);
+	}
+	return CommandFacade.execute(command, add, remove, processExecutionOptions);
 };

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
@@ -24,10 +24,16 @@ interface EnvironmentVariables {
 	[key: string]: string
 }
 
-export function execute(command: string, options?: ProcessExecutionOptions, add?: EnvironmentVariables, remove?: string[]) {
+interface CommandOutput {
+	exitCode: number;
+	standardOutput: string;
+	errorOutput: string;
+}
+
+export function execute(command: string, options?: ProcessExecutionOptions, add?: EnvironmentVariables, remove?: string[]): CommandOutput {
 	const processExecutionOptions = new ProcessExecutionOptions();
 	if (options) {
 		processExecutionOptions.setWorkingDirectory(options.workingDirectory);
 	}
-	return CommandFacade.execute(command, add, remove, processExecutionOptions);
+	return JSON.parse(CommandFacade.execute(command, add, remove, processExecutionOptions))
 };

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/index.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/index.ts
@@ -1,6 +1,7 @@
 export * as command from "./command";
 export * as engines from "./engines";
 export * as lifecycle from "./lifecycle";
+export * as os from "./os";
 export * as problems from "./problems";
 export * as registry from "./registry";
 export * as repository from "./repository";

--- a/components/api/api-platform/src/main/java/org/eclipse/dirigible/components/api/platform/CommandFacade.java
+++ b/components/api/api-platform/src/main/java/org/eclipse/dirigible/components/api/platform/CommandFacade.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-
 import org.eclipse.dirigible.commons.api.helpers.GsonHelper;
 import org.eclipse.dirigible.commons.process.execution.ProcessExecutionOptions;
 import org.eclipse.dirigible.commons.process.execution.ProcessExecutor;
@@ -78,8 +77,12 @@ public class CommandFacade {
         Future<ProcessResult<OutputsPair>> outputFuture =
                 processExecutor.executeProcess(command, environmentVariablesToUse, processExecutionOptions);
         ProcessResult<OutputsPair> output = outputFuture.get();
-        return output.getProcessOutputs()
-                     .getStandardOutput();
+        OutputsPair outputsPair = output.getProcessOutputs();
+        Map<String, Object> resultMap = new HashMap<>();
+        resultMap.put("exitCode", output.getExitCode());
+        resultMap.put("standardOutput", outputsPair.getStandardOutput());
+        resultMap.put("errorOutput", outputsPair.getErrorOutput());
+        return GsonHelper.toJson(resultMap);
     }
 
     /**

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/template/transformer-on-save.js
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/template/transformer-on-save.js
@@ -16,19 +16,21 @@ const workspace = __context.get('workspace');
 const project = __context.get('project');
 const path = __context.get('path');
 
-const modelPath = path.replace(".edm", ".model");
-const content = transformer.transform(workspace, project, path);
+if (path && path.endsWith(".edm")) {
+    const modelPath = path.replace(".edm", ".model");
+    const content = transformer.transform(workspace, project, path);
 
-if (content !== null) {
-    const bytes = require("io/bytes");
-    const input = bytes.textToByteArray(content);
+    if (content !== null) {
+        const bytes = require("io/bytes");
+        const input = bytes.textToByteArray(content);
 
-    if (workspaceManager.getWorkspace(workspace)
-        .getProject(project).getFile(path).exists()) {
-        workspaceManager.getWorkspace(workspace)
-            .getProject(project).createFile(modelPath, input);
-    } else {
-        workspaceManager.getWorkspace(workspace)
-            .getProject(project).getFile(modelPath).setContent(input);
+        if (workspaceManager.getWorkspace(workspace)
+            .getProject(project).getFile(path).exists()) {
+            workspaceManager.getWorkspace(workspace)
+                .getProject(project).createFile(modelPath, input);
+        } else {
+            workspaceManager.getWorkspace(workspace)
+                .getProject(project).getFile(modelPath).setContent(input);
+        }
     }
 }

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/extensions/workspace-after-publish.extension
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/extensions/workspace-after-publish.extension
@@ -1,5 +1,5 @@
 {
     "module": "/ide-registry/services/compile-typescript.js",
-    "extensionPoint": "ide-workspace-on-save",
+    "extensionPoint": "ide-workspace-after-publish",
     "description": "Compile TypeScript"
 }

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/extensions/workspace-on-save.extension
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/extensions/workspace-on-save.extension
@@ -1,0 +1,5 @@
+{
+    "module": "/ide-registry/services/compile-typescript.js",
+    "extensionPoint": "ide-workspace-on-save",
+    "description": "Compile TypeScript"
+}

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/services/compile-typescript.js
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/services/compile-typescript.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import { workspace as workspaceManager } from "sdk/platform"
+import { command, os } from "sdk/platform";
+
+const workspace = __context.get('workspace');
+const project = __context.get('project');
+const path = __context.get('path');
+
+if (path && path.endsWith(".ts")) {
+    const file = workspaceManager
+        .getWorkspace(workspace)
+        .getProject(project)
+        .getFile("tsconfig.json");
+    console.log(`On Save for "${path}\n\n${file.getText()}`);
+    const filePath = path.substring(1);
+    const compileCommand = `tsc --module ESNext --target ES6 --moduleResolution Node --baseUrl ../ --lib ESNext,DOM --types ../modules/types ${filePath}`;
+    const workingDirectory = `target/dirigible/repository/root/registry/public/${project}`;
+    console.error(`Command: "${compileCommand}"`);
+    const commandResult = command.execute(compileCommand, {
+        workingDirectory: workingDirectory
+    });
+    console.error(`Command Result: "${commandResult}"`);
+}

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/services/compile-typescript.js
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/services/compile-typescript.js
@@ -12,22 +12,30 @@
 import { workspace as workspaceManager } from "sdk/platform"
 import { command, os } from "sdk/platform";
 
-const workspace = __context.get('workspace');
-const project = __context.get('project');
 const path = __context.get('path');
 
 if (path && path.endsWith(".ts")) {
+    const pathTokens = path.split("/");
+    const workspace = pathTokens[3];
+    const project = pathTokens[4];
     const file = workspaceManager
         .getWorkspace(workspace)
         .getProject(project)
         .getFile("tsconfig.json");
-    console.log(`On Save for "${path}\n\n${file.getText()}`);
-    const filePath = path.substring(1);
+
+    console.log(`After Publish for "${path}\n\n${file.getText()}`);
+
+    const filePath = pathTokens.slice(5).join("/")
     const compileCommand = `tsc --module ESNext --target ES6 --moduleResolution Node --baseUrl ../ --lib ESNext,DOM --types ../modules/types ${filePath}`;
     const workingDirectory = `target/dirigible/repository/root/registry/public/${project}`;
-    console.error(`Command: "${compileCommand}"`);
-    const commandResult = command.execute(compileCommand, {
-        workingDirectory: workingDirectory
-    });
-    console.error(`Command Result: "${commandResult}"`);
+    // console.error(`Command: "${compileCommand}"`);
+    try {
+        command.execute(compileCommand, {
+            workingDirectory: workingDirectory
+        });
+        // console.error(`Command Result: "${commandResult}"`);
+
+    } catch (e) {
+        console.info(`Error occurred: ${e}`);
+    }
 }

--- a/components/ide/ide-workspace/src/main/resources/META-INF/dirigible/ide-workspace/ide-workspace-on-save.extensionpoint
+++ b/components/ide/ide-workspace/src/main/resources/META-INF/dirigible/ide-workspace/ide-workspace-on-save.extensionpoint
@@ -1,0 +1,5 @@
+{
+  "location":"/ide-workspace/ide-workspace-on-save.extensionpoint",
+  "name":"ide-workspace-on-save",
+  "description":"On Save Extension Point"
+}

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
@@ -9,10 +9,9 @@
  */
 package org.eclipse.dirigible.commons.process.execution;
 
+import java.util.concurrent.CompletableFuture;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteResultHandler;
-
-import java.util.concurrent.CompletableFuture;
 
 /**
  * The Class ProcessExecutionFuture.
@@ -36,6 +35,6 @@ public class ProcessExecutionFuture extends CompletableFuture<Integer> implement
      */
     @Override
     public void onProcessFailed(ExecuteException e) {
-        completeExceptionally(e);
+        complete(e.getExitValue());
     }
 }


### PR DESCRIPTION
- Fixes: https://github.com/eclipse/dirigible/issues/3402
- `CommandFacade` now returns result in case of a command error _(previously an exception was thrown)_
- Adds types to the `command.ts`
- The result of the CommandFacade is in the following format:

```js
{
  exitCode: 0, // In case of error, the exitCode is different than 0
  standardOutput: "some message",
  errorOutput: "some message"
}
// Note: Both standardOutput and errorOutput should be checked!
```

## Demo

https://github.com/eclipse/dirigible/assets/4092083/c569175c-0fd3-42fd-9fe7-79631c3db9e8