### PR TITLE
[IDE] Projects refactoring

### DIFF
--- a/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpoint.java
+++ b/components/core/core-tenants/src/main/java/org/eclipse/dirigible/components/tenants/endpoint/TenantEndpoint.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.components.tenants.endpoint;
 
 import java.util.List;

--- a/components/ide/ide-ui-about/src/main/resources/META-INF/dirigible/ide-about/about.html
+++ b/components/ide/ide-ui-about/src/main/resources/META-INF/dirigible/ide-about/about.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="about" ng-controller="AboutController as about">
 
     <head>

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-image-viewer.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-image-viewer.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="bpm-image-app" ng-controller="BpmImageViewController">
 

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-perspective.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-perspective.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="IDEBPMWorkspace" ng-controller="BpmWorkspaceViewController"
 	xmlns="http://www.w3.org/1999/xhtml">

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-definitions.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-definitions.html
@@ -36,9 +36,9 @@
                 title="Toggle search" aria-label="Toggle search" ng-click="definitions.toggleSearch()">
             </fd-button>
         </fd-toolbar>
-        <fd-toolbar ng-show="definitions.displaySearch">
+        <fd-toolbar ng-if="definitions.displaySearch">
             <fd-input type="search" placeholder="Search" ng-keyup="definitions.inputSearchKeyUp($event)"
-                ng-model="definitions.searchText">
+                ng-model="definitions.searchText" dg-focus="true">
             </fd-input>
         </fd-toolbar>
         <fd-scrollbar class="dg-fill-parent">

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-definitions.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-definitions.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="ide-bpm-process-definitions"
     ng-controller="IDEBpmProcessDefinitionsViewController as definitions">

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-instances.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-instances.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="ide-bpm-process-instances"
     ng-controller="IDEBpmProcessInstancesViewController as instances">

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-instances.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-process-instances.html
@@ -46,9 +46,9 @@
                 title="Skip" aria-label="Skip" ng-click="instances.skip()">
             </fd-button>
         </fd-toolbar>
-        <fd-toolbar ng-show="instances.displaySearch">
+        <fd-toolbar ng-if="instances.displaySearch">
             <fd-input type="search" placeholder="Search" ng-keyup="instances.inputSearchKeyUp($event)"
-                ng-model="instances.searchText">
+                ng-model="instances.searchText" dg-focus="true">
             </fd-input>
         </fd-toolbar>
         <fd-scrollbar class="dg-fill-parent">

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-task-details.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-task-details.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2022 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="taskDetails" ng-controller="TaskDetailsController">
 
     <head>

--- a/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-tasks.html
+++ b/components/ide/ide-ui-bpm-workspace/src/main/resources/META-INF/dirigible/ide-bpm-workspace/bpm-tasks.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2022 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="tasks" ng-controller="TasksController">
 
 <head>

--- a/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/editor-app/configuration/toolbar-default-actions.js
+++ b/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/editor-app/configuration/toolbar-default-actions.js
@@ -81,6 +81,7 @@ FLOWABLE.TOOLBAR = {
                             workspace: modelMetaData.modelId.substring(0, modelMetaData.modelId.indexOf('/', 1)),
                         }, 'ide.file.saved');
                         window.messageHub.post({ message: `File '${modelMetaData.modelId}' saved` }, 'ide.status.message');
+                        setEditorDirtyState(false);
                     })
                     .error(function (data, status, headers, config) {
                         if (status === 409) {
@@ -90,22 +91,6 @@ FLOWABLE.TOOLBAR = {
                         }
                     });
             };
-
-            messageHub.subscribe(
-                function () {
-                    saveSilently(services.$http, services.editorManager.getModel(), services.$rootScope.modelData, services.editorManager);
-                },
-                "editor.file.save.all"
-            );
-
-            messageHub.subscribe(
-                function (msg) {
-                    let file = msg.data && typeof msg.data === 'object' && msg.data.file;
-                    if (file && file === services.$rootScope.modelData.modelId)
-                        saveSilently(services.$http, services.editorManager.getModel(), services.$rootScope.modelData, services.editorManager);
-                },
-                "editor.file.save"
-            );
 
             saveSilently(services.$http, services.editorManager.getModel(), services.$rootScope.modelData, services.editorManager);
             // --- workaround for saving silently ends here
@@ -133,6 +118,7 @@ FLOWABLE.TOOLBAR = {
         },
 
         undo: function (services) {
+            setEditorDirtyState(true);
 
             // Get the last commands
             var lastCommands = services.$scope.undoStack.pop();
@@ -191,6 +177,7 @@ FLOWABLE.TOOLBAR = {
         },
 
         redo: function (services) {
+            setEditorDirtyState(true);
 
             // Get the last commands from the redo stack
             var lastCommands = services.$scope.redoStack.pop();
@@ -258,6 +245,8 @@ FLOWABLE.TOOLBAR = {
                     });
                 }
             }
+
+            setEditorDirtyState(true);
         },
 
         copy: function (services) {
@@ -273,14 +262,17 @@ FLOWABLE.TOOLBAR = {
         },
 
         paste: function (services) {
+            setEditorDirtyState(true);
             FLOWABLE.TOOLBAR.ACTIONS._getOryxEditPlugin(services).editPaste();
         },
 
         deleteItem: function (services) {
+            setEditorDirtyState(true);
             FLOWABLE.TOOLBAR.ACTIONS._getOryxEditPlugin(services).editDelete();
         },
 
         addBendPoint: function (services) {
+            setEditorDirtyState(true);
 
             // Show the tutorial the first time
             FLOWABLE_EDITOR_TOUR.sequenceFlowBendpoint(services.$scope, services.$translate, services.$q, true);
@@ -299,6 +291,7 @@ FLOWABLE.TOOLBAR = {
         },
 
         removeBendPoint: function (services) {
+            setEditorDirtyState(true);
 
             // Show the tutorial the first time
             FLOWABLE_EDITOR_TOUR.sequenceFlowBendpoint(services.$scope, services.$translate, services.$q, true);

--- a/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/editor-app/theme/style.css
+++ b/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/editor-app/theme/style.css
@@ -17,8 +17,15 @@
   font-style: normal;
 }
 
+body {
+  padding: 0;
+  margin: 0;
+}
+
 .wrapper.full {
   background-color: var(--sapBackgroundColor, #f7f7f7);
+  max-width: 100vw !important;
+  max-height: 100vh !important;
 }
 
 .row-no-gutter .col-xs-9,
@@ -965,8 +972,7 @@ hot-table .column-header.label {
 
 #decisionTableGrid tr .input-operator-cell {
   text-align: center;
-  min-width: 50px;
-   !important;
+  min-width: 50px !important;
 }
 
 #decisionTableGrid td.htInvalid {

--- a/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/index.html
+++ b/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/index.html
@@ -48,9 +48,6 @@
     </head>
 
     <body ng-app="flowableModeler" ng-cloak>
-
-
-
         <!--[if lt IE 9]>
     <div class="unsupported-browser">
         <p class="alert error">You are using an unsupported browser. Please upgrade your browser in order to use the
@@ -89,7 +86,7 @@
             </div>
         </div>
 
-        <div id="main" class="wrapper full clearfix" ng-view="" ng-cloak ng-style="{height: window.height + 'px'}">
+        <div id="main" class="wrapper full clearfix" ng-view="" ng-cloak>
         </div>
 
         <!--[if lt IE 9]>

--- a/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/scripts/app.js
+++ b/components/ide/ide-ui-bpm/src/main/resources/META-INF/dirigible/ide-bpm/scripts/app.js
@@ -13,121 +13,140 @@
 'use strict';
 
 var flowableModeler = angular.module('flowableModeler', [
-  'ngCookies',
-  'ngResource',
-  'ngSanitize',
-  'ngRoute',
-  'ngDragDrop',
-  'mgcrea.ngStrap',
-  'mgcrea.ngStrap.helpers.dimensions', // Needed for tooltips
-  'ui.grid',
-  'ui.grid.edit',
-  'ui.grid.selection',
-  'ui.grid.autoResize',
-  'ui.grid.moveColumns',
-  'ui.grid.cellNav',
-  'ngAnimate',
-  'pascalprecht.translate',
-  'ngFileUpload',
-  'angularSpectrumColorpicker',
-  'duScroll',
-  'dndLists',
-  'ngHandsontable'
+    'ngCookies',
+    'ngResource',
+    'ngSanitize',
+    'ngRoute',
+    'ngDragDrop',
+    'mgcrea.ngStrap',
+    'mgcrea.ngStrap.helpers.dimensions', // Needed for tooltips
+    'ui.grid',
+    'ui.grid.edit',
+    'ui.grid.selection',
+    'ui.grid.autoResize',
+    'ui.grid.moveColumns',
+    'ui.grid.cellNav',
+    'ngAnimate',
+    'pascalprecht.translate',
+    'ngFileUpload',
+    'angularSpectrumColorpicker',
+    'duScroll',
+    'dndLists',
+    'ngHandsontable'
 ]);
 
 var flowableModule = flowableModeler;
 var flowableApp = flowableModeler;
 
+var dgViewParams;
+
+if (window.frameElement && window.frameElement.hasAttribute("data-parameters")) {
+    dgViewParams = JSON.parse(window.frameElement.getAttribute("data-parameters") || '');
+    const projectPath = dgViewParams.file.replace(`/${dgViewParams.workspaceName}/`, '');
+    dgViewParams.project = projectPath.substring(0, projectPath.indexOf('/'));
+    dgViewParams.path = projectPath.replace(`${dgViewParams.project}/`, '');
+}
+
+function setEditorDirtyState(dirty) {
+    messageHub.post({
+        resourcePath: dgViewParams.file,
+        isDirty: dirty
+    }, 'ide-core.setEditorDirty');
+}
+
 flowableModeler
-  // Initialize routes
-  .config(['$provide', '$routeProvider', '$selectProvider', '$translateProvider', function ($provide, $routeProvider, $selectProvider, $translateProvider) {
+    // Initialize routes
+    .config(['$provide', '$routeProvider', '$selectProvider', '$translateProvider', function ($provide, $routeProvider, $selectProvider, $translateProvider) {
 
-    var appResourceRoot = FLOWABLE.CONFIG.webContextRoot + (FLOWABLE.CONFIG.webContextRoot ? '/' : '');
-    $provide.value('appResourceRoot', appResourceRoot);
+        var appResourceRoot = FLOWABLE.CONFIG.webContextRoot + (FLOWABLE.CONFIG.webContextRoot ? '/' : '');
+        $provide.value('appResourceRoot', appResourceRoot);
 
 
-    // Override caret for bs-select directive
-  	angular.extend($selectProvider.defaults, {
-      caretHtml: '&nbsp;<i class="icon icon-caret-down"></i>'
-  	});
-
-    $routeProvider
-        .when('/processes', {
-            templateUrl: appResourceRoot + 'views/processes.html',
-            controller: 'ProcessesCtrl'
-        })
-        .when('/processes/:modelId', {
-            templateUrl: appResourceRoot + 'views/process.html',
-            controller: 'ProcessCtrl'
-        })
-        .when('/processes/:modelId/history/:modelHistoryId', {
-            templateUrl: appResourceRoot + 'views/process.html',
-            controller: 'ProcessCtrl'
-        })
-        .when('/casemodels', {
-            templateUrl: appResourceRoot + 'views/casemodels.html',
-            controller: 'CaseModelsCtrl'
-        })
-        .when('/casemodels/:modelId', {
-            templateUrl: appResourceRoot + 'views/casemodel.html',
-            controller: 'CaseModelCtrl'
-        })
-        .when('/forms', {
-            templateUrl: appResourceRoot + 'views/forms.html',
-            controller: 'FormsCtrl'
-        })
-        .when('/forms/:modelId', {
-            templateUrl: appResourceRoot + 'views/form.html',
-            controller: 'FormCtrl'
-        })
-        .when('/forms/:modelId/history/:modelHistoryId', {
-            templateUrl: appResourceRoot + 'views/form.html',
-            controller: 'FormCtrl'
-        })
-        .when('/decision-tables', {
-            templateUrl: appResourceRoot + 'views/decision-tables.html',
-            controller: 'DecisionTablesController'
-        })
-        .when('/decision-tables/:modelId', {
-            templateUrl: appResourceRoot + 'views/decision-table.html',
-            controller: 'DecisionTableDetailsCtrl'
-        })
-        .when('/decision-tables/:modelId/history/:modelHistoryId', {
-            templateUrl: appResourceRoot + 'views/decision-table.html',
-            controller: 'DecisionTableDetailsCtrl'
-        })
-        .when('/apps', {
-            templateUrl: appResourceRoot + 'views/app-definitions.html',
-            controller: 'AppDefinitionsCtrl'
-        })
-        .when('/apps/:modelId', {
-            templateUrl: appResourceRoot + 'views/app-definition.html',
-            controller: 'AppDefinitionCtrl'
-        })
-        .when('/apps/:modelId/history/:modelHistoryId', {
-            templateUrl: 'views/app-definition.html',
-            controller: 'AppDefinitionCtrl'
-        })
-        .when('/editor/:workspace/:project/:path*', {
-            templateUrl: appResourceRoot + 'editor-app/editor.html',
-            controller: 'EditorController'
-        })
-        .when('/form-editor/:modelId', {
-            templateUrl: appResourceRoot + 'views/form-builder.html',
-            controller: 'FormBuilderController'
-        })
-        .when('/case-editor/:modelId', {
-            templateUrl: appResourceRoot + 'editor-app/editor.html',
-            controller: 'EditorController'
-        })
-        .when('/decision-table-editor/:modelId', {
-            templateUrl: appResourceRoot + 'views/decision-table-editor.html',
-            controller: 'DecisionTableEditorController'
-        })
-        .when('/app-editor/:modelId', {
-            templateUrl: appResourceRoot + 'views/app-definition-builder.html',
-            controller: 'AppDefinitionBuilderController'
+        // Override caret for bs-select directive
+        angular.extend($selectProvider.defaults, {
+            caretHtml: '&nbsp;<i class="icon icon-caret-down"></i>'
         });
+
+        $routeProvider
+            .when('/processes', {
+                templateUrl: appResourceRoot + 'views/processes.html',
+                controller: 'ProcessesCtrl'
+            })
+            .when('/processes/:modelId', {
+                templateUrl: appResourceRoot + 'views/process.html',
+                controller: 'ProcessCtrl'
+            })
+            .when('/processes/:modelId/history/:modelHistoryId', {
+                templateUrl: appResourceRoot + 'views/process.html',
+                controller: 'ProcessCtrl'
+            })
+            .when('/casemodels', {
+                templateUrl: appResourceRoot + 'views/casemodels.html',
+                controller: 'CaseModelsCtrl'
+            })
+            .when('/casemodels/:modelId', {
+                templateUrl: appResourceRoot + 'views/casemodel.html',
+                controller: 'CaseModelCtrl'
+            })
+            .when('/forms', {
+                templateUrl: appResourceRoot + 'views/forms.html',
+                controller: 'FormsCtrl'
+            })
+            .when('/forms/:modelId', {
+                templateUrl: appResourceRoot + 'views/form.html',
+                controller: 'FormCtrl'
+            })
+            .when('/forms/:modelId/history/:modelHistoryId', {
+                templateUrl: appResourceRoot + 'views/form.html',
+                controller: 'FormCtrl'
+            })
+            .when('/decision-tables', {
+                templateUrl: appResourceRoot + 'views/decision-tables.html',
+                controller: 'DecisionTablesController'
+            })
+            .when('/decision-tables/:modelId', {
+                templateUrl: appResourceRoot + 'views/decision-table.html',
+                controller: 'DecisionTableDetailsCtrl'
+            })
+            .when('/decision-tables/:modelId/history/:modelHistoryId', {
+                templateUrl: appResourceRoot + 'views/decision-table.html',
+                controller: 'DecisionTableDetailsCtrl'
+            })
+            .when('/apps', {
+                templateUrl: appResourceRoot + 'views/app-definitions.html',
+                controller: 'AppDefinitionsCtrl'
+            })
+            .when('/apps/:modelId', {
+                templateUrl: appResourceRoot + 'views/app-definition.html',
+                controller: 'AppDefinitionCtrl'
+            })
+            .when('/apps/:modelId/history/:modelHistoryId', {
+                templateUrl: 'views/app-definition.html',
+                controller: 'AppDefinitionCtrl'
+            })
+            .when('/editor/', {
+                redirectTo: `/editor/${dgViewParams.workspaceName}/${dgViewParams.project}/${dgViewParams.path}`
+            })
+            .when('/editor/:workspace/:project/:path*', {
+                templateUrl: appResourceRoot + 'editor-app/editor.html',
+                controller: 'EditorController'
+            })
+            .when('/form-editor/:modelId', {
+                templateUrl: appResourceRoot + 'views/form-builder.html',
+                controller: 'FormBuilderController'
+            })
+            .when('/case-editor/:modelId', {
+                templateUrl: appResourceRoot + 'editor-app/editor.html',
+                controller: 'EditorController'
+            })
+            .when('/decision-table-editor/:modelId', {
+                templateUrl: appResourceRoot + 'views/decision-table-editor.html',
+                controller: 'DecisionTableEditorController'
+            })
+            .when('/app-editor/:modelId', {
+                templateUrl: appResourceRoot + 'views/app-definition-builder.html',
+                controller: 'AppDefinitionBuilderController'
+            });
 
         if (FLOWABLE.CONFIG.appDefaultRoute) {
             $routeProvider.when('/', {
@@ -142,23 +161,23 @@ flowableModeler
 
         // Initialize angular-translate
         $translateProvider.useStaticFilesLoader({
-          prefix: './i18n/',
-          suffix: '.json'
+            prefix: './i18n/',
+            suffix: '.json'
         })
-        /*
-        This can be used to map multiple browser language keys to a
-        angular translate language key.
-        */
-        // .registerAvailableLanguageKeys(['en'], {
-        //     'en-*': 'en'
-        // })
-        .useSanitizeValueStrategy('escapeParameters')
-        .uniformLanguageTag('bcp47')
-        .determinePreferredLanguage();
+            /*
+            This can be used to map multiple browser language keys to a
+            angular translate language key.
+            */
+            // .registerAvailableLanguageKeys(['en'], {
+            //     'en-*': 'en'
+            // })
+            .useSanitizeValueStrategy('escapeParameters')
+            .uniformLanguageTag('bcp47')
+            .determinePreferredLanguage();
 
-  }])
-  .run(['$rootScope', '$timeout', '$modal', '$translate', '$location', '$http', '$window', 'appResourceRoot',
-        function($rootScope, $timeout, $modal, $translate, $location, $http, $window, appResourceRoot) {
+    }])
+    .run(['$rootScope', '$timeout', 'editorManager', '$translate', '$location', '$http', '$window', 'appResourceRoot',
+        function ($rootScope, $timeout, editorManager, $translate, $location, $http, $window, appResourceRoot) {
 
             // set angular translate fallback language
             $translate.fallbackLanguage(['en']);
@@ -168,26 +187,26 @@ flowableModeler
                 moment.locale($translate.proposedLanguage());
             }
 
-            $rootScope.restRootUrl = function() {
+            $rootScope.restRootUrl = function () {
                 return FLOWABLE.CONFIG.contextRoot;
             };
 
-          	$rootScope.appResourceRoot = appResourceRoot;
+            $rootScope.appResourceRoot = appResourceRoot;
 
             $rootScope.window = {};
-            var updateWindowSize = function() {
+            var updateWindowSize = function () {
                 $rootScope.window.width = $window.innerWidth;
-                $rootScope.window.height  = $window.innerHeight;
+                $rootScope.window.height = $window.innerHeight;
             };
 
             // Window resize hook
-            angular.element($window).bind('resize', function() {
+            angular.element($window).bind('resize', function () {
                 $rootScope.safeApply(updateWindowSize());
             });
 
-            $rootScope.$watch('window.forceRefresh', function(newValue) {
-                if(newValue) {
-                    $timeout(function() {
+            $rootScope.$watch('window.forceRefresh', function (newValue) {
+                if (newValue) {
+                    $timeout(function () {
                         updateWindowSize();
                         $rootScope.window.forceRefresh = false;
                     });
@@ -195,6 +214,37 @@ flowableModeler
             });
 
             updateWindowSize();
+
+            messageHub.subscribe(function (event) {
+                if ($rootScope.modelData.modelId === event.resourcePath.replace('/', '')) {
+                    if ($window.frameElement && $window.frameElement.hasAttribute("data-parameters")) {
+                        dgViewParams = JSON.parse($window.frameElement.getAttribute("data-parameters"));
+                        const projectPath = dgViewParams.file.replace(`/${dgViewParams.workspaceName}/`, '');
+                        dgViewParams.project = projectPath.substring(0, projectPath.indexOf('/'));
+                        dgViewParams.path = projectPath.replace(`${dgViewParams.project}/`, '');
+                        $rootScope.modelData.modelId = dgViewParams.file.replace('/', '');
+                    }
+                }
+            }, "core.editors.reloadParams");
+
+            messageHub.subscribe(
+                function () {
+                    var services = { '$rootScope': $rootScope, '$http': $http, 'editorManager': editorManager };
+                    FLOWABLE.TOOLBAR.ACTIONS.saveModel(services);
+                },
+                "editor.file.save.all"
+            );
+
+            messageHub.subscribe(
+                function (msg) {
+                    let file = msg.data && typeof msg.data === 'object' && msg.data.file;
+                    if (file && file === dgViewParams.file) {
+                        var services = { '$rootScope': $rootScope, '$http': $http, 'editorManager': editorManager };
+                        FLOWABLE.TOOLBAR.ACTIONS.saveModel(services);
+                    }
+                },
+                "editor.file.save"
+            );
 
             // Main navigation
             $rootScope.mainNavigation = [
@@ -243,7 +293,7 @@ flowableModeler
              * Set the current main page, using the page object. If the page is already active,
              * this is a no-op.
              */
-            $rootScope.setMainPage = function(mainPage) {
+            $rootScope.setMainPage = function (mainPage) {
                 $rootScope.mainPage = mainPage;
                 $location.path($rootScope.mainPage.path);
             };
@@ -252,8 +302,8 @@ flowableModeler
              * Set the current main page, using the page ID. If the page is already active,
              * this is a no-op.
              */
-            $rootScope.setMainPageById = function(mainPageId) {
-                for (var i=0; i<$rootScope.mainNavigation.length; i++) {
+            $rootScope.setMainPageById = function (mainPageId) {
+                for (var i = 0; i < $rootScope.mainNavigation.length; i++) {
                     if (mainPageId == $rootScope.mainNavigation[i].id) {
                         $rootScope.mainPage = $rootScope.mainNavigation[i];
                         break;
@@ -264,10 +314,10 @@ flowableModeler
             /**
              * A 'safer' apply that avoids concurrent updates (which $apply allows).
              */
-            $rootScope.safeApply = function(fn) {
+            $rootScope.safeApply = function (fn) {
                 var phase = this.$root.$$phase;
-                if(phase == '$apply' || phase == '$digest') {
-                    if(fn && (typeof(fn) === 'function')) {
+                if (phase == '$apply' || phase == '$digest') {
+                    if (fn && (typeof (fn) === 'function')) {
                         fn();
                     }
                 } else {
@@ -280,11 +330,11 @@ flowableModeler
                 queue: []
             };
 
-            $rootScope.showAlert = function(alert) {
-                if(alert.queue.length > 0) {
+            $rootScope.showAlert = function (alert) {
+                if (alert.queue.length > 0) {
                     alert.current = alert.queue.shift();
                     // Start timout for message-pruning
-                    alert.timeout = $timeout(function() {
+                    alert.timeout = $timeout(function () {
                         if (alert.queue.length == 0) {
                             alert.current = undefined;
                             alert.timeout = undefined;
@@ -297,8 +347,8 @@ flowableModeler
                 }
             };
 
-            $rootScope.addAlert = function(message, type) {
-                var newAlert = {message: message, type: type};
+            $rootScope.addAlert = function (message, type) {
+                var newAlert = { message: message, type: type };
                 if (!$rootScope.alerts.timeout) {
                     // Timeout for message queue is not running, start one
                     $rootScope.alerts.queue.push(newAlert);
@@ -308,7 +358,7 @@ flowableModeler
                 }
             };
 
-            $rootScope.dismissAlert = function() {
+            $rootScope.dismissAlert = function () {
                 if (!$rootScope.alerts.timeout) {
                     $rootScope.alerts.current = undefined;
                 } else {
@@ -318,40 +368,40 @@ flowableModeler
                 }
             };
 
-            $rootScope.addAlertPromise = function(promise, type) {
+            $rootScope.addAlertPromise = function (promise, type) {
                 if (promise) {
-                    promise.then(function(data) {
+                    promise.then(function (data) {
                         $rootScope.addAlert(data, type);
                     });
                 }
             };
 
-//            $http.get(FLOWABLE.APP_URL.getAccountUrl())
-//	        	.success(function (data, status, headers, config) {
-//	              	$rootScope.account = data;
-//	               	$rootScope.invalidCredentials = false;
-//	 				$rootScope.authenticated = true;
-//	          	});
+            //            $http.get(FLOWABLE.APP_URL.getAccountUrl())
+            //	        	.success(function (data, status, headers, config) {
+            //	              	$rootScope.account = data;
+            //	               	$rootScope.invalidCredentials = false;
+            //	 				$rootScope.authenticated = true;
+            //	          	});
 
-//	        $rootScope.logout = function () {
-//                $rootScope.authenticated = false;
-//                $rootScope.authenticationError = false;
-//                $http.get(FLOWABLE.APP_URL.getLogoutUrl())
-//                    .success(function (data, status, headers, config) {
-//                        $rootScope.login = null;
-//                        $rootScope.authenticated = false;
-//                        $window.location.href = '/';
-//                        $window.location.reload();
-//                    });
-//            };
+            //	        $rootScope.logout = function () {
+            //                $rootScope.authenticated = false;
+            //                $rootScope.authenticationError = false;
+            //                $http.get(FLOWABLE.APP_URL.getLogoutUrl())
+            //                    .success(function (data, status, headers, config) {
+            //                        $rootScope.login = null;
+            //                        $rootScope.authenticated = false;
+            //                        $window.location.href = '/';
+            //                        $window.location.reload();
+            //                    });
+            //            };
         }
-  ])
-  .run(['$rootScope', '$location', '$translate', '$window', '$modal',
-        function($rootScope, $location, $translate, $window , $modal) {
+    ])
+    .run(['$rootScope', '$location', '$translate', '$window', '$modal',
+        function ($rootScope, $location, $translate, $window, $modal) {
 
             var fixedUrlPart = '/editor/';
 
-            $rootScope.backToLanding = function() {
+            $rootScope.backToLanding = function () {
                 var baseUrl = $location.absUrl();
                 var index = baseUrl.indexOf(fixedUrlPart);
                 if (index >= 0) {
@@ -363,8 +413,8 @@ flowableModeler
         }])
 
     // Moment-JS date-formatting filter
-    .filter('dateformat', function() {
-        return function(date, format) {
+    .filter('dateformat', function () {
+        return function (date, format) {
             if (date) {
                 if (format) {
                     return moment(date).format(format);

--- a/components/ide/ide-ui-console/src/main/resources/META-INF/dirigible/ide-console/console.html
+++ b/components/ide/ide-ui-console/src/main/resources/META-INF/dirigible/ide-console/console.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="console" ng-controller="ConsoleController as ctrl">
 
     <head>

--- a/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/editor.html
+++ b/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="csv-editor" ng-controller="CsvViewController">
 
@@ -30,7 +30,7 @@
     </head>
 
     <body class="dg-vbox" ng-mousedown="handleClick($event)" dg-contextmenu="contextMenuContent" dg-shortcut="'ctrl+s'"
-        dg-shortcut-action="save()">
+        dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/js/editor.js
+++ b/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/js/editor.js
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 agGrid.initialiseAgGridWithAngular1(angular);
-let csvView = angular.module('csv-editor', ["ideUI", "ideView", "agGrid"]);
+const csvView = angular.module('csv-editor', ["ideUI", "ideView", "agGrid"]);
 csvView.controller('CsvViewController', ['$scope', '$http', '$window', 'messageHub', 'ViewParameters', function ($scope, $http, $window, messageHub, ViewParameters) {
     let contents;
     let csrfToken;
@@ -378,7 +378,8 @@ csvView.controller('CsvViewController', ['$scope', '$http', '$window', 'messageH
         });
     };
 
-    $scope.save = function () {
+    $scope.save = function (_keySet, event) {
+        if (event) event.preventDefault();
         $scope.state.busyText = "Saving...";
         $scope.state.isBusy = true;
         $scope.search.text = "";

--- a/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
+++ b/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="csvim-editor" ng-controller="CsvimViewController">
 
@@ -25,7 +25,7 @@
         <script type="text/javascript" src="js/editor.js"></script>
     </head>
 
-    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
+++ b/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -44,9 +44,9 @@
                             state="{{ forms.editor.$valid && isFileChanged ? '' : 'disabled'  }}">
                         </fd-button>
                     </fd-toolbar>
-                    <fd-toolbar ng-show="searchVisible">
+                    <fd-toolbar ng-if="searchVisible">
                         <fd-input type="search" placeholder="Search" ng-keyup="filterFiles()"
-                            ng-model="searchField.text">
+                            ng-model="searchField.text" dg-focus="true">
                         </fd-input>
                     </fd-toolbar>
                     <fd-list compact="true" fd-scrollbar>

--- a/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/js/editor.js
+++ b/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/js/editor.js
@@ -9,7 +9,7 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let editorView = angular.module('csvim-editor', ["ideUI", "ideView", "ideWorkspace"]);
+const editorView = angular.module('csvim-editor', ["ideUI", "ideView", "ideWorkspace"]);
 editorView.directive('uniqueField', function ($parse) {
     return {
         require: 'ngModel',
@@ -168,7 +168,8 @@ editorView.controller('CsvimViewController', ['$scope', '$http', 'messageHub', '
         return $scope.quoteCharList.includes(quoteChar);
     };
 
-    $scope.save = function () {
+    $scope.save = function (_keySet, event) {
+        if (event) event.preventDefault();
         if ($scope.forms.editor.$valid && $scope.isFileChanged) {
             $scope.checkResource($scope.csvimData.files[$scope.activeItemId].file);
             $scope.csvimData.files[$scope.activeItemId].name = $scope.getFileName($scope.csvimData.files[$scope.activeItemId].file, false);

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.html
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
@@ -24,7 +24,7 @@
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox dg-center__horizontal" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox dg-center__horizontal" dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.js
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.js
@@ -13,7 +13,7 @@ angular.module('page', ["ideUI", "ideView"])
 	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
 		let contents;
 		let csrfToken;
-		$scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
 		};
@@ -131,7 +131,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.html
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
@@ -25,7 +25,7 @@
     </head>
 
     <body class="fd-padding dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'"
-        dg-shortcut-action="save()">
+        dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.js
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.js
@@ -90,7 +90,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/views/data-structures.html
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/views/data-structures.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="dataStructures"
     ng-controller="DataStructuresController as controller">
 

--- a/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/explorer/explorer.html
+++ b/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/explorer/explorer.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="database" ng-controller="DatabaseController">
 

--- a/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/index.html
+++ b/components/ide/ide-ui-database/src/main/resources/META-INF/dirigible/ide-database/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="database" ng-controller="DatabaseController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/databases.html
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/databases.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="databases" ng-controller="DatabaseController" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/dialogs/database-dialog.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="dbdialog" ng-controller="DBDialogController">
 
     <head>

--- a/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/transfer.html
+++ b/components/ide/ide-ui-databases/src/main/resources/META-INF/dirigible/ide-databases/transfer.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="transfer" ng-controller="TransferController as controller" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-debugger/src/main/resources/META-INF/dirigible/ide-debugger/index.html
+++ b/components/ide/ide-ui-debugger/src/main/resources/META-INF/dirigible/ide-debugger/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="debugger" ng-controller="DebuggerController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/index.html
+++ b/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2022 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="documents" ng-controller="DocumentsController" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
+++ b/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -81,7 +81,7 @@
                     <span class="sap-icon--search" role="presentation"></span>
                 </fd-input-group-addon>
                 <fd-input type="search" in-group="true" ng-model="search.filterBy" ng-change="clearSelection()"
-                    placeholder="Find in folder">
+                    placeholder="Find in folder" dg-focus="true">
                 </fd-input>
                 <fd-input-group-addon ng-if="search.filterBy" has-button="true">
                     <fd-button in-group="true" glyph="sap-icon--clear-filter" dg-type="transparent"

--- a/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
+++ b/components/ide/ide-ui-documents/src/main/resources/META-INF/dirigible/ide-documents/ui/documents/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html id="ng-app" ng-app="app" ng-controller="DocServiceCtrl">
 

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="ui.entity-data.modeler" ng-controller="ModelerCtrl as ctrl">
 

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/details.html
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/details.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="edmDetails" ng-controller="DetailsController">
 
     <head>

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/nav-details.html
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/nav-details.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="edmDetails" ng-controller="DetailsController">
 
     <head>

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/reference.html
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/views/reference.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="edmReference" ng-controller="ReferenceController">
 
     <head>

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.html
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
     <head>
@@ -11,12 +20,11 @@
         <theme></theme>
         <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
         </script>
-        <link type="text/css" rel="stylesheet"
-            href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.js
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.js
@@ -87,7 +87,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.html
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
     <head>
@@ -11,12 +20,11 @@
         <theme></theme>
         <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
         </script>
-        <link type="text/css" rel="stylesheet"
-            href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.js
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.js
@@ -87,7 +87,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/views/extensions.html
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/views/extensions.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="extensions" ng-controller="ExtensionsController as controller">
 
     <head>

--- a/components/ide/ide-ui-file-manager/src/main/resources/META-INF/dirigible/ide-file-manager/file-manager.html
+++ b/components/ide/ide-ui-file-manager/src/main/resources/META-INF/dirigible/ide-file-manager/file-manager.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -36,8 +36,9 @@
                 title="Toggle search" aria-label="Toggle search" ng-click="toggleSearch()">
             </fd-button>
         </fd-toolbar>
-        <fd-toolbar ng-show="searchVisible">
-            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+        <fd-toolbar ng-if="searchVisible">
+            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"
+                dg-focus="true"></fd-input>
         </fd-toolbar>
         <div id="dgFileManager" class="jstree-fiori--fill jstree-fiori--context-menu fd-scrollbar"
             dg-contextmenu="contextMenuContent"></div>

--- a/components/ide/ide-ui-file-manager/src/main/resources/META-INF/dirigible/ide-file-manager/file-manager.html
+++ b/components/ide/ide-ui-file-manager/src/main/resources/META-INF/dirigible/ide-file-manager/file-manager.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="fileManager" ng-controller="FileManagerViewController">
 

--- a/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/editor.html
+++ b/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="app" ng-controller="DesignerController">
 
@@ -29,7 +29,7 @@
         <script type="text/javascript" src="js/editor.js"></script>
     </head>
 
-    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox" dg-shortcut="'ctrl+s|delete'" dg-shortcut-action="shortcuts">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>
@@ -88,8 +88,7 @@
                     <fd-scrollbar class="fd-padding">
                         <div id="formContainer" class="dg-checkered-bg dg-vbox fb-main-container dg-restrict-width"
                             ng-attr-disabled="{{state.canSave === false || undefined}}" data-preview="{{state.preview}}"
-                            data-type="container-main" dg-contextmenu="contextMenuContent" dg-shortcut="'delete'"
-                            dg-shortcut-action="deleteSelected()">
+                            data-type="container-main" dg-contextmenu="contextMenuContent">
                         </div>
                     </fd-scrollbar>
                 </div>

--- a/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/js/editor.js
+++ b/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/js/editor.js
@@ -1370,6 +1370,8 @@ editorView.controller('DesignerController', ['$scope', '$window', '$document', '
     };
 
     $scope.switchTab = function (tabId) {
+        $scope.selectedCtrlId = undefined;
+        $scope.selectedContainerId = undefined;
         $scope.selectedTab = tabId;
     };
 
@@ -1499,17 +1501,34 @@ editorView.controller('DesignerController', ['$scope', '$window', '$document', '
         });
     }
 
-    $scope.save = function () {
-        if ($scope.state.canSave && $scope.isFileChanged) {
-            $scope.state.isBusy = true;
-            const formFile = {
-                feeds: $scope.formData.feeds,
-                scripts: $scope.formData.scripts,
-                code: $scope.formData.code,
-                form: $scope.createFormJson($scope.formModel)
-            };
-            saveContents(JSON.stringify(formFile, null, 4));
+    $scope.shortcuts = function (keySet, event) {
+        switch (keySet) {
+            case 'ctrl+s':
+                event.preventDefault();
+                if ($scope.state.canSave && $scope.isFileChanged) {
+                    $scope.$apply(() => $scope.state.isBusy = true);
+                    const formFile = {
+                        feeds: $scope.formData.feeds,
+                        scripts: $scope.formData.scripts,
+                        code: $scope.formData.code,
+                        form: $scope.createFormJson($scope.formModel)
+                    };
+                    saveContents(JSON.stringify(formFile, null, 4));
+                }
+                break;
+            case 'delete':
+                if ($scope.selectedTab === 'designer' && event.target.tagName !== 'INPUT') {
+                    if ($scope.selectedCtrlId) {
+                        $scope.$apply(() => $scope.deleteControl($scope.selectedCtrlId));
+                    } else if ($scope.selectedContainerId) {
+                        $scope.$apply(() => $scope.deleteControl($scope.selectedContainerId, true));
+                    }
+                }
+                break;
+            default:
+                break;
         }
+
     };
 
     $scope.fileChanged = function () {
@@ -1551,14 +1570,6 @@ editorView.controller('DesignerController', ['$scope', '$window', '$document', '
             }
         }
     };
-
-    $scope.deleteSelected = function () {
-        if ($scope.selectedCtrlId) {
-            $scope.deleteControl($scope.selectedCtrlId);
-        } else if ($scope.selectedContainerId) {
-            $scope.deleteControl($scope.selectedContainerId, true);
-        }
-    }
 
     messageHub.onDidReceiveMessage(
         'contextmenu',

--- a/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/local.html
+++ b/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/local.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -66,8 +66,9 @@
         </fd-popover-body>
       </fd-popover>
     </fd-toolbar>
-    <fd-toolbar dg-size="cozy" ng-show="searchVisible">
-      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+    <fd-toolbar dg-size="cozy" ng-if="searchVisible">
+      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text" dg-focus="true">
+      </fd-input>
     </fd-toolbar>
     <fd-scrollbar class="dg-full-height" ng-hide="branches.length || loadingBranches">
       <fd-message-page glyph="sap-icon--hint">

--- a/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/local.html
+++ b/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/local.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="localBranches" ng-controller="LocalBranchesViewController">
 

--- a/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/remote.html
+++ b/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/remote.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="remoteBranches"
   ng-controller="RemoteBranchesViewController">

--- a/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/remote.html
+++ b/components/ide/ide-ui-git-branches/src/main/resources/META-INF/dirigible/ide-git-branches/remote.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -66,8 +66,9 @@
         </fd-popover-body>
       </fd-popover>
     </fd-toolbar>
-    <fd-toolbar dg-size="cozy" ng-show="searchVisible">
-      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+    <fd-toolbar dg-size="cozy" ng-if="searchVisible">
+      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text" dg-focus="true">
+      </fd-input>
     </fd-toolbar>
     <fd-scrollbar class="dg-full-height" ng-hide="branches.length || loadingBranches">
       <fd-message-page glyph="sap-icon--hint">

--- a/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/git-projects.html
+++ b/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/git-projects.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="gitProjects" ng-controller="GitProjectsViewController">
 

--- a/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/git-projects.html
+++ b/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/git-projects.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -58,8 +58,9 @@
         </fd-popover-body>
       </fd-popover>
     </fd-toolbar>
-    <fd-toolbar ng-show="searchVisible">
-      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+    <fd-toolbar ng-if="searchVisible">
+      <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text" dg-focus="true">
+      </fd-input>
     </fd-toolbar>
     <div id="dgProjects" class="jstree-fiori--fill jstree-fiori--context-menu fd-scrollbar"
       dg-contextmenu="contextMenuContent"></div>

--- a/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/js/git-projects.js
+++ b/components/ide/ide-ui-git-projects/src/main/resources/META-INF/dirigible/ide-git-projects/js/git-projects.js
@@ -9,7 +9,7 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let gitProjectsView = angular.module('gitProjects', ['ideUI', 'ideView', 'ideWorkspace', 'ideGit']);
+const gitProjectsView = angular.module('gitProjects', ['ideUI', 'ideView', 'ideWorkspace', 'ideGit']);
 
 gitProjectsView.controller('GitProjectsViewController', [
     '$scope',
@@ -36,7 +36,7 @@ gitProjectsView.controller('GitProjectsViewController', [
         $scope.searchField = { text: '' };
         $scope.workspaceNames = [];
         $scope.imageFileExts = ['ico', 'bmp', 'png', 'jpg', 'jpeg', 'gif', 'svg'];
-        $scope.modelFileExts = ['extension', 'extensionpoint', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
+        $scope.modelFileExts = ['extension', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
 
         $scope.selectedWorkspace = JSON.parse(localStorage.getItem('DIRIGIBLE.workspace') || '{}');
         if (!$scope.selectedWorkspace.name) {
@@ -459,20 +459,28 @@ gitProjectsView.controller('GitProjectsViewController', [
         }
 
         function getFileIcon(fileName) {
-            let ext = getFileExtension(fileName);
+            const ext = getFileExtension(fileName);
             let icon;
-            if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'json') {
-                icon = "sap-icon--syntax";
+            if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'tsx' || ext === 'py' || ext === 'json') {
+                icon = 'sap-icon--syntax';
             } else if (ext === 'css' || ext === 'less' || ext === 'scss') {
-                icon = "sap-icon--number-sign";
+                icon = 'sap-icon--number-sign';
             } else if (ext === 'txt') {
-                icon = "sap-icon--text";
+                icon = 'sap-icon--text';
             } else if (ext === 'pdf') {
-                icon = "sap-icon--pdf-attachment";
+                icon = 'sap-icon--pdf-attachment';
+            } else if (ext === 'md') {
+                icon = 'sap-icon--information';
+            } else if (ext === 'access') {
+                icon = 'sap-icon--locked';
+            } else if (ext === 'zip') {
+                icon = 'sap-icon--attachment-zip-file';
+            } else if (ext === 'extensionpoint') {
+                icon = 'sap-icon--puzzle';
             } else if ($scope.imageFileExts.indexOf(ext) !== -1) {
-                icon = "sap-icon--picture";
+                icon = 'sap-icon--picture';
             } else if ($scope.modelFileExts.indexOf(ext) !== -1) {
-                icon = "sap-icon--document-text";
+                icon = 'sap-icon--document-text';
             } else {
                 icon = 'jstree-file';
             }

--- a/components/ide/ide-ui-git/src/main/resources/META-INF/dirigible/ide-git/git/history.html
+++ b/components/ide/ide-ui-git/src/main/resources/META-INF/dirigible/ide-git/git/history.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="historyApp" ng-controller="HistoryContoller">
 
     <head>

--- a/components/ide/ide-ui-git/src/main/resources/META-INF/dirigible/ide-git/index.html
+++ b/components/ide/ide-ui-git/src/main/resources/META-INF/dirigible/ide-git/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="git" ng-controller="GitController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/editor.html
+++ b/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="image-app" ng-controller="ImageViewController">
 

--- a/components/ide/ide-ui-import/src/main/resources/META-INF/dirigible/ide-import/import.html
+++ b/components/ide/ide-ui-import/src/main/resources/META-INF/dirigible/ide-import/import.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="import" ng-controller="ImportViewController">
 

--- a/components/ide/ide-ui-import/src/main/resources/META-INF/dirigible/ide-import/js/import.js
+++ b/components/ide/ide-ui-import/src/main/resources/META-INF/dirigible/ide-import/js/import.js
@@ -28,9 +28,10 @@ importView.controller('ImportViewController', [
         transportApi,
         FileUploader,
     ) {
-        let projectImportUrl = transportApi.getProjectImportUrl();
+        const projectImportUrl = transportApi.getProjectImportUrl();
         $scope.selectedWorkspace = { name: 'workspace' }; // Default
         $scope.workspaceNames = [];
+        $scope.projectsViewId = undefined;
         $scope.inDialog = false;
         $scope.importRepository = false;
         $scope.inputAccept = '.zip';
@@ -76,6 +77,7 @@ importView.controller('ImportViewController', [
                         if (pathSegments.length <= 2) $scope.uploader.url += '/%252F';
                     }
                 }
+                $scope.projectsViewId = params.projectsViewId;
             } else $scope.reloadWorkspaceList();
         }
 
@@ -116,7 +118,7 @@ importView.controller('ImportViewController', [
                 messageHub.announceRepositoryModified();
             } else if ($scope.inDialog) {
                 // Temporary, publishes all files in the import directory, not just imported ones
-                messageHub.announceWorkspaceChanged({ name: $scope.selectedWorkspace.name, publish: { path: $scope.uploadPath } });
+                messageHub.announceWorkspaceChanged({ name: $scope.selectedWorkspace.name, projectsViewId: $scope.projectsViewId, publish: { path: $scope.uploadPath } });
             } else {
                 messageHub.announceWorkspaceChanged({ name: $scope.selectedWorkspace.name, publish: { workspace: true } });
             }
@@ -143,7 +145,7 @@ importView.controller('ImportViewController', [
         };
 
         $scope.reloadWorkspaceList = function () {
-            let userSelected = JSON.parse(localStorage.getItem('DIRIGIBLE.workspace') || '{}');
+            const userSelected = JSON.parse(localStorage.getItem('DIRIGIBLE.workspace') || '{}');
             if (!userSelected.name) {
                 $scope.selectedWorkspace.name = 'workspace'; // Default
             } else {

--- a/components/ide/ide-ui-integrations/src/main/resources/META-INF/dirigible/ide-integrations/editor.html
+++ b/components/ide/ide-ui-integrations/src/main/resources/META-INF/dirigible/ide-integrations/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html id="appBase" lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="integrations"
     ng-controller="EditorViewController">

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
@@ -24,7 +24,7 @@
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox dg-center__horizontal" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox dg-center__horizontal" dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.js
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.js
@@ -93,7 +93,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/index.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2018-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="jobs" ng-controller="JobsController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-assign.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-assign.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="jobAssign" ng-controller="JobAssignController">
 
     <head>

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-logs.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-logs.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="jobLogs" ng-controller="JobLogsController" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-trigger.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/job-trigger.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="jobTrigger" ng-controller="JobTriggerController">
 
     <head>

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/jobs.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/view/jobs.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="jobs" ng-controller="JobsController as controller" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.html
+++ b/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
     <head>
@@ -11,13 +20,12 @@
         <theme></theme>
         <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
         </script>
-        <link type="text/css" rel="stylesheet"
-            href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
     <body class="fd-padding dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'"
-        dg-shortcut-action="save()">
+        dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.js
+++ b/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.js
@@ -85,7 +85,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/view/listeners.html
+++ b/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/view/listeners.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="listeners"
     ng-controller="ListenersController as controller">
 

--- a/components/ide/ide-ui-logs/src/main/resources/META-INF/dirigible/ide-logs/loggers.html
+++ b/components/ide/ide-ui-logs/src/main/resources/META-INF/dirigible/ide-logs/loggers.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="loggers" ng-controller="LoggersController">
 
     <head>

--- a/components/ide/ide-ui-logs/src/main/resources/META-INF/dirigible/ide-logs/logs.html
+++ b/components/ide/ide-ui-logs/src/main/resources/META-INF/dirigible/ide-logs/logs.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="logs" ng-controller="LogsController as controller">
 
     <head>

--- a/components/ide/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
+++ b/components/ide/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
@@ -959,8 +959,7 @@ class DirigibleEditor {
         }, "editor.file.save.all");
 
         messageHub.subscribe(function (event) {
-            const file = event.resourcePath;
-            if (file === fileName) {
+            if (event.resourcePath === fileIO.resolvePath()) {
                 new ViewParameters();
             }
         }, "core.editors.reloadParams");

--- a/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/index.html
+++ b/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2018-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="operations" ng-controller="OperationsController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/views/artefacts.html
+++ b/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/views/artefacts.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="artefacts" ng-controller="ArtefactsController as artefacts">
 
     <head>

--- a/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/views/configurations.html
+++ b/components/ide/ide-ui-operations/src/main/resources/META-INF/dirigible/ide-operations/views/configurations.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="configurations" ng-controller="ConfigurationsController as configurations">
 
     <head>

--- a/components/ide/ide-ui-plugins/src/main/resources/META-INF/dirigible/ide-plugins/views/plugins/index.html
+++ b/components/ide/ide-ui-plugins/src/main/resources/META-INF/dirigible/ide-plugins/views/plugins/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2018 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="plugins" ng-controller="PluginsController as controller">
 
     <head>

--- a/components/ide/ide-ui-preview/src/main/resources/META-INF/dirigible/ide-preview/preview.html
+++ b/components/ide/ide-ui-preview/src/main/resources/META-INF/dirigible/ide-preview/preview.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="preview" ng-controller="PreviewController">
 
     <head>

--- a/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problem-details.html
+++ b/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problem-details.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2020 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="problemDetails"
     ng-controller="ProblemDetailsController as problem">
 

--- a/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problems.html
+++ b/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problems.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -8,7 +8,6 @@
   ~ Contributors:
   ~ SAP - initial API and implementation
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="problems" ng-controller="ProblemsController as problems">
 
     <head>
@@ -46,7 +45,7 @@
                     <span class="sap-icon--search" role="presentation"></span>
                 </fd-input-group-addon>
                 <fd-input type="search" in-group="true" ng-model="problems.searchText"
-                    ng-keyup="problems.inputSearchKeyUp($event)" placeholder="Search">
+                    ng-keyup="problems.inputSearchKeyUp($event)" dg-focus="true" placeholder="Search">
                 </fd-input>
                 <fd-input-group-addon ng-if="problems.filterBy" has-button="true">
                     <fd-button in-group="true" glyph="sap-icon--clear-filter" dg-type="transparent"

--- a/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problems.html
+++ b/components/ide/ide-ui-problems/src/main/resources/META-INF/dirigible/ide-problems/problems.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="problems" ng-controller="ProblemsController as problems">
 

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
@@ -343,20 +343,10 @@ projectsView.controller('ProjectsViewController', [
         function getProjectNode(parents) {
             for (let i = 0; i < parents.length; i++) {
                 if (parents[i] !== '#') {
-                    let parent = $scope.jstreeWidget.jstree(true).get_node(parents[i]);
+                    const parent = $scope.jstreeWidget.jstree(true).get_node(parents[i]);
                     if (parent.type === 'project') {
                         return parent;
                     }
-                }
-            }
-        }
-
-        function setParentsIndicator(parents, modified) {
-            for (let i = 0; i < parents.length; i++) {
-                if (parents[i] !== '#') {
-                    const parent = $scope.jstreeWidget.jstree(true).get_node(parents[i]);
-                    parent.state.containsChanges = modified;
-                    $scope.jstreeWidget.jstree(true).redraw_node(parent);
                 }
             }
         }
@@ -1634,12 +1624,18 @@ projectsView.controller('ProjectsViewController', [
                 const instance = $scope.jstreeWidget.jstree(true);
                 for (let item in instance._model.data) { // Uses the unofficial '_model' property but this is A LOT faster then using 'get_json()'
                     if (item !== '#' && instance._model.data.hasOwnProperty(item) && instance._model.data[item].data.path === fileDescriptor.path) {
-                        const parent = getProjectNode(instance._model.data[item].parents);
-                        if (parent.li_attr.git) {
-                            if (data.status === 'modified')
-                                instance._model.data[item].state.status = 'M';
-                            else instance._model.data[item].state.status = undefined;
-                            instance.redraw_node(instance._model.data[item], false, false, false, data.status === 'modified');
+                        for (let i = 0; i < instance._model.data[item].parents.length; i++) {
+                            if (instance._model.data[item].parents[i] !== '#') {
+                                if (instance._model.data[instance._model.data[item].parents[i]].type === 'project') {
+                                    if (instance._model.data[instance._model.data[item].parents[i]].li_attr.git) {
+                                        if (data.status === 'modified')
+                                            instance._model.data[item].state.status = 'M';
+                                        else instance._model.data[item].state.status = undefined;
+                                        instance.redraw_node(instance._model.data[item], false, false, false, data.status === 'modified');
+                                    }
+                                    return;
+                                }
+                            }
                         }
                         break;
                     }

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
@@ -9,7 +9,7 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let projectsView = angular.module('projects', ['ideUI', 'ideView', 'ideEditors', 'ideWorkspace', 'idePublisher', 'ideTemplates', 'ideGenerate', 'ideTransport', 'ideActions']);
+const projectsView = angular.module('projects', ['ideUI', 'ideView', 'ideEditors', 'ideWorkspace', 'idePublisher', 'ideTemplates', 'ideGenerate', 'ideTransport', 'ideActions']);
 
 projectsView.controller('ProjectsViewController', [
     '$scope',
@@ -21,6 +21,7 @@ projectsView.controller('ProjectsViewController', [
     'generateApi',
     'transportApi',
     'actionsApi',
+    'platform',
     function (
         $scope,
         messageHub,
@@ -31,6 +32,7 @@ projectsView.controller('ProjectsViewController', [
         generateApi,
         transportApi,
         actionsApi,
+        platform
     ) {
         $scope.state = {
             isBusy: true,
@@ -76,55 +78,32 @@ projectsView.controller('ProjectsViewController', [
 
         $scope.jstreeWidget = angular.element('#dgProjects');
         $scope.spinnerObj = {
-            text: "Loading...",
-            type: "spinner",
+            text: 'Loading...',
+            type: 'spinner',
             li_attr: { spinner: true },
         };
         $scope.jstreeConfig = {
             core: {
                 check_callback: true,
                 themes: {
-                    name: "fiori",
-                    variant: "compact",
+                    name: 'fiori',
+                    variant: 'compact',
                 },
-                data: function (node, cb) {
+                data: function (_node, cb) {
                     cb($scope.projects);
                 },
-                keyboard: {
-                    'enter': function (e) {
-                        e.type = "dblclick";
-                        $(e.currentTarget).trigger(e);
-                    },
-                    'f2': function (e) {
-                        e.preventDefault();
-                        $scope.renameNodeData = $scope.jstreeWidget.jstree(true).get_node(e.target.id);
-                        openRenameDialog();
-                    },
-                    'delete': function () {
-                        let nodes = $scope.jstreeWidget.jstree(true).get_selected(true);
-                        if (nodes.length === 1) openDeleteDialog(nodes[0]);
-                        else if (nodes.length > 1) openDeleteDialog(nodes);
-                    },
-                    'ctrl+c': function (e) {
-                        $scope.jstreeWidget.jstree(true).copy($scope.jstreeWidget.jstree(true).get_node(e.target.id));
-                    },
-                    'ctrl+x': function (e) {
-                        $scope.jstreeWidget.jstree(true).cut($scope.jstreeWidget.jstree(true).get_node(e.target.id));
-                    },
-                    'ctrl+v': function (e) {
-                        if ($scope.jstreeWidget.jstree(true).can_paste()) {
-                            let parent = $scope.jstreeWidget.jstree(true).get_node(e.target.id);
-                            if (parent.type === 'folder' || parent.type === 'project') {
-                                $scope.jstreeWidget.jstree(true).paste(parent);
-                            }
-                        }
-                    },
-                },
+                keyboard: { // We have to have this, in order to disable the default behavior.
+                    'enter': function () { },
+                    'f2': function () { },
+                    // 'down': function (e) {
+                    //     console.log(e)
+                    // }
+                }
             },
             search: {
                 case_sensitive: false,
             },
-            plugins: ["wholerow", "dnd", "search", "state", "types", "indicator"],
+            plugins: ['wholerow', 'dnd', 'search', 'state', 'types', 'indicator'],
             dnd: {
                 large_drop_target: true,
                 large_drag_target: true,
@@ -138,32 +117,88 @@ projectsView.controller('ProjectsViewController', [
             state: { key: 'ide-projects' },
             types: {
                 '#': {
-                    valid_children: ["project"]
+                    valid_children: ['project']
                 },
-                "default": {
-                    icon: "sap-icon--question-mark",
+                'default': {
+                    icon: 'sap-icon--question-mark',
                     valid_children: [],
                 },
                 file: {
-                    icon: "jstree-file",
+                    icon: 'jstree-file',
                     valid_children: [],
                 },
                 folder: {
-                    icon: "jstree-folder",
+                    icon: 'jstree-folder',
                     valid_children: ['folder', 'file', 'spinner'],
                 },
                 project: {
-                    icon: "jstree-project",
+                    icon: 'jstree-project',
                     valid_children: ['folder', 'file', 'spinner'],
                 },
                 spinner: {
-                    icon: "jstree-spinner",
+                    icon: 'jstree-spinner',
                     valid_children: [],
                 },
             },
         };
 
-        $scope.jstreeWidget.on('select_node.jstree', function (event, data) {
+        $scope.keyboardShortcuts = function (keySet, event) {
+            event.preventDefault();
+            let nodes;
+            switch (keySet) {
+                case 'enter':
+                    const focused = $scope.jstreeWidget.jstree(true).get_node(document.activeElement);
+                    if (focused && !focused.state.selected) {
+                        $scope.jstreeWidget.jstree(true).deselect_all();
+                        $scope.jstreeWidget.jstree(true).select_node(focused);
+                        openFile(focused);
+                    } else {
+                        nodes = $scope.jstreeWidget.jstree(true).get_selected(true);
+                        for (let i = 0; i < nodes.length; i++) {
+                            if (nodes[i].type === 'file') {
+                                openFile(nodes[0]);
+                            } else if (nodes[i].type === 'folder' || nodes[i].type === 'project') {
+                                if (nodes[i].state.opened) $scope.jstreeWidget.jstree(true).close_node(nodes[i]);
+                                else $scope.jstreeWidget.jstree(true).open_node(nodes[i]);
+                            }
+                        }
+                    }
+                    break;
+                case 'f2':
+                    nodes = $scope.jstreeWidget.jstree(true).get_selected(true);
+                    if (nodes.length < 2) {
+                        $scope.renameNodeData = nodes[0];
+                        openRenameDialog();
+                    }
+                    break;
+                case 'delete':
+                case 'meta+backspace':
+                    nodes = $scope.jstreeWidget.jstree(true).get_top_selected(true);
+                    if (nodes.length === 1) openDeleteDialog(nodes[0]);
+                    else if (nodes.length > 1) openDeleteDialog(nodes);
+                    break;
+                case 'ctrl+c':
+                    nodes = $scope.jstreeWidget.jstree(true).get_top_selected(true);
+                    $scope.jstreeWidget.jstree(true).copy(nodes);
+                    break;
+                case 'ctrl+x':
+                    nodes = $scope.jstreeWidget.jstree(true).get_top_selected(true);
+                    $scope.jstreeWidget.jstree(true).cut(nodes[0]);
+                    break;
+                case 'ctrl+v':
+                    nodes = $scope.jstreeWidget.jstree(true).get_selected(true);
+                    if (nodes.length === 1 && $scope.jstreeWidget.jstree(true).can_paste()) {
+                        if (nodes[0].type === 'folder' || nodes[0].type === 'project') {
+                            $scope.jstreeWidget.jstree(true).paste(nodes[0]);
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+        };
+
+        $scope.jstreeWidget.on('select_node.jstree', function (_event, data) {
             if (data.event && data.event.type === 'click' && data.node.type === 'file') {
                 messageHub.announceFileSelected({
                     name: data.node.text,
@@ -180,6 +215,50 @@ projectsView.controller('ProjectsViewController', [
                 openFile(node);
             }
         });
+
+        $scope.tstCopy = function () {
+            workspaceApi.copy(
+                ['/1test/index.html', '/1test/view.js'],
+                '/1test/test',
+                'workspace',
+                'workspace',
+            ).then(function (response) {
+                if (response.status === 201) {
+                    $scope.reloadWorkspace();
+                } else {
+                    console.log(response);
+                }
+            });
+        };
+
+        // $scope.jstreeWidget.on('paste.jstree', function (_event, pasteObj) {
+        //     console.log(_event, pasteObj);
+        //     if (pasteObj.mode === 'copy_node') {
+        //         const parent = $scope.jstreeWidget.jstree(true).get_node(pasteObj.parent);
+        //         const spinnerId = showSpinner(parent);
+        //         const targetWorkspace = parent.data.workspace;
+        //         const sourceWorkspace = pasteObj.node[0].data.workspace;
+        //         const targetPath = (parent.data.path.endsWith('/') ? parent.data.path : parent.data.path + '/');
+        //         let copyArray = [];
+        //         for (let i = 0; i < pasteObj.node.length; i++) {
+        //             copyArray.push(targetPath + pasteObj.node[i].text);
+        //         }
+        //         workspaceApi.copy(
+        //             copyArray,
+        //             targetPath,
+        //             sourceWorkspace,
+        //             targetWorkspace,
+        //         ).then(function (response) {
+        //             if (response.status === 201) {
+        //                 console.log(response);
+        //                 // $scope.reloadWorkspace();
+        //             } else {
+        //                 console.log(response);
+        //             }
+        //             hideSpinner(spinnerId);
+        //         });
+        //     }
+        // });
 
         $scope.jstreeWidget.on('copy_node.jstree', function (event, copyObj) {
             if (!copyObj.node.state.failedCopy) {
@@ -220,7 +299,57 @@ projectsView.controller('ProjectsViewController', [
             } else delete copyObj.node.state.failedCopy;
         });
 
-        $scope.jstreeWidget.on('move_node.jstree', function (event, moveObj) {
+        // $scope.jstreeWidget.on('copy_node.jstree', function (_event, copyObj) {
+        //     if (!copyObj.node.state.failedCopy) {
+        //         $scope.jstreeWidget.jstree(true).hide_node(copyObj.node);
+        //         const parent = $scope.jstreeWidget.jstree(true).get_node(copyObj.parent);
+        //         const spinnerId = showSpinner(parent);
+        //         let workspace;
+        //         let path;
+        //         workspace = parent.data.workspace;
+        //         path = (parent.data.path.endsWith('/') ? parent.data.path : parent.data.path + '/');
+        //         const buffer = $scope.jstreeWidget.jstree(true).get_buffer();
+        //         $scope.jstreeWidget.jstree(true).clear_buffer();
+        //         let copyArray = [];
+        //         const targetWorkspace = copyObj.original.data.workspace;
+        //         if (buffer.node.length) {
+        //             for (let i = 0; i < buffer.node.length; i++) {
+        //                 copyArray.push(path + buffer.node[i].text);
+        //             }
+        //         } else {
+        //             copyObj.node.data = {
+        //                 path: path + copyObj.node.text,
+        //                 contentType: copyObj.original.data.contentType,
+        //                 workspace: workspace,
+        //             };
+        //         }
+        //         copyArray.push(copyObj.original.data.path);
+        //         workspaceApi.copy(
+        //             copyObj.original.data.path,
+        //             path,
+        //             targetWorkspace,
+        //             workspace,
+        //         ).then(function (response) {
+        //             if (response.status === 201) {
+        //                 for (let i = 0; i < parent.children.length; i++) { // Temp solution
+        //                     const node = $scope.jstreeWidget.jstree(true).get_node(parent.children[i]);
+        //                     if (node.text === copyObj.node.text && node.id !== copyObj.node.id) {
+        //                         $scope.reloadWorkspace();
+        //                         return;
+        //                     }
+        //                 }
+        //                 $scope.jstreeWidget.jstree(true).show_node(copyObj.node);
+        //             } else {
+        //                 copyObj.node.state.failedCopy = true;
+        //                 messageHub.setStatusError(`Unable to copy '${copyObj.node.text}'.`);
+        //                 $scope.jstreeWidget.jstree(true).delete_node(copyObj.node);
+        //             }
+        //             hideSpinner(spinnerId);
+        //         });
+        //     } else delete copyObj.node.state.failedCopy;
+        // });
+
+        $scope.jstreeWidget.on('move_node.jstree', function (_event, moveObj) {
             function failedToMove(showAlert = true) {
                 moveObj.node.state.failedMove = true;
                 if (showAlert)
@@ -377,7 +506,7 @@ projectsView.controller('ProjectsViewController', [
             if ($scope.jstreeWidget[0].contains(element)) {
                 let id;
                 if (element.tagName !== "LI") {
-                    let closest = element.closest("li");
+                    const closest = element.closest("li");
                     if (closest) {
                         id = closest.id;
                     } else {
@@ -416,14 +545,14 @@ projectsView.controller('ProjectsViewController', [
                     id = element.id;
                 }
                 if (id) {
-                    let node = $scope.jstreeWidget.jstree(true).get_node(id);
+                    const node = $scope.jstreeWidget.jstree(true).get_node(id);
                     if (!node.state.selected) {
                         $scope.jstreeWidget.jstree(true).deselect_all();
                         $scope.jstreeWidget.jstree(true).select_node(node, false, true);
                     }
                     let nodes = $scope.jstreeWidget.jstree(true).get_selected(false);
                     if (nodes.length === 1) nodes.length = 0;
-                    let newSubmenu = {
+                    const newSubmenu = {
                         id: "new",
                         label: "New",
                         icon: "sap-icon--create",
@@ -445,30 +574,30 @@ projectsView.controller('ProjectsViewController', [
                             },
                         }]
                     };
-                    let cutObj = {
+                    const cutObj = {
                         id: "cut",
                         label: "Cut",
-                        shortcut: "Ctrl+X",
+                        shortcut: platform.isMac ? '⌘X' : 'Ctrl+X',
                         divider: true,
                         icon: "sap-icon--scissors",
                         data: node,
                     };
-                    let copyObj = {
+                    const copyObj = {
                         id: "copy",
                         label: "Copy",
-                        shortcut: "Ctrl+C",
+                        shortcut: platform.isMac ? '⌘C' : 'Ctrl+C',
                         icon: "sap-icon--copy",
                         data: node,
                     };
-                    let pasteObj = {
+                    const pasteObj = {
                         id: "paste",
                         label: "Paste",
-                        shortcut: "Ctrl+V",
+                        shortcut: platform.isMac ? '⌘V' : 'Ctrl+V',
                         icon: "sap-icon--paste",
-                        isDisabled: !$scope.jstreeWidget.jstree(true).can_paste(),
+                        isDisabled: !$scope.jstreeWidget.jstree(true).can_paste() || nodes.length > 1,
                         data: node,
                     };
-                    let renameObj = {
+                    const renameObj = {
                         id: "rename",
                         label: "Rename",
                         shortcut: "F2",
@@ -476,10 +605,10 @@ projectsView.controller('ProjectsViewController', [
                         icon: "sap-icon--edit",
                         data: node,
                     };
-                    let deleteObj = {
+                    const deleteObj = {
                         id: "delete",
                         label: (nodes.length) ? `Delete ${nodes.length} items` : "Delete",
-                        shortcut: "Del",
+                        shortcut: platform.isMac ? '⌘⌫' : 'Del',
                         icon: "sap-icon--delete",
                         data: (nodes.length) ? nodes : node,
                     };
@@ -520,14 +649,14 @@ projectsView.controller('ProjectsViewController', [
                             data: node,
                         };
                     }
-                    let importObj = {
+                    const importObj = {
                         id: "import",
                         label: "Import",
                         icon: "sap-icon--attachment",
                         divider: true,
                         data: node,
                     };
-                    let importZipObj = {
+                    const importZipObj = {
                         id: "importZip",
                         label: "Import from zip",
                         icon: "sap-icon--attachment-zip-file",
@@ -1313,7 +1442,7 @@ projectsView.controller('ProjectsViewController', [
         }
 
         function openDeleteDialog(selected) {
-            let isMultiple = Array.isArray(selected);
+            const isMultiple = Array.isArray(selected);
             messageHub.showDialogAsync(
                 (isMultiple) ? `Delete ${selected.length} items?` : `Delete '${selected.text}'?`,
                 'This action cannot be undone. It is recommended that you unpublish and delete.',

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/js/projects.js
@@ -158,6 +158,11 @@ projectsView.controller('ProjectsViewController', [
                         openSelected([focused]);
                     } else openSelected();
                     break;
+                case 'shift+enter':
+                    const toSelect = $scope.jstreeWidget.jstree(true).get_node(document.activeElement);
+                    if (toSelect && !toSelect.state.selected) $scope.jstreeWidget.jstree(true).select_node(toSelect);
+                    else $scope.jstreeWidget.jstree(true).deselect_node(toSelect);
+                    break;
                 case 'f2':
                     nodes = $scope.jstreeWidget.jstree(true).get_selected(true);
                     if (nodes.length < 2) {
@@ -170,6 +175,9 @@ projectsView.controller('ProjectsViewController', [
                     nodes = $scope.jstreeWidget.jstree(true).get_top_selected(true);
                     if (nodes.length === 1) openDeleteDialog(nodes[0]);
                     else if (nodes.length > 1) openDeleteDialog(nodes);
+                    break;
+                case 'ctrl+f':
+                    $scope.$apply(() => $scope.toggleSearch());
                     break;
                 case 'ctrl+c':
                     $scope.jstreeWidget.jstree(true).copy($scope.jstreeWidget.jstree(true).get_top_selected(true));
@@ -1167,8 +1175,12 @@ projectsView.controller('ProjectsViewController', [
         };
 
         let to = 0;
-        $scope.search = function () {
+        $scope.search = function (event) {
             if (to) { clearTimeout(to); }
+            if (event.originalEvent.key === "Escape") {
+                $scope.toggleSearch();
+                return;
+            }
             to = setTimeout(function () {
                 $scope.jstreeWidget.jstree(true).search($scope.searchField.text);
             }, 250);

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -32,7 +32,8 @@
         <script type="text/javascript" src="js/projects.js"></script>
     </head>
 
-    <body class="dg-vbox">
+    <body class="dg-vbox" dg-shortcut="'enter|f2|delete|ctrl+c|ctrl+x|ctrl+v|meta+backspace|down'"
+        dg-shortcut-action="keyboardShortcuts" ignore-inputs>
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
@@ -42,7 +42,7 @@
             <fd-button compact="true" dg-type="transparent" glyph="sap-icon--save" title="Save all"
                 aria-label="Save all" ng-click="saveAll()"></fd-button>
             <fd-button compact="true" dg-type="transparent" glyph="sap-icon--play" title="Publish all"
-                aria-label="Publish all" ng-click="publishAll()" ng-show="isPublishEnabled()"></fd-button>
+                aria-label="Publish all" ng-click="publishAll()" ng-if="isPublishEnabled()"></fd-button>
             <fd-button compact="true" dg-type="transparent" glyph="sap-icon--refresh" title="Refresh"
                 aria-label="Refresh" ng-click="reloadWorkspace()"></fd-button>
             <fd-toolbar-separator></fd-toolbar-separator>
@@ -72,9 +72,6 @@
                 <fd-button dg-type="transparent" dg-label="Duplicate project" glyph="sap-icon--duplicate"
                     is-overflow="true" ng-click="duplicateProject()">
                 </fd-button>
-                <!-- <fd-button dg-type="transparent" dg-label="Link project" glyph="sap-icon--chain-link"
-                    is-overflow="true" ng-click="linkProject()">
-                </fd-button> -->
                 <fd-button dg-type="transparent" dg-label="Export projects" glyph="sap-icon--download-from-cloud"
                     is-overflow="true" ng-click="exportProjects()">
                 </fd-button>
@@ -87,8 +84,10 @@
                 </fd-button>
             </fd-toolbar-overflow>
         </fd-toolbar>
-        <fd-toolbar ng-show="searchVisible && !state.error && !state.isBusy">
-            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+        <fd-toolbar ng-if="searchVisible && !state.error && !state.isBusy">
+            <fd-input type="search" placeholder="Search" ng-keyup="search()" dg-focus="true"
+                ng-model="searchField.text">
+            </fd-input>
         </fd-toolbar>
         <div id="dgProjects" class="jstree-fiori--fill jstree-fiori--context-menu fd-scrollbar"
             dg-contextmenu="contextMenuContent" ng-show="!state.error && !state.isBusy"></div>

--- a/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
+++ b/components/ide/ide-ui-projects/src/main/resources/META-INF/dirigible/ide-projects/projects.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="projects" ng-controller="ProjectsViewController">
 
@@ -32,7 +32,7 @@
         <script type="text/javascript" src="js/projects.js"></script>
     </head>
 
-    <body class="dg-vbox" dg-shortcut="'enter|f2|delete|ctrl+c|ctrl+x|ctrl+v|meta+backspace|down'"
+    <body class="dg-vbox" dg-shortcut="'enter|shift+enter|f2|delete|ctrl+f|ctrl+c|ctrl+x|ctrl+v|meta+backspace|down'"
         dg-shortcut-action="keyboardShortcuts" ignore-inputs>
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
@@ -85,7 +85,7 @@
             </fd-toolbar-overflow>
         </fd-toolbar>
         <fd-toolbar ng-if="searchVisible && !state.error && !state.isBusy">
-            <fd-input type="search" placeholder="Search" ng-keyup="search()" dg-focus="true"
+            <fd-input type="search" placeholder="Search" ng-keyup="search($event)" dg-focus="true"
                 ng-model="searchField.text">
             </fd-input>
         </fd-toolbar>

--- a/components/ide/ide-ui-properties/src/main/resources/META-INF/dirigible/ide-properties/properties.html
+++ b/components/ide/ide-ui-properties/src/main/resources/META-INF/dirigible/ide-properties/properties.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="properties" ng-controller="PropertiesController">
 
   <head>

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/js/registry.js
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/js/registry.js
@@ -9,15 +9,17 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let registryView = angular.module('registry', ['ideUI', 'ideView', 'ideRepository', 'ideRegistry']);
+const registryView = angular.module('registry', ['ideUI', 'ideView', 'ideRepository', 'ideRegistry']);
 registryView.controller('RegistryController', [
 	'$scope',
+	'$document',
 	'messageHub',
 	'ViewParameters',
 	'repositoryApi',
 	'registryApi',
 	function (
 		$scope,
+		$document,
 		messageHub,
 		ViewParameters,
 		repositoryApi,
@@ -31,7 +33,7 @@ registryView.controller('RegistryController', [
 		};
 		$scope.renameNodeData;
 		$scope.imageFileExts = ['ico', 'bmp', 'png', 'jpg', 'jpeg', 'gif', 'svg'];
-		$scope.modelFileExts = ['extension', 'extensionpoint', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
+		$scope.modelFileExts = ['extension', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
 
 		$scope.treeData = [];
 		$scope.basePath = '/';
@@ -290,20 +292,28 @@ registryView.controller('RegistryController', [
 		}
 
 		function getFileIcon(fileName) {
-			let ext = getFileExtension(fileName);
+			const ext = getFileExtension(fileName);
 			let icon;
-			if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'json') {
-				icon = "sap-icon--syntax";
+			if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'tsx' || ext === 'py' || ext === 'json') {
+				icon = 'sap-icon--syntax';
 			} else if (ext === 'css' || ext === 'less' || ext === 'scss') {
-				icon = "sap-icon--number-sign";
+				icon = 'sap-icon--number-sign';
 			} else if (ext === 'txt') {
-				icon = "sap-icon--text";
+				icon = 'sap-icon--text';
 			} else if (ext === 'pdf') {
-				icon = "sap-icon--pdf-attachment";
+				icon = 'sap-icon--pdf-attachment';
+			} else if (ext === 'md') {
+				icon = 'sap-icon--information';
+			} else if (ext === 'access') {
+				icon = 'sap-icon--locked';
+			} else if (ext === 'zip') {
+				icon = 'sap-icon--attachment-zip-file';
+			} else if (ext === 'extensionpoint') {
+				icon = 'sap-icon--puzzle';
 			} else if ($scope.imageFileExts.indexOf(ext) !== -1) {
-				icon = "sap-icon--picture";
+				icon = 'sap-icon--picture';
 			} else if ($scope.modelFileExts.indexOf(ext) !== -1) {
-				icon = "sap-icon--document-text";
+				icon = 'sap-icon--document-text';
 			} else {
 				icon = 'jstree-file';
 			}
@@ -555,7 +565,8 @@ registryView.controller('RegistryController', [
 			true
 		);
 
-		// Initialization
-		$scope.reloadFileTree($scope.basePath, true);
+		angular.element($document[0]).ready(function () {
+			$scope.reloadFileTree($scope.basePath, true);
+		});
 		$scope.parameters = ViewParameters.get();
 	}]);

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/registry.html
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/registry.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="registry" ng-controller="RegistryController">
 

--- a/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/registry.html
+++ b/components/ide/ide-ui-registry/src/main/resources/META-INF/dirigible/ide-registry/registry.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -8,7 +8,6 @@
   ~ Contributors:
   ~ SAP - initial API and implementation
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="registry" ng-controller="RegistryController">
 
     <head>
@@ -37,8 +36,9 @@
                 title="Toggle search" aria-label="Toggle search" ng-click="toggleSearch()">
             </fd-button>
         </fd-toolbar>
-        <fd-toolbar ng-show="searchVisible">
-            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+        <fd-toolbar ng-if="searchVisible">
+            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"
+                dg-focus="true"></fd-input>
         </fd-toolbar>
         <div id="dgRegistry" class="jstree-fiori--fill jstree-fiori--context-menu fd-scrollbar"
             dg-contextmenu="contextMenuContent"></div>

--- a/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/js/repository.js
+++ b/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/js/repository.js
@@ -9,15 +9,17 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let repositoryView = angular.module('repository', ['ideUI', 'ideView', 'ideEditors', 'ideTransport', 'ideRepository']);
+const repositoryView = angular.module('repository', ['ideUI', 'ideView', 'ideEditors', 'ideTransport', 'ideRepository']);
 repositoryView.controller('RepositoryViewController', [
     '$scope',
+    '$document',
     'messageHub',
     'Editors',
     'transportApi',
     'repositoryApi',
     function (
         $scope,
+        $document,
         messageHub,
         Editors,
         transportApi,
@@ -31,7 +33,7 @@ repositoryView.controller('RepositoryViewController', [
         };
         $scope.renameNodeData;
         $scope.imageFileExts = ['ico', 'bmp', 'png', 'jpg', 'jpeg', 'gif', 'svg'];
-        $scope.modelFileExts = ['extension', 'extensionpoint', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
+        $scope.modelFileExts = ['extension', 'edm', 'model', 'dsm', 'schema', 'bpmn', 'job', 'listener', 'websocket', 'roles', 'constraints', 'table', 'view'];
 
         $scope.treeData = [];
         $scope.basePath = '/';
@@ -308,51 +310,59 @@ repositoryView.controller('RepositoryViewController', [
         }
 
         function getFileIcon(fileName) {
-            let ext = getFileExtension(fileName);
+            const ext = getFileExtension(fileName);
             let icon;
-            if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'json') {
-                icon = "sap-icon--syntax";
+            if (ext === 'js' || ext === 'mjs' || ext === 'xsjs' || ext === 'ts' || ext === 'tsx' || ext === 'py' || ext === 'json') {
+                icon = 'sap-icon--syntax';
             } else if (ext === 'css' || ext === 'less' || ext === 'scss') {
-                icon = "sap-icon--number-sign";
+                icon = 'sap-icon--number-sign';
             } else if (ext === 'txt') {
-                icon = "sap-icon--text";
+                icon = 'sap-icon--text';
             } else if (ext === 'pdf') {
-                icon = "sap-icon--pdf-attachment";
+                icon = 'sap-icon--pdf-attachment';
+            } else if (ext === 'md') {
+                icon = 'sap-icon--information';
+            } else if (ext === 'access') {
+                icon = 'sap-icon--locked';
+            } else if (ext === 'zip') {
+                icon = 'sap-icon--attachment-zip-file';
+            } else if (ext === 'extensionpoint') {
+                icon = 'sap-icon--puzzle';
             } else if ($scope.imageFileExts.indexOf(ext) !== -1) {
-                icon = "sap-icon--picture";
+                icon = 'sap-icon--picture';
             } else if ($scope.modelFileExts.indexOf(ext) !== -1) {
-                icon = "sap-icon--document-text";
+                icon = 'sap-icon--document-text';
             } else {
                 icon = 'jstree-file';
             }
             return icon;
         }
 
-        function getEditorsForType(node) {
-            let editors = [{
-                id: 'openWith',
-                label: Editors.defaultEditor.label,
-                data: {
-                    node: node,
-                    editorId: Editors.defaultEditor.id,
-                }
-            }];
-            let editorsForContentType = Editors.editorsForContentType;
-            if (Object.keys(editorsForContentType).indexOf(node.data.contentType) > -1) {
-                for (let i = 0; i < editorsForContentType[node.data.contentType].length; i++) {
-                    if (editorsForContentType[node.data.contentType][i].id !== Editors.defaultEditor.id)
-                        editors.push({
-                            id: 'openWith',
-                            label: editorsForContentType[node.data.contentType][i].label,
-                            data: {
-                                node: node,
-                                editorId: editorsForContentType[node.data.contentType][i].id,
-                            }
-                        });
-                }
-            }
-            return editors;
-        }
+        // function getEditorsForType(node) {
+        //     let editors = [{
+        //         id: 'openWith',
+        //         label: Editors.defaultEditor.label,
+        //         data: {
+        //             node: node,
+        //             editorId: Editors.defaultEditor.id,
+        //         }
+        //     }];
+        //     let editorsForContentType = Editors.editorsForContentType;
+        //     if (Object.keys(editorsForContentType).indexOf(node.data.contentType) > -1) {
+        //         for (let i = 0; i < editorsForContentType[node.data.contentType].length; i++) {
+        //             if (editorsForContentType[node.data.contentType][i].id !== Editors.defaultEditor.id)
+        //                 editors.push({
+        //                     id: 'openWith',
+        //                     label: editorsForContentType[node.data.contentType][i].label,
+        //                     data: {
+        //                         node: node,
+        //                         editorId: editorsForContentType[node.data.contentType][i].id,
+        //                     }
+        //                 });
+        //         }
+        //     }
+        //     return editors;
+        // }
 
         function openFile(node, editor) {
             messageHub.openEditor(
@@ -603,6 +613,7 @@ repositoryView.controller('RepositoryViewController', [
             true
         );
 
-        // Initialization
-        $scope.reloadFileTree($scope.basePath, true);
+        angular.element($document[0]).ready(function () {
+            $scope.reloadFileTree($scope.basePath, true);
+        });
     }]);

--- a/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/repository.html
+++ b/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/repository.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="repository" ng-controller="RepositoryViewController">
 

--- a/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/repository.html
+++ b/components/ide/ide-ui-repository/src/main/resources/META-INF/dirigible/ide-repository/repository.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2010-2024 SAP and others.
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
@@ -42,8 +42,9 @@
             <fd-button dg-type="transparent" glyph="sap-icon--download-from-cloud" title="Export" aria-label="Export"
                 ng-click="exportRepository()"></fd-button>
         </fd-toolbar>
-        <fd-toolbar ng-show="searchVisible">
-            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"></fd-input>
+        <fd-toolbar ng-if="searchVisible">
+            <fd-input type="search" placeholder="Search" ng-keyup="search()" ng-model="searchField.text"
+                dg-focus="true"></fd-input>
         </fd-toolbar>
         <div id="dgRepository" class="jstree-fiori--fill jstree-fiori--context-menu fd-scrollbar"
             dg-contextmenu="contextMenuContent"></div>

--- a/components/ide/ide-ui-result/src/main/resources/META-INF/dirigible/ide-result/result.html
+++ b/components/ide/ide-ui-result/src/main/resources/META-INF/dirigible/ide-result/result.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="result" ng-controller="DatabaseResultController" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-schema/src/main/resources/META-INF/dirigible/ide-schema/modeler.html
+++ b/components/ide/ide-ui-schema/src/main/resources/META-INF/dirigible/ide-schema/modeler.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="ui.schema.modeler" ng-controller="ModelerCtrl as ctrl">
 

--- a/components/ide/ide-ui-search/src/main/resources/META-INF/dirigible/ide-search/search.html
+++ b/components/ide/ide-ui-search/src/main/resources/META-INF/dirigible/ide-search/search.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="search" ng-controller="SearchController">
 
     <head>

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
@@ -24,7 +24,7 @@
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-full-height" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.js
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.js
@@ -95,7 +95,8 @@ angular.module('page', ["ideUI", "ideView"])
             xhr.send(text);
         }
 
-        $scope.save = function () {
+        $scope.save = function (_keySet, event) {
+            if (event) event.preventDefault();
             if (!$scope.state.error) {
                 $scope.state.busyText = "Saving...";
                 $scope.state.isBusy = true;

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
@@ -24,7 +24,7 @@
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
-    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save()">
+    <body class="dg-vbox" dg-shortcut="'ctrl+s'" dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-full-height" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.js
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.js
@@ -82,7 +82,8 @@ angular.module('page', ["ideUI", "ideView"])
             xhr.send(text);
         }
 
-        $scope.save = function () {
+        $scope.save = function (_keySet, event) {
+            if (event) event.preventDefault();
             if (!$scope.state.error) {
                 $scope.state.busyText = "Saving...";
                 $scope.state.isBusy = true;

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/views/access.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/views/access.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="access" ng-controller="AccessController as controller">
 
     <head>

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/views/roles.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/views/roles.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="roles" ng-controller="RolesController as controller">
 
     <head>

--- a/components/ide/ide-ui-sql/src/main/resources/META-INF/dirigible/ide-sql/editor.html
+++ b/components/ide/ide-ui-sql/src/main/resources/META-INF/dirigible/ide-sql/editor.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2022 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 
   <head>

--- a/components/ide/ide-ui-staging/src/main/resources/META-INF/dirigible/ide-staging/staging.html
+++ b/components/ide/ide-ui-staging/src/main/resources/META-INF/dirigible/ide-staging/staging.html
@@ -1,12 +1,12 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="staging" ng-controller="StagingViewController">
 

--- a/components/ide/ide-ui-terminal/src/main/resources/META-INF/dirigible/ide-terminal/index.html
+++ b/components/ide/ide-ui-terminal/src/main/resources/META-INF/dirigible/ide-terminal/index.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2020 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" ng-app="terminal" ng-controller="TerminalController" xmlns="http://www.w3.org/1999/xhtml">
 
     <head>

--- a/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.html
+++ b/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.html
@@ -1,4 +1,13 @@
 <!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.eclipse.org/legal/epl-v20.html
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
 <html lang="en" ng-app="page" ng-controller="PageController">
 
     <head>
@@ -11,13 +20,12 @@
         <theme></theme>
         <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
         </script>
-        <link type="text/css" rel="stylesheet"
-            href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 
     <body class="fd-padding dg-vbox dg-center__horizontal" fd-scrollbar dg-shortcut="'ctrl+s'"
-        dg-shortcut-action="save()">
+        dg-shortcut-action="save">
         <fd-busy-indicator-extended class="dg-fill-parent" ng-hide="state.error || !state.isBusy" dg-size="l">
             {{state.busyText}}
         </fd-busy-indicator-extended>

--- a/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.js
+++ b/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.js
@@ -84,7 +84,8 @@ angular.module('page', ["ideUI", "ideView"])
 			xhr.send(text);
 		}
 
-		$scope.save = function () {
+		$scope.save = function (_keySet, event) {
+			if (event) event.preventDefault();
 			if ($scope.forms.editor.$valid && !$scope.state.error) {
 				$scope.state.busyText = "Saving...";
 				$scope.state.isBusy = true;

--- a/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/view/websockets.html
+++ b/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/view/websockets.html
@@ -1,14 +1,13 @@
 <!DOCTYPE HTML>
 <!--
-  ~ Copyright (c) 2010-2023 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="websockets"
     ng-controller="WebsocketsController as controller">
 

--- a/components/ide/ide-ui-welcome/src/main/resources/META-INF/dirigible/ide-welcome/welcome.html
+++ b/components/ide/ide-ui-welcome/src/main/resources/META-INF/dirigible/ide-welcome/welcome.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2022 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
-
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="welcome" ng-controller="welcomeCtrl">
 
   <head>

--- a/components/ide/ide-ui-workbench/src/main/resources/META-INF/dirigible/ide/index.html
+++ b/components/ide/ide-ui-workbench/src/main/resources/META-INF/dirigible/ide/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <!--
-  ~ Copyright (c) 2010-2024 SAP and others.
+  ~ Copyright (c) 2024 Eclipse Dirigible contributors
   ~ All rights reserved. This program and the accompanying materials
   ~ are made available under the terms of the Eclipse Public License v2.0
   ~ which accompanies this distribution, and is available at
   ~ http://www.eclipse.org/legal/epl-v20.html
-  ~ Contributors:
-  ~ SAP - initial API and implementation
+  ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
+  ~ SPDX-License-Identifier: EPL-2.0
   -->
 <html lang="en" ng-app="workbench" ng-controller="WorkbenchController" xmlns="http://www.w3.org/1999/xhtml">
 

--- a/components/ide/ide-ui-workspace-service/src/main/resources/META-INF/dirigible/ide-workspace-service/workspace.js
+++ b/components/ide/ide-ui-workspace-service/src/main/resources/META-INF/dirigible/ide-workspace-service/workspace.js
@@ -15,21 +15,21 @@ angular.module('ideWorkspace', [])
         this.workspaceManagerServiceUrl = '/services/ide/workspace';
         this.workspaceSearchServiceUrl = '/services/ide/workspace-search';
         this.$get = ['$http', function workspaceApiFactory($http) {
-            let setWorkspace = function (workspaceName) {
+            const setWorkspace = function (workspaceName) {
                 if (workspaceName !== undefined && !(typeof workspaceName === 'string'))
                     throw Error("setWorkspace: workspaceName must be an string");
-                let workspace = { name: workspaceName };
+                const workspace = { name: workspaceName };
                 localStorage.setItem('DIRIGIBLE.workspace', JSON.stringify(workspace));
                 return workspace;
             };
 
-            let getCurrentWorkspace = function () {
+            const getCurrentWorkspace = function () {
                 let storedWorkspace = JSON.parse(localStorage.getItem('DIRIGIBLE.workspace') || '{}');
                 if (!('name' in storedWorkspace)) storedWorkspace = setWorkspace('workspace');
                 return storedWorkspace;
             };
 
-            let listWorkspaceNames = function () {
+            const listWorkspaceNames = function () {
                 return $http.get(this.workspacesServiceUrl)
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -39,8 +39,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let load = function (resourcePath) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(resourcePath.split('/')).build();
+            const load = function (resourcePath) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(resourcePath.split('/')).build();
                 return $http.get(url, { headers: { 'describe': 'application/json' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -50,8 +50,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let resourceExists = function (resourcePath) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(resourcePath.split('/')).build();
+            const resourceExists = function (resourcePath) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(resourcePath.split('/')).build();
                 return $http.head(url)
                     .then(function successCallback(response) {
                         return { status: response.status };
@@ -62,8 +62,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let loadContent = async function (workspace, filePath) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(filePath.split('/')).build();
+            const loadContent = async function (workspace, filePath) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(filePath.split('/')).build();
                 return $http.get(url)
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -73,8 +73,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let saveContent = async function (workspace, filePath, content) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(filePath.split('/')).build();
+            const saveContent = async function (workspace, filePath, content) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(filePath.split('/')).build();
                 return $http.put(url, content, { headers: { 'Content-Type': 'text/plain;charset=UTF-8' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -84,7 +84,7 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let getMetadata = function (resourceUrl) {
+            const getMetadata = function (resourceUrl) {
                 return $http.get(resourceUrl, { headers: { 'describe': 'application/json' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -94,16 +94,16 @@ angular.module('ideWorkspace', [])
                     });
             }
 
-            let getMetadataByPath = function (workspace, path) {
-                let resourceUrl = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(path.split('/')).build();
+            const getMetadataByPath = function (workspace, path) {
+                const resourceUrl = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(path.split('/')).build();
                 return getMetadata(resourceUrl);
             }.bind(this);
 
-            let rename = function (oldName, newName, path, workspaceName) {
+            const rename = function (oldName, newName, path, workspaceName) {
                 let pathSegments = path.split('/');
                 pathSegments = pathSegments.slice(1);
                 if (pathSegments.length >= 1) {
-                    let url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(workspaceName).path('rename').build();
+                    const url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(workspaceName).path('rename').build();
                     return $http.post(url, {
                         sources: [new UriBuilder().path(pathSegments).path(oldName).build()],
                         target: new UriBuilder().path(pathSegments).path(newName).build(),
@@ -118,8 +118,8 @@ angular.module('ideWorkspace', [])
                 }
             }.bind(this);
 
-            let remove = function (filepath) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(filepath.split('/')).build();
+            const remove = function (filepath) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(filepath.split('/')).build();
                 return $http.delete(url, { headers: { 'Dirigible-Editor': 'Workspace' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -129,11 +129,11 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let copy = function (sourcePath, targetPath, sourceWorkspace, targetWorkspace) {
-                let url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(targetWorkspace).path('copy').build();
+            const copy = function (sourcePath, targetPath, sourceWorkspace, targetWorkspace) {
+                const url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(targetWorkspace).path('copy').build();
                 return $http.post(url, {
                     sourceWorkspace: sourceWorkspace,
-                    sources: [sourcePath],
+                    sources: Array.isArray(sourcePath) ? sourcePath : [sourcePath],
                     targetWorkspace: targetWorkspace,
                     target: (targetPath.endsWith('/') ? targetPath : targetPath + '/'),
                 }).then(function successCallback(response) {
@@ -144,11 +144,11 @@ angular.module('ideWorkspace', [])
                 });
             }.bind(this);
 
-            let move = function (sourcePath, targetPath, sourceWorkspace, targetWorkspace) {
+            const move = function (sourcePath, targetPath, sourceWorkspace, targetWorkspace) {
                 // TODO: Move to another workspace
-                let url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(sourceWorkspace).path('move').build();
+                const url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(sourceWorkspace).path('move').build();
                 return $http.post(url, {
-                    sources: [sourcePath],
+                    sources: Array.isArray(sourcePath) ? sourcePath : [sourcePath],
                     target: targetPath,
                     sourceWorkspace: sourceWorkspace,
                     targetWorkspace: targetWorkspace
@@ -160,7 +160,7 @@ angular.module('ideWorkspace', [])
                 });
             }.bind(this);
 
-            let createNode = function (name, targetPath, isDirectory, content = '') {
+            const createNode = function (name, targetPath, isDirectory, content = '') {
                 let url = new UriBuilder().path((this.workspacesServiceUrl + targetPath).split('/')).path(name).build();
                 if (isDirectory)
                     url += "/";
@@ -176,8 +176,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let createWorkspace = function (workspace) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).build();
+            const createWorkspace = function (workspace) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).build();
                 return $http.post(url, {})
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -187,8 +187,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let deleteWorkspace = function (workspace) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).build();
+            const deleteWorkspace = function (workspace) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).build();
                 return $http.delete(url, { headers: { 'Dirigible-Editor': 'Workspace' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -198,8 +198,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let createProject = function (workspace, projectName) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(projectName).build();
+            const createProject = function (workspace, projectName) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(projectName).build();
                 return $http.post(url, {})
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -209,10 +209,10 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let linkProject = function (workspace, projectName, path) {
-                let url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(workspace).path('linkProject').build();
+            const linkProject = function (workspace, projectName, path) {
+                const url = new UriBuilder().path(this.workspaceManagerServiceUrl.split('/')).path(workspace).path('linkProject').build();
                 return $http.post(url, {
-                    sources: [projectName],
+                    sources: Array.isArray(sourcePath) ? projectName : [projectName],
                     target: path
                 }).then(function successCallback(response) {
                     return { status: response.status, data: response.data };
@@ -222,8 +222,8 @@ angular.module('ideWorkspace', [])
                 });
             }.bind(this);
 
-            let deleteProject = function (workspace, projectName) {
-                let url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(projectName).build();
+            const deleteProject = function (workspace, projectName) {
+                const url = new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(projectName).build();
                 return $http.delete(url, { headers: { 'Dirigible-Editor': 'Workspace' } })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -233,8 +233,8 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
-            let search = function (workspace, resourcePath, searchTerm) {
-                let url = new UriBuilder().path(this.workspaceSearchServiceUrl.split('/')).path(workspace).path(resourcePath.split('/')).build();
+            const search = function (workspace, resourcePath, searchTerm) {
+                const url = new UriBuilder().path(this.workspaceSearchServiceUrl.split('/')).path(workspace).path(resourcePath.split('/')).build();
                 return $http.post(url, searchTerm)
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };

--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/domain/WorkspaceFromToPair.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/domain/WorkspaceFromToPair.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.components.ide.workspace.domain;
 
 /**

--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpoint.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpoint.java
@@ -340,14 +340,7 @@ public class WorkspaceEndpoint {
                                 .equals(targetProject.toLowerCase())) {
             if (multiple) {
                 // multiple source files, so the target must be a folder or a project
-                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
-                        && workspaceService.existsProject(workspace, targetProject)) {
-                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
-                    String casesensitivefix = targetCombinedFilePath + "_temp";
-                    workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, casesensitivefix);
-                    workspaceService.moveFolder(workspace, sourceProject, casesensitivefix, targetProject, IRepository.SEPARATOR);
-                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
-                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     String casesensitivefix = targetCombinedFilePath + "_temp";
@@ -367,12 +360,7 @@ public class WorkspaceEndpoint {
         } else {
             if (multiple) {
                 // multiple source files, so the target must be a folder or a project
-                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
-                        && workspaceService.existsProject(workspace, targetProject)) {
-                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
-                    workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
-                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
-                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
@@ -407,14 +395,7 @@ public class WorkspaceEndpoint {
                                 .equals(targetProject.toLowerCase())) {
             if (multiple) {
                 // multiple source files, so the target must be a folder or a project
-                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
-                        && workspaceService.existsProject(workspace, targetProject)) {
-                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
-                    String casesensitivefix = targetCombinedFilePath + "_temp";
-                    workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, casesensitivefix);
-                    workspaceService.moveFile(workspace, sourceProject, casesensitivefix, targetProject, IRepositoryStructure.SEPARATOR);
-                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
-                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     String casesensitivefix = targetCombinedFilePath + "_temp";
@@ -434,12 +415,7 @@ public class WorkspaceEndpoint {
         } else {
             if (multiple) {
                 // multiple source files, so the target must be a folder or a project
-                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
-                        && workspaceService.existsProject(workspace, targetProject)) {
-                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
-                    workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
-                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
-                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);

--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpoint.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/endpoint/WorkspaceEndpoint.java
@@ -339,8 +339,15 @@ public class WorkspaceEndpoint {
                 && sourceProject.toLowerCase()
                                 .equals(targetProject.toLowerCase())) {
             if (multiple) {
-                // multiple source files, so the target must be a folder
-                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                // multiple source files, so the target must be a folder or a project
+                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
+                        && workspaceService.existsProject(workspace, targetProject)) {
+                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
+                    String casesensitivefix = targetCombinedFilePath + "_temp";
+                    workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, casesensitivefix);
+                    workspaceService.moveFolder(workspace, sourceProject, casesensitivefix, targetProject, IRepository.SEPARATOR);
+                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
+                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     String casesensitivefix = targetCombinedFilePath + "_temp";
@@ -348,7 +355,7 @@ public class WorkspaceEndpoint {
                     workspaceService.moveFolder(workspace, sourceProject, casesensitivefix, targetProject, targetFilePath);
                     result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
                 } else {
-                    String error = "Target path is not a folder";
+                    String error = "Target path is not a folder or a project";
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, error);
                 }
             } else {
@@ -359,14 +366,19 @@ public class WorkspaceEndpoint {
             }
         } else {
             if (multiple) {
-                // multiple source files, so the target must be a folder
-                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                // multiple source files, so the target must be a folder or a project
+                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
+                        && workspaceService.existsProject(workspace, targetProject)) {
+                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
+                    workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
+                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
+                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     workspaceService.moveFolder(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
                     result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
                 } else {
-                    String error = "Target path is not a folder";
+                    String error = "Target path is not a folder or a project";
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, error);
                 }
             } else {
@@ -394,8 +406,15 @@ public class WorkspaceEndpoint {
                 && sourceProject.toLowerCase()
                                 .equals(targetProject.toLowerCase())) {
             if (multiple) {
-                // multiple source files, so the target must be a folder
-                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                // multiple source files, so the target must be a folder or a project
+                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
+                        && workspaceService.existsProject(workspace, targetProject)) {
+                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
+                    String casesensitivefix = targetCombinedFilePath + "_temp";
+                    workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, casesensitivefix);
+                    workspaceService.moveFile(workspace, sourceProject, casesensitivefix, targetProject, IRepositoryStructure.SEPARATOR);
+                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
+                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     String casesensitivefix = targetCombinedFilePath + "_temp";
@@ -403,7 +422,7 @@ public class WorkspaceEndpoint {
                     workspaceService.moveFile(workspace, sourceProject, casesensitivefix, targetProject, targetFilePath);
                     result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
                 } else {
-                    String error = "Target path is not a folder";
+                    String error = "Target path is not a folder or a project";
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, error);
                 }
             } else {
@@ -414,14 +433,19 @@ public class WorkspaceEndpoint {
             }
         } else {
             if (multiple) {
-                // multiple source files, so the target must be a folder
-                if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
+                // multiple source files, so the target must be a folder or a project
+                if (targetFilePath.equals(IRepositoryStructure.SEPARATOR + targetProject)
+                        && workspaceService.existsProject(workspace, targetProject)) {
+                    String targetCombinedFilePath = sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
+                    workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
+                    result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
+                } else if (workspaceService.existsFolder(workspace, targetProject, targetFilePath)) {
                     String targetCombinedFilePath =
                             targetFilePath + sourceFilePath.substring(sourceFilePath.lastIndexOf(IRepositoryStructure.SEPARATOR));
                     workspaceService.moveFile(workspace, sourceProject, sourceFilePath, targetProject, targetCombinedFilePath);
                     result.add(new WorkspaceFromToPair(sourceProject + sourceFilePath, targetProject + targetCombinedFilePath));
                 } else {
-                    String error = "Target path is not a folder";
+                    String error = "Target path is not a folder or a project";
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, error);
                 }
             } else {

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/core-modules.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/core-modules.js
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2010-2024 SAP and others.
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
  *
- * Contributors:
- *   SAP - initial API and implementation
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
  */
 /*
  * Provides key microservices for constructing and managing the IDE UI
@@ -112,7 +113,8 @@ angular.module('idePerspective', ['ngResource', 'ngCookies', 'ideExtensions', 'i
                         submenusLinks[i].setAttribute("aria-expanded", false);
                         submenusLinks[i].classList.remove("is-expanded");
                     }
-                }
+                    messageHub.triggerEvent('ide-contextmenu.close', true);
+                };
 
                 scope.menuHovered = function () {
                     if (openedMenuId !== "") {

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/layout.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/layout.js
@@ -923,7 +923,6 @@ angular.module('ideLayout', ['idePerspective', 'ideEditors', 'ideMessageHub', 'i
                         messageHub.postMessage(msg.callbackTopic, {
                             isOpen: true,
                             isDirty: result.tabsView.tabs[result.index].dirty || false,
-                            isFlowable: result.tabsView.tabs[result.index].path.startsWith('../ide-bpm/index.html#/editor') // Temp Flowable fix
                         }, true);
                     } else {
                         messageHub.postMessage(msg.callbackTopic, { isOpen: false }, true);
@@ -1055,9 +1054,6 @@ angular.module('ideLayout', ['idePerspective', 'ideEditors', 'ideMessageHub', 'i
                             contentType: contentType
                         }, extraArgs || {});
 
-                        if (eId === 'flowable')
-                            editorPath += resourcePath;
-
                         let result = findCenterSplittedTabViewByPath(resourcePath);
                         let currentTabsView = result ? result.tabsView : getCurrentCenterSplittedTabViewPane();
                         if (result) {
@@ -1097,8 +1093,6 @@ angular.module('ideLayout', ['idePerspective', 'ideEditors', 'ideMessageHub', 'i
                     else {
                         let result = findCenterSplittedTabViewByPath(resourcePath);
                         if (result) {
-                            if (result.tabsView.tabs[result.index].path.startsWith('../ide-bpm/index.html#/editor'))
-                                throw Error("updateEditor: File is opened in the Flowable editor which doesn't support dynamic updates");
                             result.tabsView.tabs[result.index].label = resourceLabel;
                             result.tabsView.tabs[result.index].params.file = newResourcePath;
                             messageHub.editorReloadParameters(resourcePath);

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/view.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/view.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2024 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * Copyright (c) 2024 Eclipse Dirigible contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
  *
- * SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Eclipse Dirigible contributors
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
 angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
@@ -31,8 +31,7 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
                 return response;
             }
         };
-    })
-    .factory('Views', ['Extensions', 'extensionPoint', function (Extensions, extensionPoint) {
+    }).factory('Views', ['Extensions', 'extensionPoint', function (Extensions, extensionPoint) {
         let cachedViews;
         let cachedSubviews;
         let get = function () {
@@ -99,11 +98,9 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
             get: get,
             getSubviews: getSubviews
         };
-    }])
-    .config(['$httpProvider', function ($httpProvider) {
+    }]).config(['$httpProvider', function ($httpProvider) {
         $httpProvider.interceptors.push('baseHttpInterceptor');
-    }])
-    .factory('ViewParameters', ['$window', function ($window) {
+    }]).factory('ViewParameters', ['$window', function ($window) {
         return {
             get: function () {
                 if ($window.frameElement && $window.frameElement.hasAttribute("data-parameters")) {
@@ -112,8 +109,7 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
                 return {};
             }
         };
-    }])
-    .service('Subviews', ['Views', function (Views) {
+    }]).service('Subviews', ['Views', function (Views) {
         return {
             getIdList: function (startsWith) {
                 return new Promise((resolve, reject) => {
@@ -139,8 +135,7 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
                 });
             }
         };
-    }])
-    .directive('embeddedView', ['Views', 'view', function (Views, view) {
+    }]).directive('embeddedView', ['Views', 'view', function (Views, view) {
         /**
          * viewId: String - ID of the view you want to show.
          * params: JSON - JSON object containing extra parameters/data.
@@ -198,8 +193,7 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
             },
             template: '<iframe loading="{{loadType}}" ng-src="{{path}}" data-parameters="{{getParams()}}"></iframe>'
         }
-    }])
-    .directive('dgContextmenu', ['messageHub', '$window', function (messageHub, $window) {
+    }]).directive('dgContextmenu', ['messageHub', '$window', function (messageHub, $window) {
         return {
             restrict: 'A',
             replace: false,
@@ -252,6 +246,16 @@ angular.module('ideView', ['ngResource', 'ideExtensions', 'ideTheming'])
                                 callbackTopic: menu.callbackTopic,
                                 hasIcons: menu.hasIcons || false,
                                 items: menu.items
+                            },
+                            true
+                        );
+                        const onCloseHandler = messageHub.onDidReceiveMessage(
+                            'ide-contextmenu.close',
+                            function () {
+                                if ($window.frameElement) {
+                                    $window.frameElement.contentWindow.focus();
+                                }
+                                messageHub.unsubscribe(onCloseHandler);
                             },
                             true
                         );

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
@@ -139,7 +139,6 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
             for (let i = 0; i < shortcuts.length; i++) {
                 shortcut = shortcuts[i];
                 if (match(eventKeys, shortcut.keys)) {
-                    e.preventDefault();
                     if (shortcut.action) shortcut.action(shortcut.keySet, e);
                     return;
                 }

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2010-2024 SAP and others.
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v20.html
  *
- * Contributors:
- *   SAP - initial API and implementation
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
  */
 angular.module('ideUI', ['ngAria', 'ideMessageHub'])
     .constant('ScreenEdgeMargin', {
@@ -16,6 +17,8 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
     }).constant('SplitPaneState', {
         EXPANDED: 0,
         COLLAPSED: 1
+    }).constant('platform', {
+        isMac: navigator.userAgent.includes('Mac')
     }).config(function config($compileProvider) {
         if ($compileProvider.debugInfoEnabled())
             $compileProvider.debugInfoEnabled(false);
@@ -79,28 +82,27 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
             return classes.join(' ');
         }
         return classNames;
-    }).factory('shortcuts', ['$document', function ($document) {
+    }).factory('shortcuts', ['$document', 'platform', function ($document, platform) {
         // Factory is based on example code from zachsnow
         let shortcuts = [];
         let ignoreInputs = false;
         let separateCtrl = false;
-        let isMac = navigator.userAgent.indexOf('Mac') >= 0;
-        let charKeyCodes = { "0": 58, "1": 49, "2": 50, "3": 51, "4": 52, "5": 53, "6": 54, "7": 55, "8": 56, "9": 57, "delete": 46, "tab": 9, "enter": 13, "return": 13, "esc": 27, "space": 32, "left": 37, "up": 38, "right": 39, "down": 40, ";": 186, "=": 187, ",": 188, "-": 189, ".": 190, "/": 191, "`": 192, "[": 219, "\\": 220, "]": 221, "'": 222, "a": 65, "b": 66, "c": 67, "d": 68, "e": 69, "f": 70, "g": 71, "h": 72, "i": 73, "j": 74, "k": 75, "l": 76, "m": 77, "n": 78, "o": 79, "p": 80, "q": 81, "r": 82, "s": 83, "t": 84, "u": 85, "v": 86, "w": 87, "x": 88, "y": 89, "z": 90 };
-        let keyCodeChars = { 46: "delete", 9: "tab", 13: "return", 27: "esc", 32: "space", 37: "left", 38: "up", 39: "right", 40: "down", 49: "1", 50: "2", 51: "3", 52: "4", 53: "5", 54: "6", 55: "7", 56: "8", 57: "9", 58: "0", 65: "a", 66: "b", 67: "c", 68: "d", 69: "e", 70: "f", 71: "g", 72: "h", 73: "i", 74: "j", 75: "k", 76: "l", 77: "m", 78: "n", 79: "o", 80: "p", 81: "q", 82: "r", 83: "s", 84: "t", 85: "u", 86: "v", 87: "w", 88: "x", 89: "y", 90: "z", 186: ";", 187: "=", 188: ",", 189: "-", 190: ".", 191: "/", 192: "`", 219: "[", 220: "\\", 221: "]", 222: "'" };
-        let modifierKeys = { 'shift': 'shift', 'ctrl': 'ctrl', 'meta': 'meta', 'alt': 'alt' };
+        const charKeyCodes = { 'f1': 112, 'f2': 113, 'f3': 114, 'f4': 115, 'f5': 116, 'f6': 117, 'f7': 118, 'f8': 119, 'f9': 120, 'f10': 121, 'f11': 122, 'f12': 123, '0': 58, '1': 49, '2': 50, '3': 51, '4': 52, '5': 53, '6': 54, '7': 55, '8': 56, '9': 57, 'backspace': 8, 'delete': 46, 'tab': 9, 'enter': 13, 'return': 13, 'esc': 27, 'space': 32, 'left': 37, 'up': 38, 'right': 39, 'down': 40, ';': 186, '=': 187, ',': 188, '-': 189, '.': 190, '/': 191, '`': 192, '[': 219, '\\': 220, ']': 221, "'": 222, 'a': 65, 'b': 66, 'c': 67, 'd': 68, 'e': 69, 'f': 70, 'g': 71, 'h': 72, 'i': 73, 'j': 74, 'k': 75, 'l': 76, 'm': 77, 'n': 78, 'o': 79, 'p': 80, 'q': 81, 'r': 82, 's': 83, 't': 84, 'u': 85, 'v': 86, 'w': 87, 'x': 88, 'y': 89, 'z': 90 };
+        const keyCodeChars = { 112: 'f1', 113: 'f2', 114: 'f3', 115: 'f4', 116: 'f5', 117: 'f6', 118: 'f7', 119: 'f8', 120: 'f9', 121: 'f10', 122: 'f11', 123: 'f12', 8: 'backspace', 46: 'delete', 9: 'tab', 13: 'return', 27: 'esc', 32: 'space', 37: 'left', 38: 'up', 39: 'right', 40: 'down', 49: '1', 50: '2', 51: '3', 52: '4', 53: '5', 54: '6', 55: '7', 56: '8', 57: '9', 58: '0', 65: 'a', 66: 'b', 67: 'c', 68: 'd', 69: 'e', 70: 'f', 71: 'g', 72: 'h', 73: 'i', 74: 'j', 75: 'k', 76: 'l', 77: 'm', 78: 'n', 79: 'o', 80: 'p', 81: 'q', 82: 'r', 83: 's', 84: 't', 85: 'u', 86: 'v', 87: 'w', 88: 'x', 89: 'y', 90: 'z', 186: ';', 187: '=', 188: ',', 189: '-', 190: '.', 191: '/', 192: '`', 219: '[', 220: '\\', 221: ']', 222: "'" };
+        const modifierKeys = { 'shift': 'shift', 'ctrl': 'ctrl', 'meta': 'meta', 'alt': 'alt' };
 
         function parseKeySet(keySet) {
             let names;
             let keys = {};
-            if (isMac && !separateCtrl) {
-                keySet = keySet.replaceAll('ctrl', 'meta');
+            if (platform.isMac && !separateCtrl) {
+                keySet = keySet.replaceAll('ctrl', 'meta').toLowerCase();
                 names = keySet.split('+');
             } else names = keySet.split('+');
             for (const name in modifierKeys) {
                 keys[modifierKeys[name]] = false;
             }
             for (const name in names) {
-                let modifierKey = modifierKeys[names[name]];
+                const modifierKey = modifierKeys[names[name]];
                 if (modifierKey) keys[modifierKey] = true;
                 else {
                     keys.keyCode = charKeyCodes[names[name]];
@@ -138,7 +140,7 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
                 shortcut = shortcuts[i];
                 if (match(eventKeys, shortcut.keys)) {
                     e.preventDefault();
-                    shortcut.action();
+                    if (shortcut.action) shortcut.action(shortcut.keySet, e);
                     return;
                 }
             }
@@ -162,14 +164,16 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
                 overwriteWithout(shortcuts, shortcut);
             }
         };
-    }]).directive('dgShortcut', ['$parse', 'shortcuts', function ($parse, shortcuts) {
+    }]).directive('dgShortcut', ['shortcuts', function (shortcuts) {
         /**
          * Directive is based on example code from zachsnow 
          * How to use:
-         * <div dg-shortcut="'ctrl+s|ctrl+k'" dg-shortcut-action="save()" ignore-inputs separate-ctrl>
+         * <div dg-shortcut="'ctrl+s|ctrl+k'" dg-shortcut-action="save" ignore-inputs separate-ctrl>
          * Options:
          * * dg-shortcut - String containing the shortcut or shortcuts. There can be multiple shortcuts for a single action. You can separate the shortcuts using '|'.
-         * * dg-shortcut-action - Reference to a function that will get called when the shortcut is activated.
+         * * dg-shortcut-action - The name of the function that will get called. It has two parameters:
+         * * * keySet - The keyboard shortcut activated.
+         * * * event - The JavaScript key event.
          * * ignore-inputs - If this attribute is present, then events from 'input' and 'textarea' controls will be ignored.
          * * separate-ctrl - On macOS, by default, the ctrl key is replaced with the meta (cmd) key, so shortcuts like 'Ctrl+S' are automatically translated to 'Cmd+S'.
          * If you want the ctrl key to match the ctrl and be separate from the meta on a mac, then use this attribute.
@@ -177,31 +181,27 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
          */
         return {
             restrict: 'A',
-            link: function (scope, element, attrs) {
+            link: function (scope, _element, attrs) {
                 let shortcutKeySets = scope.$eval(attrs.dgShortcut);
-                let ignoreInputs = 'ignoreInputs' in attrs;
-                let separateCtrl = 'separateCtrl' in attrs;
+                const ignoreInputs = 'ignoreInputs' in attrs;
+                const separateCtrl = 'separateCtrl' in attrs;
                 shortcuts.ignoreInputs(ignoreInputs);
                 shortcuts.separateCtrl(separateCtrl);
-                if (shortcutKeySets === undefined) return;
-                shortcutKeySets = shortcutKeySets.split('|');
-                let action;
-                if (attrs.dgShortcutAction) {
-                    let fn = $parse(attrs.dgShortcutAction);
-                    action = function () {
-                        scope.$apply(function () {
-                            fn(scope);
-                        });
-                    };
-                }
-                for (let i = 0; i < shortcutKeySets.length; i++) {
-                    let shortcut = shortcuts.register({
-                        keySet: shortcutKeySets[i],
-                        action: action,
-                        description: attrs.dgShortcutDescription || ''
-                    });
+                if (shortcutKeySets !== undefined) {
+                    shortcutKeySets = shortcutKeySets.split('|');
+                    const action = scope.$eval(attrs.dgShortcutAction);
+                    let shortcutList = [];
+                    for (let i = 0; i < shortcutKeySets.length; i++) {
+                        shortcutList.push(shortcuts.register({
+                            keySet: shortcutKeySets[i],
+                            action: action,
+                            description: attrs.dgShortcutDescription || ''
+                        }));
+                    }
                     scope.$on("$destroy", function () {
-                        shortcuts.unregister(shortcut);
+                        for (let i = 0; i < shortcutList.length; i++) {
+                            shortcuts.unregister(shortcutList[i]);
+                        }
                     });
                 }
             }
@@ -217,6 +217,7 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
          * }
          */
         return {
+            restrict: 'A',
             require: 'ngModel',
             link: function (scope, element, attr, controller) {
                 let parseFn = $parse(attr.dgInputRules);

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets.js
@@ -198,7 +198,7 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
                             description: attrs.dgShortcutDescription || ''
                         }));
                     }
-                    scope.$on("$destroy", function () {
+                    scope.$on('$destroy', function () {
                         for (let i = 0; i < shortcutList.length; i++) {
                             shortcuts.unregister(shortcutList[i]);
                         }
@@ -206,7 +206,16 @@ angular.module('ideUI', ['ngAria', 'ideMessageHub'])
                 }
             }
         }
-    }]).directive('dgInputRules', function ($parse) {
+    }]).directive('dgFocus', function ($timeout) {
+        return {
+            restrict: 'A',
+            link: function (_scope, element, attrs) {
+                attrs.$observe('dgFocus', function (newValue) {
+                    if (newValue === 'true') $timeout(function () { element.focus() });
+                });
+            }
+        };
+    }).directive('dgInputRules', function ($parse) {
         /**
          * How to use:
          * <input ng-model="inputModel" ng-required dg-input-rules="inputRules">

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets/indicator.plugin.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/widgets/indicator.plugin.js
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
 (function (factory) {
     "use strict";
     if (typeof define === 'function' && define.amd) {

--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/ContextCreator.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/ContextCreator.java
@@ -71,7 +71,7 @@ public class ContextCreator {
                                                                  .allowHostSocketAccess(true)
                                                                  .build())
                                                 .option("js.nashorn-compat", "true")
-                                                .option("js.import-assertions", "true")
+                                                .option("js.import-attributes", "true")
                                                 .option("js.json-modules", "true")
                                                 .option("js.operator-overloading", "true")
                                                 .option("js.intl-402", "true")

--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/EngineCreator.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/graal/EngineCreator.java
@@ -45,7 +45,6 @@ public class EngineCreator {
     }
 
     private static Engine.Builder getDefaultEngineBuilder() {
-        System.setProperty("polyglotimpl.DisableClassPathIsolation", "true");
         return Engine.newBuilder()
                      .allowExperimentalOptions(true)
                      .out(outputStream())

--- a/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/python/PythonCodeRunner.java
+++ b/modules/engines/engine-graalium/execution/src/main/java/org/eclipse/dirigible/graalium/core/python/PythonCodeRunner.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2024 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.dirigible.graalium.core.python;
 
 public interface PythonCodeRunner {

--- a/modules/repository/repository-api/src/main/java/org/eclipse/dirigible/repository/api/RepositoryPath.java
+++ b/modules/repository/repository-api/src/main/java/org/eclipse/dirigible/repository/api/RepositoryPath.java
@@ -229,7 +229,10 @@ public class RepositoryPath {
      * @return the string
      */
     public String constructPathFrom(int number) {
-        if (number >= segments.length) {
+        if (number == segments.length) {
+            return IRepository.SEPARATOR;
+        }
+        if (number > segments.length) {
             return toString();
         }
         if (segments.length == 0) {

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<webjars.locator.core.version>0.58</webjars.locator.core.version>
 
 		<!-- GraalVM -->
-		<graalvm.version>23.1.1</graalvm.version>
+		<graalvm.version>24.0.1</graalvm.version>
 
 		<!-- Commons -->
 		<commons.io>2.16.1</commons.io>


### PR DESCRIPTION
### What does this PR do?

This started as a simple Projects view refactoring but for certain reasons, it grew to include much more.

BPM/Flowable editor:
* Editor now has dirty state (modified file indicator)
* Editor can now save using the `CTRL+S`/`CMD+S` shortcut
* Auto saving file is now fixed
* Save on close is now fixed
* Flowable now behaves like a native Dirigible editor. It can get updates from the `data-parameters` attribute when its file has been renamed/moved.

BPM Perspective, CSVIM Editor, File Manager, Documents Perspective, Git Perspective, Problem view, Registry view, Repository view, :
* Rendering the search toolbar only if necessary.
* When search is shown, the search input is now automatically focused.

Layout:
* Removed all special handling of the BPM/Flowable editor.

Widgets:
* Added `platform` injectable constant, so a view can determine if it's running on macOS or Linux/Windows.
* Added a new `dg-focus` directive. It allows us to automatically focus an input.
Example:
```html
<fd-input type="search" placeholder="Search" dg-focus="true">
```
If you want to focus an input which is already shown, then you can use a scope variable to set the value to true/false:
```html
<fd-input type="search" placeholder="Search" dg-focus="{{shouldFocus}}">
```
* Refactored the `dg-shortcut` directive to support more keys and it now provides the event in the handler.
How to use:
```html
<div dg-shortcut="'ctrl+s|ctrl+d'" dg-shortcut-action="shortcuts" ignore-inputs separate-ctrl>
```

  * dg-shortcut - String containing the shortcut or shortcuts. There can be multiple shortcuts for a single action. You can separate the shortcuts using '|'.
  * dg-shortcut-action - The name of the function that will get called. It receives two parameters:
    * keySet - The keyboard shortcut activated.
    * event - The JavaScript key event.
  * ignore-inputs - If this attribute is present, then events from 'input' and 'textarea' controls will be ignored.
  * separate-ctrl - On macOS, by default, the ctrl key is replaced with the meta (cmd) key, so shortcuts like 'Ctrl+S' are automatically translated to 'Cmd+S'. If you want the ctrl key to match the ctrl and be separate from the meta on a mac, then use this attribute.

```javascript
$scope.shortcuts = function (keySet, event) {
  event.preventDefault(); // If needed.
  switch (keySet) {
    case 'ctrl+s':
      // Save action
      break;
    case 'ctrl+d':
      // Delete action
      break;
  }
};
```

Form Editor:
* Fixed the widget getting deleted when a user presses the delete key while inside an input.

Projects view:
* Changed most messageHub listeners from being permanently registered to being registered only when it's needed and unregistering them when they are done. This is optimization work.
* Removed some unneeded AngularJS watchers.
* Added new file type icons.
* When a user performs an action (like create/move/rename/copy/delete/import a file/folder), the tree is now partially reloaded to save time, instead of performing a complete refresh.
* User can now copy/move multiple files and folders.
* Removed JSTree keyboard shortcut configuration and used `dg-shortcut` instead.
* When a file from a git project is changed, it will now be indicated and all of its parents will also get updated with an indicator.
* When renamed, the file `content/type` is also updated, if the file extension is changed.
* Vastly improved keyboard navigation and default shortcuts:
  * Arrow down - Move down without selecting
  * Arrow up - Move up without selecting
  * Enter - select and open file/folder. If a folder is already opened, it will be closed.
  * Shift+Enter - Select but do not open.
  * Ctrl+F / ⌘+F - Toggle search
  * Esc - Close search
  * Delete / ⌘+Backspace - Delete file/folder
  * F2 - Rename file/folder
  * Ctrl+C / ⌘+C - Copy
  * Ctrl+X / ⌘+X - Cut
  * Ctrl+V / ⌘+V - Paste

License header updates

### What issues does this PR fix or reference?

#2152 
#3724
#3727
#3728
#3729
#3761 