### PR TITLE
[Editors] #3869 - Migrate native editors to use the Workspace API

### DIFF
--- a/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/editor.html
+++ b/components/ide/ide-ui-csv/src/main/resources/META-INF/dirigible/ide-csv/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="services/csv-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="js/papaparse.min.js"></script>
         <script type="text/javascript" src="js/ag-grid-community.min.noStyle.js"></script>
         <script type="text/javascript" src="js/editor.js"></script>

--- a/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
+++ b/components/ide/ide-ui-csvim/src/main/resources/META-INF/dirigible/ide-csvim/editor.html
@@ -18,10 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="services/csvim-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <script type="text/javascript" src="/services/web/ide-workspace-service/workspace.js"></script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="js/editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.html
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/table-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.js
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/table/editor.js
@@ -9,10 +9,9 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, $window, workspaceApi, messageHub, ViewParameters) {
 		let contents;
-		let csrfToken;
 		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
@@ -47,29 +46,24 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
 		$scope.load = function () {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				$scope.table = JSON.parse(contents);
-				$scope.fixBooleans();
-				contents = JSON.stringify($scope.table, null, 4);
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						$scope.table = response.data;
+						$scope.fixBooleans();
+						contents = JSON.stringify($scope.table, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		};
 
@@ -101,12 +95,8 @@ angular.module('page', ["ideUI", "ideView"])
 		};
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -118,17 +108,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {
@@ -227,9 +214,8 @@ angular.module('page', ["ideUI", "ideView"])
 		);
 
 		$scope.$watch('table', function () {
-			if (!$scope.state.error) {
-				let table = JSON.stringify($scope.table, null, 4);
-				messageHub.setEditorDirty($scope.dataParameters.file, contents !== table);
+			if (!$scope.state.error && !$scope.state.isBusy) {
+				messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.table, null, 4));
 			}
 		}, true);
 

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.html
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/table-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.js
+++ b/components/ide/ide-ui-data-structures/src/main/resources/META-INF/dirigible/ide-data-structures/editors/view/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, $window, workspaceApi, messageHub, ViewParameters) {
 		let contents;
-		let csrfToken;
-		$scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
 		};
@@ -34,38 +33,29 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
 		$scope.load = function () {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				$scope.view = JSON.parse(contents);
-				contents = JSON.stringify($scope.view, null, 4);
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						$scope.view = response.data;
+						contents = JSON.stringify($scope.view, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		};
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -77,17 +67,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {
@@ -172,9 +159,8 @@ angular.module('page', ["ideUI", "ideView"])
 		);
 
 		$scope.$watch('view', function () {
-			if (!$scope.state.error) {
-				let view = JSON.stringify($scope.view, null, 4);
-				messageHub.setEditorDirty($scope.dataParameters.file, contents !== view);
+			if (!$scope.state.error && !$scope.state.isBusy) {
+				messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.view, null, 4));
 			}
 		}, true);
 

--- a/components/ide/ide-ui-designer/src/main/resources/META-INF/dirigible/ide-designer/js/editor.js
+++ b/components/ide/ide-ui-designer/src/main/resources/META-INF/dirigible/ide-designer/js/editor.js
@@ -9,17 +9,18 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let editorView = angular.module('integrations', ['ideUI', 'ideView']);
+const editorView = angular.module('integrations', ['ideUI', 'ideView', 'ideWorkspace']);
 
 let editorScope;
 
-editorView.controller('EditorViewController', ['$scope', '$window', 'messageHub', 'ViewParameters', function ($scope, $window, messageHub, ViewParameters) {
+editorView.controller('EditorViewController', function ($scope, $window, workspaceApi, messageHub, ViewParameters) {
     $scope.state = {
         isBusy: true,
         error: false,
         busyText: "Loading...",
     };
     $scope.errorMessage = '';
+    $scope.workspaceApiBaseUrl = workspaceApi.getFullURL();
 
     angular.element($window).bind("focus", function () {
         messageHub.setFocusedEditor($scope.dataParameters.file);
@@ -41,52 +42,44 @@ editorView.controller('EditorViewController', ['$scope', '$window', 'messageHub'
         document.getElementsByTagName('head')[0].appendChild(script);
     }
 
-    $scope.saveContents = function(text) {
-        let xhr = new XMLHttpRequest();
-        xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-        //xhr.setRequestHeader('X-Requested-With', 'Fetch');
-        //xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-        xhr.onreadystatechange = function () {
-          if (xhr.readyState === 4) {
-              messageHub.announceFileSaved({
-                  name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
-                  path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
-                  contentType: $scope.dataParameters.contentType,
-                  workspace: $scope.dataParameters.file.substring(1, $scope.dataParameters.file.indexOf('/', 1)),
-              });
-              messageHub.setStatusMessage(`File '${$scope.dataParameters.file}' saved`);
-              messageHub.setEditorDirty($scope.dataParameters.file, false);
-              $scope.$apply(function () {
-                  $scope.state.isBusy = false;
-                  $scope.isFileChanged = false;
-              });
-          }
-        };
-        xhr.onerror = function (error) {
-          console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-          messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-          messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-          $scope.$apply(function () {
-              $scope.state.isBusy = false;
-          });
-        };
-        xhr.send(text);
+    $scope.saveContents = function (text) {
+        workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+            if (response.status === 200) {
+                messageHub.announceFileSaved({
+                    name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
+                    path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
+                    contentType: $scope.dataParameters.contentType,
+                    workspace: $scope.dataParameters.file.substring(1, $scope.dataParameters.file.indexOf('/', 1)),
+                });
+                messageHub.setStatusMessage(`File '${$scope.dataParameters.file}' saved`);
+                messageHub.setEditorDirty($scope.dataParameters.file, false);
+                $scope.$apply(function () {
+                    $scope.state.isBusy = false;
+                });
+            } else {
+                messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+                messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+                $scope.$apply(function () {
+                    $scope.state.isBusy = false;
+                });
+            }
+        });
     }
 
     window.addEventListener('keydown',
         function (event) {
             if ((event.ctrlKey || event.metaKey) && event.key == 's') {
                 event.preventDefault();
-                if(window.designerApp) {
+                if (window.designerApp) {
                     $scope.saveContents(window.designerApp.state.yaml);
                 }
             }
         }
     );
-}]);
+});
 
 function getBaseUrl() {
-    return '/services/ide/workspaces';
+    return editorScope.workspaceApiBaseUrl;
 }
 
 function getFileName() {

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/modeler.html
@@ -8,7 +8,7 @@
   ~ SPDX-FileCopyrightText: Eclipse Dirigible contributors
   ~ SPDX-License-Identifier: EPL-2.0
   -->
-<html lang="en" ng-app="ui.entity-data.modeler" ng-controller="ModelerCtrl as ctrl">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="ui.entity-data.modeler" ng-controller="ModelerCtrl">
 
     <head>
         <meta charset="utf-8">
@@ -18,12 +18,12 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="services/entity-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <script type="text/javascript" src="/services/web/ide-workspace-service/workspace.js"></script>
         <script type="text/javascript" src="/services/web/ide-generate-service/generate.js"></script>
         <script type="text/javascript" src="/services/web/ide-template-service/templates.js"></script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <link type="text/css" href="css/styles.css" rel="stylesheet">
         <script type="text/javascript">
             mxBasePath = '/services/web/resources/mxgraph/3.9.1/src';

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.html
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/extension-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.js
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extension/editor.js
@@ -9,10 +9,9 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, $http, messageHub, $window, ViewParameters) {
-		let contents;
-		let csrfToken;
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, $http, messageHub, workspaceApi, $window, ViewParameters) {
+		let contents = '';
 		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
@@ -28,41 +27,30 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
-		$scope.load = function () {
+		function load() {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				if (contents === '') $scope.extension = {};
-				else {
-					$scope.extension = JSON.parse(contents);
-					contents = JSON.stringify($scope.extension, null, 4);
-				}
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						if (response.data === '') $scope.extension = {};
+						else $scope.extension = response.data;
+						contents = JSON.stringify($scope.extension, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		};
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -74,17 +62,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {
@@ -139,9 +124,8 @@ angular.module('page', ["ideUI", "ideView"])
 		);
 
 		$scope.$watch('extension', function () {
-			if (!$scope.state.error) {
-				let extension = JSON.stringify($scope.extension, null, 4);
-				messageHub.setEditorDirty($scope.dataParameters.file, contents !== extension);
+			if (!$scope.state.error && !$scope.state.isBusy) {
+				messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.extension, null, 4));
 			}
 		}, true);
 
@@ -161,7 +145,7 @@ angular.module('page', ["ideUI", "ideView"])
 							value: e
 						}
 					});
-					$scope.load();
+					load();
 				}, function (error) {
 					$scope.state.error = true;
 					$scope.errorMessage = error.data.message;

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.html
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/extensionpoint-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.js
+++ b/components/ide/ide-ui-extensions/src/main/resources/META-INF/dirigible/ide-extensions/editors/extensionpoint/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, messageHub, workspaceApi, $window, ViewParameters) {
 		let contents;
-		let csrfToken;
-		$scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
 		};
@@ -28,41 +27,30 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
 		function load() {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				if (contents === '') $scope.extensionpoint = {};
-				else {
-					$scope.extensionpoint = JSON.parse(contents);
-					contents = JSON.stringify($scope.extensionpoint, null, 4);
-				}
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						if (response.data === '') $scope.extensionpoint = {};
+						else $scope.extensionpoint = response.data;
+						contents = JSON.stringify($scope.extensionpoint, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		}
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -74,17 +62,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {
@@ -139,9 +124,8 @@ angular.module('page', ["ideUI", "ideView"])
 		);
 
 		$scope.$watch('extensionpoint', function () {
-			if (!$scope.state.error) {
-				let extensionpoint = JSON.stringify($scope.extensionpoint, null, 4);
-				messageHub.setEditorDirty($scope.dataParameters.file, contents !== extensionpoint);
+			if (!$scope.state.error && !$scope.state.isBusy) {
+				messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.extensionpoint, null, 4));
 			}
 		}, true);
 

--- a/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/editor.html
+++ b/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/editor.html
@@ -21,9 +21,9 @@
         <script type="text/javascript" src="/webjars/sortablejs/1.15.2/Sortable.min.js"></script>
         <link type="text/css" rel="stylesheet" data-name="vs/editor/editor.main"
             href="/services/js/resources-core/services/loader.js?id=code-editor-css" />
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js"></script>
-        <script type="text/javascript" src="/services/web/ide-workspace-service/workspace.js"></script>
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js"></script>
         <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=code-editor-js"></script>
         <link type="text/css" rel="stylesheet" href="css/editor.css" />
         <script type="text/javascript" src="js/editor.js"></script>

--- a/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/js/editor.js
+++ b/components/ide/ide-ui-form-builder/src/main/resources/META-INF/dirigible/ide-form-builder/js/editor.js
@@ -1443,6 +1443,8 @@ editorView.controller('DesignerController', function ($scope, $window, $document
                 $scope.$apply(function () {
                     $scope.state.isBusy = false;
                 });
+            } else if (response.status === 404) {
+                messageHub.closeEditor($scope.dataParameters.file);
             } else {
                 $scope.$apply(function () {
                     $scope.state.error = true;

--- a/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/generate.js
+++ b/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/generate.js
@@ -14,12 +14,8 @@ angular.module('ideGenerate', [])
         this.generateServiceUrl = '/services/ide/generate';
         this.generateModelServiceUrl = '/services/js/ide-generate-service/generate.mjs';
         this.$get = ['$http', function generateApiFactory($http) {
-	
-            let generateFromTemplate = function (workspace, project, file, template, parameters = []) {
-                let url = new UriBuilder().path(this.generateServiceUrl.split('/')).path('file').path(workspace).path(project).path(file.split('/')).build();
-                if (parameters.length === 0) {
-					parameters = {"__empty": ""};
-				}
+            const generateFromTemplate = function (workspace, project, file, template, parameters = { "__empty": "" }) {
+                const url = new UriBuilder().path(this.generateServiceUrl.split('/')).path('file').path(workspace).path(project).path(file.split('/')).build();
                 return $http.post(url, { "template": template, "parameters": parameters })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -29,12 +25,9 @@ angular.module('ideGenerate', [])
                     });
             }.bind(this);
 
-            let generateFromModel = function (workspace, project, file, template, parameters = []) {
+            const generateFromModel = function (workspace, project, file, template, parameters = { "__empty": "" }) {
                 let url = new UriBuilder().path(this.generateModelServiceUrl.split('/')).path('model').path(workspace).path(project).build();
                 url = `${url}?path=${file.split('/')}`;
-                if (parameters.length === 0) {
-					parameters = {"__empty": ""};
-				}
                 return $http.post(url, { "template": template, "parameters": parameters, "model": file })
                     .then(function successCallback(response) {
                         return { status: response.status, data: response.data };
@@ -43,10 +36,10 @@ angular.module('ideGenerate', [])
                         return { status: response.status };
                     });
             }.bind(this);
-            
-            let isEnabled = function() {
-				return true;
-			}.bind(this);
+
+            const isEnabled = function () {
+                return true;
+            }.bind(this);
 
             return {
                 generateFromTemplate: generateFromTemplate,

--- a/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/editor.html
+++ b/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/editor.html
@@ -17,8 +17,9 @@
 		<title dg-view-title></title>
 		<script type="text/javascript" src="services/image-editor.js"></script>
 		<theme></theme>
-		<script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js"></script>
-		<link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+		<script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js"></script>
+		<link type="text/css" rel="stylesheet"
+			href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
 		<script type="text/javascript" src="js/editor.js"></script>
 	</head>
 

--- a/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/js/editor.js
+++ b/components/ide/ide-ui-image/src/main/resources/META-INF/dirigible/ide-image/js/editor.js
@@ -9,23 +9,26 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-let editorView = angular.module('image-app', ['ideUI', 'ideView']);
-
-editorView.controller('ImageViewController', ['$scope', '$window', 'messageHub', 'ViewParameters', function ($scope, $window, messageHub, ViewParameters) {
-    $scope.imageLink = "";
+const editorView = angular.module('image-app', ['ideUI', 'ideView', 'ideWorkspace']);
+editorView.controller('ImageViewController', function ($scope, $window, messageHub, workspaceApi, ViewParameters) {
+    $scope.imageLink = '';
     $scope.state = {
         isBusy: true,
         error: false,
-        busyText: "Loading...",
+        busyText: 'Loading...',
     };
 
-    angular.element($window).bind("focus", function () {
+    angular.element($window).bind('focus', function () {
         messageHub.setFocusedEditor($scope.dataParameters.file);
         messageHub.setStatusCaret('');
     });
 
+    angular.element('#image-view').bind('error', function () {
+        messageHub.closeEditor($scope.dataParameters.file);
+    });
+
     $scope.loadFileContents = function () {
-        $scope.imageLink = '/services/ide/workspaces' + $scope.dataParameters.file;
+        $scope.imageLink = workspaceApi.getFullURL('', $scope.dataParameters.file);
         $scope.state.isBusy = false;
     };
 
@@ -51,4 +54,4 @@ editorView.controller('ImageViewController', ['$scope', '$window', 'messageHub',
     } else {
         $scope.loadFileContents();
     }
-}]);
+});

--- a/components/ide/ide-ui-integrations/src/main/resources/META-INF/dirigible/ide-integrations/editor.html
+++ b/components/ide/ide-ui-integrations/src/main/resources/META-INF/dirigible/ide-integrations/editor.html
@@ -18,8 +18,9 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="services/integrations-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js"></script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js"></script>
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="js/editor.js"></script>
         <link type="text/css" rel="stylesheet" href="designer/static/css/main.0f378c6c.css">
     </head>

--- a/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.html
+++ b/components/ide/ide-ui-jobs/src/main/resources/META-INF/dirigible/ide-jobs/editor/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../services/job-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.html
+++ b/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../services/listener-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.js
+++ b/components/ide/ide-ui-listeners/src/main/resources/META-INF/dirigible/ide-listeners/editor/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, messageHub, workspaceApi, $window, ViewParameters) {
 		let contents;
-		let csrfToken;
-		$scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
 		};
@@ -29,38 +28,30 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
 		$scope.load = function () {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				$scope.listener = JSON.parse(contents);
-				contents = JSON.stringify($scope.listener, null, 4);
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						if (response.data === '') $scope.listener = {};
+						else $scope.listener = response.data;
+						contents = JSON.stringify($scope.listener, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		};
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -72,17 +63,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {

--- a/components/ide/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
+++ b/components/ide/ide-ui-monaco/src/main/resources/META-INF/dirigible/ide-monaco/js/editor.js
@@ -440,58 +440,6 @@ class EditorActionsProvider {
         };
     }
 
-    static createCloseAction() {
-        return {
-            id: 'dirigible-close',
-            label: 'Close',
-            keybindings: [
-                monaco.KeyMod.Alt | monaco.KeyCode.KeyW
-            ],
-            precondition: null,
-            keybindingContext: null,
-            contextMenuGroupId: 'fileIO',
-            contextMenuOrder: 1.5,
-            run: function () {
-                DirigibleEditor.closeEditor();
-            }
-        };
-    }
-
-    static createCloseOthersAction() {
-        return {
-            id: 'dirigible-close-others',
-            label: 'Close Others',
-            keybindings: [
-                monaco.KeyMod.Alt | monaco.KeyMod.WinCtrl | monaco.KeyMod.Shift | monaco.KeyCode.KeyW
-            ],
-            precondition: null,
-            keybindingContext: null,
-            contextMenuGroupId: 'fileIO',
-            contextMenuOrder: 1.5,
-            run: function () {
-                const fileIO = new FileIO();
-                messageHub.post({ resourcePath: fileIO.resolvePath() }, 'ide-core.closeOtherEditors');
-            }
-        };
-    }
-
-    static createCloseAllAction() {
-        return {
-            id: 'dirigible-close-all',
-            label: 'Close All',
-            keybindings: [
-                monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyW
-            ],
-            precondition: null,
-            keybindingContext: null,
-            contextMenuGroupId: 'fileIO',
-            contextMenuOrder: 1.5,
-            run: function () {
-                messageHub.post('', 'ide-core.closeAllEditors');
-            }
-        };
-    }
-
     static createToggleAutoFormattingAction() {
         return {
             id: 'dirigible-toggle-auto-formatting',
@@ -757,9 +705,6 @@ class DirigibleEditor {
             editor.addAction(EditorActionsProvider.createSaveAction());
         }
         editor.addAction(EditorActionsProvider.createSearchAction());
-        editor.addAction(EditorActionsProvider.createCloseAction());
-        editor.addAction(EditorActionsProvider.createCloseOthersAction());
-        editor.addAction(EditorActionsProvider.createCloseAllAction());
         EditorActionsProvider._toggleAutoFormattingActionRegistration = editor.addAction(EditorActionsProvider.createToggleAutoFormattingAction());
         EditorActionsProvider._toggleAutoRevealActionRegistration = editor.addAction(EditorActionsProvider.createToggleAutoRevealAction());
 

--- a/components/ide/ide-ui-report/src/main/resources/META-INF/dirigible/ide-report/editors/report/editor.html
+++ b/components/ide/ide-ui-report/src/main/resources/META-INF/dirigible/ide-report/editors/report/editor.html
@@ -18,10 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/report-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <script type="text/javascript" src="/services/web/ide-workspace-service/workspace.js"></script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-report/src/main/resources/META-INF/dirigible/ide-report/editors/report/editor.js
+++ b/components/ide/ide-ui-report/src/main/resources/META-INF/dirigible/ide-report/editors/report/editor.js
@@ -88,7 +88,8 @@ angular.module('page', ['ideUI', 'ideView', 'ideWorkspace'])
 			if (!$scope.state.error) {
 				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
 					if (response.status === 200) {
-						$scope.report = response.data;
+						if (response.data === '') $scope.report = {};
+						else $scope.report = response.data;
 						contents = JSON.stringify($scope.report, null, 4);
 						$scope.$apply(function () {
 							$scope.state.isBusy = false;
@@ -1267,21 +1268,24 @@ angular.module('page', ['ideUI', 'ideView', 'ideWorkspace'])
 
 		$scope.generateQuery = function () {
 			$scope.query = "SELECT ";
-			for (let i = 0; i < $scope.report.columns.length; i++) {
-				if ($scope.report.columns[i].select === true) {
-					if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
-						$scope.query += $scope.report.columns[i].aggregate + "(";
+			if ($scope.report.columns) {
+				for (let i = 0; i < $scope.report.columns.length; i++) {
+					if ($scope.report.columns[i].select === true) {
+						if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
+							$scope.query += $scope.report.columns[i].aggregate + "(";
+						}
+						$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name;
+						if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
+							$scope.query += ")";
+						}
+						$scope.query += ' as ' + $scope.report.columns[i].alias + ', ';
 					}
-					$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name;
-					if ($scope.report.columns[i].aggregate !== undefined && $scope.report.columns[i].aggregate !== "NONE") {
-						$scope.query += ")";
-					}
-					$scope.query += ' as ' + $scope.report.columns[i].alias + ', ';
 				}
 			}
 			if ($scope.query.substring($scope.query.length - 2) === ', ')
 				$scope.query = $scope.query.substring(0, $scope.query.length - 2);
-			$scope.query += "\nFROM " + $scope.report.table + " as " + $scope.report.alias;
+			if ($scope.report.table && $scope.report.alias)
+				$scope.query += "\nFROM " + $scope.report.table + " as " + $scope.report.alias;
 
 			if ($scope.report.joins) {
 				for (let i = 0; i < $scope.report.joins.length; i++) {
@@ -1298,10 +1302,12 @@ angular.module('page', ['ideUI', 'ideView', 'ideWorkspace'])
 				}
 			}
 
-			$scope.query += "\nGROUP BY ";
-			for (let i = 0; i < $scope.report.columns.length; i++) {
-				if ($scope.report.columns[i].grouping === true) {
-					$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name + ', ';
+			if ($scope.report.columns) {
+				$scope.query += "\nGROUP BY ";
+				for (let i = 0; i < $scope.report.columns.length; i++) {
+					if ($scope.report.columns[i].grouping === true) {
+						$scope.query += $scope.report.columns[i].table + "." + $scope.report.columns[i].name + ', ';
+					}
 				}
 			}
 			if ($scope.query.substring($scope.query.length - 2) === ', ')

--- a/components/ide/ide-ui-schema/src/main/resources/META-INF/dirigible/ide-schema/modeler.html
+++ b/components/ide/ide-ui-schema/src/main/resources/META-INF/dirigible/ide-schema/modeler.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="services/schema-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <link type="text/css" href="css/styles.css" rel="stylesheet">
         <script type="text/javascript">
             mxBasePath = '/services/web/resources/mxgraph/3.9.1/src';

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/access-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.js
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/access/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-    .controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+    .controller('PageController', function ($scope, messageHub, workspaceApi, $window, ViewParameters) {
         let contents;
-        let csrfToken;
-        $scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+        $scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
         $scope.state = {
             isBusy: true,
             error: false,
@@ -39,38 +38,30 @@ angular.module('page', ["ideUI", "ideView"])
             messageHub.setStatusCaret('');
         });
 
-        function getResource(resourcePath) {
-            let xhr = new XMLHttpRequest();
-            xhr.open('GET', resourcePath, false);
-            xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-            xhr.send();
-            if (xhr.status === 200) {
-                csrfToken = xhr.getResponseHeader("x-csrf-token");
-                return xhr.responseText;
-            } else {
-                $scope.state.error = true;
-                $scope.errorMessage = "Unable to load the file. See console, for more information.";
-                messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-                return '{}';
-            }
-        }
-
-        $scope.load = function () {
+        function load() {
             if (!$scope.state.error) {
-                contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-                $scope.access = JSON.parse(contents);
-                contents = JSON.stringify($scope.access, null, 4);
-                $scope.state.isBusy = false;
+                workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+                    if (response.status === 200) {
+                        if (response.data === '') $scope.access = {};
+                        else $scope.access = response.data;
+                        contents = JSON.stringify($scope.access, null, 4);
+                        $scope.$apply(() => $scope.state.isBusy = false);
+                    } else if (response.status === 404) {
+                        messageHub.closeEditor($scope.dataParameters.file);
+                    } else {
+                        $scope.$apply(function () {
+                            $scope.state.error = true;
+                            $scope.errorMessage = 'There was a problem with loading the file';
+                            $scope.state.isBusy = false;
+                        });
+                    }
+                });
             }
         };
 
         function saveContents(text) {
-            let xhr = new XMLHttpRequest();
-            xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-            xhr.setRequestHeader('X-Requested-With', 'Fetch');
-            xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-            xhr.onreadystatechange = function () {
-                if (xhr.readyState === 4) {
+            workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+                if (response.status === 200) {
                     messageHub.announceFileSaved({
                         name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
                         path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -82,17 +73,14 @@ angular.module('page', ["ideUI", "ideView"])
                     $scope.$apply(function () {
                         $scope.state.isBusy = false;
                     });
+                } else {
+                    messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+                    messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+                    $scope.$apply(function () {
+                        $scope.state.isBusy = false;
+                    });
                 }
-            };
-            xhr.onerror = function (error) {
-                console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-                messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-                messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-                $scope.$apply(function () {
-                    $scope.state.isBusy = false;
-                });
-            };
-            xhr.send(text);
+            });
         }
 
         $scope.save = function (_keySet, event) {
@@ -183,9 +171,8 @@ angular.module('page', ["ideUI", "ideView"])
         );
 
         $scope.$watch('access', function () {
-            if (!$scope.state.error) {
-                let access = JSON.stringify($scope.access, null, 4);
-                messageHub.setEditorDirty($scope.dataParameters.file, contents !== access);
+            if (!$scope.state.error && !$scope.state.isBusy) {
+                messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.access, null, 4));
             }
         }, true);
 
@@ -332,5 +319,5 @@ angular.module('page', ["ideUI", "ideView"])
         } else if (!$scope.dataParameters.hasOwnProperty('contentType')) {
             $scope.state.error = true;
             $scope.errorMessage = "The 'contentType' data parameter is missing.";
-        } else $scope.load();
+        } else load();
     });

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.html
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../../services/access-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.js
+++ b/components/ide/ide-ui-security/src/main/resources/META-INF/dirigible/ide-security/editors/roles/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-    .controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+    .controller('PageController', function ($scope, messageHub, workspaceApi, $window, ViewParameters) {
         let contents;
-        let csrfToken;
-        $scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+        $scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
         $scope.state = {
             isBusy: true,
             error: false,
@@ -26,38 +25,30 @@ angular.module('page', ["ideUI", "ideView"])
             messageHub.setStatusCaret('');
         });
 
-        function getResource(resourcePath) {
-            let xhr = new XMLHttpRequest();
-            xhr.open('GET', resourcePath, false);
-            xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-            xhr.send();
-            if (xhr.status === 200) {
-                csrfToken = xhr.getResponseHeader("x-csrf-token");
-                return xhr.responseText;
-            } else {
-                $scope.state.error = true;
-                $scope.errorMessage = "Unable to load the file. See console, for more information.";
-                messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-                return '{}';
-            }
-        }
-
-        $scope.load = function () {
+        function load() {
             if (!$scope.state.error) {
-                contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-                $scope.roles = JSON.parse(contents);
-                contents = JSON.stringify($scope.roles, null, 4);
-                $scope.state.isBusy = false;
+                workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+                    if (response.status === 200) {
+                        if (response.data === '') $scope.roles = {};
+                        else $scope.roles = response.data;
+                        contents = JSON.stringify($scope.roles, null, 4);
+                        $scope.$apply(() => $scope.state.isBusy = false);
+                    } else if (response.status === 404) {
+                        messageHub.closeEditor($scope.dataParameters.file);
+                    } else {
+                        $scope.$apply(function () {
+                            $scope.state.error = true;
+                            $scope.errorMessage = 'There was a problem with loading the file';
+                            $scope.state.isBusy = false;
+                        });
+                    }
+                });
             }
         };
 
         function saveContents(text) {
-            let xhr = new XMLHttpRequest();
-            xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-            xhr.setRequestHeader('X-Requested-With', 'Fetch');
-            xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-            xhr.onreadystatechange = function () {
-                if (xhr.readyState === 4) {
+            workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+                if (response.status === 200) {
                     messageHub.announceFileSaved({
                         name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
                         path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -69,17 +60,14 @@ angular.module('page', ["ideUI", "ideView"])
                     $scope.$apply(function () {
                         $scope.state.isBusy = false;
                     });
+                } else {
+                    messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+                    messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+                    $scope.$apply(function () {
+                        $scope.state.isBusy = false;
+                    });
                 }
-            };
-            xhr.onerror = function (error) {
-                console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-                messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-                messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-                $scope.$apply(function () {
-                    $scope.state.isBusy = false;
-                });
-            };
-            xhr.send(text);
+            });
         }
 
         $scope.save = function (_keySet, event) {
@@ -164,9 +152,8 @@ angular.module('page', ["ideUI", "ideView"])
         );
 
         $scope.$watch('roles', function () {
-            if (!$scope.state.error) {
-                let roles = JSON.stringify($scope.roles, null, 4);
-                messageHub.setEditorDirty($scope.dataParameters.file, contents !== roles);
+            if (!$scope.state.error && !$scope.state.isBusy) {
+                messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.roles, null, 4));
             }
         }, true);
 
@@ -283,5 +270,5 @@ angular.module('page', ["ideUI", "ideView"])
         } else if (!$scope.dataParameters.hasOwnProperty('contentType')) {
             $scope.state.error = true;
             $scope.errorMessage = "The 'contentType' data parameter is missing.";
-        } else $scope.load();
+        } else load();
     });

--- a/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.html
+++ b/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.html
@@ -18,9 +18,10 @@
         <title dg-view-title></title>
         <script type="text/javascript" src="../services/websocket-editor.js"></script>
         <theme></theme>
-        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-view-js">
+        <script type="text/javascript" src="/services/js/resources-core/services/loader.js?id=ide-editor-js">
         </script>
-        <link type="text/css" rel="stylesheet" href="/services/js/resources-core/services/loader.js?id=ide-view-css" />
+        <link type="text/css" rel="stylesheet"
+            href="/services/js/resources-core/services/loader.js?id=ide-editor-css" />
         <script type="text/javascript" src="editor.js"></script>
     </head>
 

--- a/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.js
+++ b/components/ide/ide-ui-websockets/src/main/resources/META-INF/dirigible/ide-websockets/editor/editor.js
@@ -9,11 +9,10 @@
  * SPDX-FileCopyrightText: Eclipse Dirigible contributors
  * SPDX-License-Identifier: EPL-2.0
  */
-angular.module('page', ["ideUI", "ideView"])
-	.controller('PageController', function ($scope, messageHub, $window, ViewParameters) {
+angular.module('page', ["ideUI", "ideView", "ideWorkspace"])
+	.controller('PageController', function ($scope, messageHub, workspaceApi, $window, ViewParameters) {
 		let contents;
-		let csrfToken;
-		$scope.errorMessage = 'Аn unknown error was encountered. Please see console for more information.';
+		$scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
 		$scope.forms = {
 			editor: {},
 		};
@@ -28,38 +27,30 @@ angular.module('page', ["ideUI", "ideView"])
 			messageHub.setStatusCaret('');
 		});
 
-		function getResource(resourcePath) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', resourcePath, false);
-			xhr.setRequestHeader('X-CSRF-Token', 'Fetch');
-			xhr.send();
-			if (xhr.status === 200) {
-				csrfToken = xhr.getResponseHeader("x-csrf-token");
-				return xhr.responseText;
-			} else {
-				$scope.state.error = true;
-				$scope.errorMessage = "Unable to load the file. See console, for more information.";
-				messageHub.setStatusError(`Error loading '${$scope.dataParameters.file}'`);
-				return '{}';
-			}
-		}
-
-		$scope.load = function () {
+		function load() {
 			if (!$scope.state.error) {
-				contents = getResource('/services/ide/workspaces' + $scope.dataParameters.file);
-				$scope.websocket = JSON.parse(contents);
-				contents = JSON.stringify($scope.websocket, null, 4);
-				$scope.state.isBusy = false;
+				workspaceApi.loadContent('', $scope.dataParameters.file).then(function (response) {
+					if (response.status === 200) {
+						if (response.data === '') $scope.websocket = {};
+						else $scope.websocket = response.data;
+						contents = JSON.stringify($scope.websocket, null, 4);
+						$scope.$apply(() => $scope.state.isBusy = false);
+					} else if (response.status === 404) {
+						messageHub.closeEditor($scope.dataParameters.file);
+					} else {
+						$scope.$apply(function () {
+							$scope.state.error = true;
+							$scope.errorMessage = 'There was a problem with loading the file';
+							$scope.state.isBusy = false;
+						});
+					}
+				});
 			}
 		};
 
 		function saveContents(text) {
-			let xhr = new XMLHttpRequest();
-			xhr.open('PUT', '/services/ide/workspaces' + $scope.dataParameters.file);
-			xhr.setRequestHeader('X-Requested-With', 'Fetch');
-			xhr.setRequestHeader('X-CSRF-Token', csrfToken);
-			xhr.onreadystatechange = function () {
-				if (xhr.readyState === 4) {
+			workspaceApi.saveContent('', $scope.dataParameters.file, text).then(function (response) {
+				if (response.status === 200) {
 					messageHub.announceFileSaved({
 						name: $scope.dataParameters.file.substring($scope.dataParameters.file.lastIndexOf('/') + 1),
 						path: $scope.dataParameters.file.substring($scope.dataParameters.file.indexOf('/', 1)),
@@ -71,17 +62,14 @@ angular.module('page', ["ideUI", "ideView"])
 					$scope.$apply(function () {
 						$scope.state.isBusy = false;
 					});
+				} else {
+					messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
+					messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
+					$scope.$apply(function () {
+						$scope.state.isBusy = false;
+					});
 				}
-			};
-			xhr.onerror = function (error) {
-				console.error(`Error saving '${$scope.dataParameters.file}'`, error);
-				messageHub.setStatusError(`Error saving '${$scope.dataParameters.file}'`);
-				messageHub.showAlertError('Error while saving the file', 'Please look at the console for more information');
-				$scope.$apply(function () {
-					$scope.state.isBusy = false;
-				});
-			};
-			xhr.send(text);
+			});
 		}
 
 		$scope.save = function (_keySet, event) {
@@ -136,9 +124,8 @@ angular.module('page', ["ideUI", "ideView"])
 		);
 
 		$scope.$watch('websocket', function () {
-			if (!$scope.state.error) {
-				let websocket = JSON.stringify($scope.websocket, null, 4);
-				messageHub.setEditorDirty($scope.dataParameters.file, contents !== websocket);
+			if (!$scope.state.error && !$scope.state.isBusy) {
+				messageHub.setEditorDirty($scope.dataParameters.file, contents !== JSON.stringify($scope.websocket, null, 4));
 			}
 		}, true);
 
@@ -149,5 +136,5 @@ angular.module('page', ["ideUI", "ideView"])
 		} else if (!$scope.dataParameters.hasOwnProperty('contentType')) {
 			$scope.state.error = true;
 			$scope.errorMessage = "The 'contentType' data parameter is missing.";
-		} else $scope.load();
+		} else load();
 	});

--- a/components/ide/ide-ui-workspace-service/src/main/resources/META-INF/dirigible/ide-workspace-service/workspace.js
+++ b/components/ide/ide-ui-workspace-service/src/main/resources/META-INF/dirigible/ide-workspace-service/workspace.js
@@ -244,6 +244,10 @@ angular.module('ideWorkspace', [])
                     });
             }.bind(this);
 
+            const getFullURL = function (workspace, resourcePath) {
+                return new UriBuilder().path(this.workspacesServiceUrl.split('/')).path(workspace).path(resourcePath ? resourcePath.split('/') : '').build();
+            }.bind(this);
+
             return {
                 setWorkspace: setWorkspace,
                 getCurrentWorkspace: getCurrentWorkspace,
@@ -265,6 +269,7 @@ angular.module('ideWorkspace', [])
                 linkProject: linkProject,
                 deleteProject: deleteProject,
                 search: search,
+                getFullURL: getFullURL,
             };
         }];
     });

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/services/loader.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/services/loader.js
@@ -15,6 +15,28 @@ import { uuid } from "sdk/utils";
 
 const COOKIE_PREFIX = "DIRIGIBLE.resources-core.loader.";
 
+const viewJs = [
+    "/jquery/3.6.0/jquery.min.js",
+    "/angularjs/1.8.2/angular.min.js",
+    "/angularjs/1.8.2/angular-resource.min.js",
+    "/angular-aria/1.8.2/angular-aria.min.js",
+    "/split.js/1.6.5/dist/split.min.js",
+    "/resources-core/core/message-hub.js",
+    "/resources-core/core/ide-message-hub.js",
+    "/resources-core/ui/theming.js",
+    "/resources-core/ui/widgets.js",
+    "/resources-core/ui/extensions.js",
+    "/resources-core/ui/view.js",
+    "/resources-core/core/uri-builder.js",
+    "/resources-core/ui/entityApi.js",
+];
+
+const viewCss = [
+    "/fundamental-styles/0.30.2/dist/fundamental-styles.css",
+    "/resources/styles/core.css",
+    "/resources/styles/widgets.css",
+];
+
 let scriptId = request.getParameter("id");
 if (scriptId) {
     if (isCached(scriptId)) {
@@ -78,21 +100,9 @@ function getLocations(scriptId) {
     switch (scriptId) {
         case "application-view-js":
         case "ide-view-js":
-            return [
-                "/jquery/3.6.0/jquery.min.js",
-                "/angularjs/1.8.2/angular.min.js",
-                "/angularjs/1.8.2/angular-resource.min.js",
-                "/angular-aria/1.8.2/angular-aria.min.js",
-                "/split.js/1.6.5/dist/split.min.js",
-                "/resources-core/core/message-hub.js",
-                "/resources-core/core/ide-message-hub.js",
-                "/resources-core/ui/theming.js",
-                "/resources-core/ui/widgets.js",
-                "/resources-core/ui/extensions.js",
-                "/resources-core/ui/view.js",
-                "/resources-core/core/uri-builder.js",
-                "/resources-core/ui/entityApi.js",
-            ];
+            return viewJs;
+        case "ide-editor-js":
+            return [...viewJs, "/ide-workspace-service/workspace.js"]
         case "application-perspective-js":
         case "ide-perspective-js":
             return [
@@ -122,21 +132,12 @@ function getLocations(scriptId) {
         case "sanitize-js":
             return ["/angularjs/1.8.2/angular-sanitize.min.js"];
         case "application-view-css":
+        case "ide-editor-css":
         case "ide-view-css":
-            return [
-                "/fundamental-styles/0.30.2/dist/fundamental-styles.css",
-                "/resources/styles/core.css",
-                "/resources/styles/widgets.css",
-            ];
+            return viewCss;
         case "application-perspective-css":
         case "ide-perspective-css":
-            return [
-                "/fundamental-styles/0.30.2/dist/fundamental-styles.css",
-                "/resources/styles/core.css",
-                "/resources/styles/layout.css",
-                "/resources/styles/widgets.css",
-                "/resources/styles/perspective.css",
-            ];
+            return [...viewCss, "/resources/styles/layout.css", "/resources/styles/perspective.css"]
         case "code-editor-js":
             return ["/ide-monaco/embeddable/editor.js", "/monaco-editor/0.40.0/min/vs/loader.js", "/monaco-editor/0.40.0/min/vs/editor/editor.main.nls.js", "/monaco-editor/0.40.0/min/vs/editor/editor.main.js"];
         case "code-editor-css":

--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/layout.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/layout.js
@@ -897,6 +897,14 @@ angular.module('ideLayout', ['idePerspective', 'ideEditors', 'ideMessageHub', 'i
                     }
                 );
 
+                messageHub.onFileDeleted(
+                    function (fileDescriptor) {
+                        $scope.$apply(
+                            $scope.closeEditor(`/${fileDescriptor.workspace}${fileDescriptor.path}`)
+                        );
+                    }
+                );
+
                 messageHub.onDidReceiveMessage('ide-core.setFocusedEditor', function (msg) {
                     const result = findCenterSplittedTabViewByPath(msg.resourcePath);
                     if (result) {


### PR DESCRIPTION
### What does this PR do?

* Creates two new loader.js parameters - `ide-editor-js` and `ide-editor-css`
Those will be used by all Dirigible editors and will provide all the needed JS and CSS.

* Migrates all the native editors to use the Workspace API service.

* When a file gets deleted while it's opened in an editor, the editor will close automatically.

* When the Entity (EDM) and Schema (DSM) editors generate all the companion files on initialization, the project in the Projects view will now get automatically refreshed.

* When a project is regenerated from the EDM editor, only the project in question will get refreshed in the Projects view, instead of the whole workspace.

### What issues does this PR fix or reference?

#3869 