### PR TITLE
Improve cache API

### DIFF
--- a/components/api/api-cache/src/main/java/org/eclipse/dirigible/components/api/cache/CacheFacade.java
+++ b/components/api/api-cache/src/main/java/org/eclipse/dirigible/components/api/cache/CacheFacade.java
@@ -24,8 +24,8 @@ public class CacheFacade {
     private static final Logger LOGGER = LoggerFactory.getLogger(CacheFacade.class);
 
     private static final Cache<String, Object> cache = Caffeine.newBuilder()
-                                                               .expireAfterWrite(15, TimeUnit.MINUTES)
-                                                               .maximumSize(1000)
+                                                               .expireAfterWrite(30, TimeUnit.MINUTES)
+                                                               .maximumSize(1500)
                                                                .build();
 
 

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/util/FileUtil.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/util/FileUtil.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -39,6 +40,10 @@ public class FileUtil {
     }
 
     public static List<Path> findFiles(Path folder) throws IOException {
+        if (!Files.exists(folder)) {
+            LOGGER.info("Folder [{}] doesn't exist", folder);
+            return Collections.emptyList();
+        }
         if (!Files.isDirectory(folder)) {
             throw new IllegalArgumentException("Path [" + folder + "] must be a directory");
         }

--- a/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
+++ b/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
@@ -86,7 +86,7 @@ test('cache-api-object', () => {
     const KEY = "object-key";
     const VALUE = {
         name : "Ivan",
-        age: 15
+        age: 15,
         parent:{
           name : "Patar",
                 age: 35

--- a/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
+++ b/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
@@ -25,3 +25,76 @@ test('cache-api-test', () => {
     assertFalse(caches.contains(KEY))
     assertEquals(null, caches.get(KEY));
 });
+
+test('cache-api-boolean', () => {
+
+    const KEY = "boolean-key";
+    const VALUE = true;
+
+    caches.clear();
+
+    caches.set(KEY, VALUE);
+    assertEquals(VALUE, caches.get(KEY));
+});
+
+test('cache-api-number', () => {
+
+    const KEY = "number-key";
+    const VALUE = 123;
+
+    caches.clear();
+
+    caches.set(KEY, VALUE);
+    assertEquals(VALUE, caches.get(KEY));
+});
+
+test('cache-api-string', () => {
+
+    const KEY = "string-key";
+    const VALUE = "This is a string value";
+
+    caches.clear();
+
+    caches.set(KEY, VALUE);
+    assertEquals(VALUE, caches.get(KEY));
+});
+
+function isEqual(obj1, obj2) {
+    if (obj1 === null || obj1 === undefined || obj2 === null || obj2 === undefined) {
+        return obj1 === obj2;
+    }
+
+    if (typeof obj1 !== 'object' || typeof obj2 !== 'object') {
+        return obj1 === obj2;
+    }
+
+    if (Object.keys(obj1).length !== Object.keys(obj2).length) {
+        return false;
+    }
+
+    for (let key in obj1) {
+        if (!isEqual(obj1[key], obj2[key])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+test('cache-api-object', () => {
+
+    const KEY = "object-key";
+    const VALUE = {
+        name : "Ivan",
+        age: 15
+        parent:{
+          name : "Patar",
+                age: 35
+        }
+    };
+
+    caches.clear();
+
+    caches.set(KEY, VALUE);
+    assertTrue(isEqual(VALUE, caches.get(KEY));
+});

--- a/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
+++ b/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
@@ -96,5 +96,5 @@ test('cache-api-object', () => {
     caches.clear();
 
     caches.set(KEY, VALUE);
-    assertTrue(isEqual(VALUE, caches.get(KEY));
+    assertTrue(isEqual(VALUE, caches.get(KEY)));
 });

--- a/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
+++ b/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
@@ -64,7 +64,11 @@ test('cache-api-object', () => {
     const KEY = "object-key";
     const VALUE = {
         name : "Ivan",
-        age: 35
+        age: 35,
+        parent:  {
+           name : "Petar",
+           age: 55
+        }
     };
 
     caches.clear();
@@ -73,6 +77,10 @@ test('cache-api-object', () => {
 
     const cachedValue = caches.get(KEY);
     assertTrue(cachedValue != null);
+
     assertEquals("Ivan", cachedValue.name);
     assertEquals(35, cachedValue.age);
+
+    assertEquals("Petar", cachedValue.parent.name);
+    assertEquals(55, cachedValue.parent.age);
 });

--- a/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
+++ b/tests/tests-integrations/src/test/resources/META-INF/dirigible/modules-tests/src/cache/cache-test.ts
@@ -59,42 +59,20 @@ test('cache-api-string', () => {
     assertEquals(VALUE, caches.get(KEY));
 });
 
-function isEqual(obj1, obj2) {
-    if (obj1 === null || obj1 === undefined || obj2 === null || obj2 === undefined) {
-        return obj1 === obj2;
-    }
-
-    if (typeof obj1 !== 'object' || typeof obj2 !== 'object') {
-        return obj1 === obj2;
-    }
-
-    if (Object.keys(obj1).length !== Object.keys(obj2).length) {
-        return false;
-    }
-
-    for (let key in obj1) {
-        if (!isEqual(obj1[key], obj2[key])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 test('cache-api-object', () => {
 
     const KEY = "object-key";
     const VALUE = {
         name : "Ivan",
-        age: 15,
-        parent:{
-          name : "Patar",
-                age: 35
-        }
+        age: 35
     };
 
     caches.clear();
 
     caches.set(KEY, VALUE);
-    assertTrue(isEqual(VALUE, caches.get(KEY)));
+
+    const cachedValue = caches.get(KEY);
+    assertTrue(cachedValue != null);
+    assertEquals("Ivan", cachedValue.name);
+    assertEquals(35, cachedValue.age);
 });


### PR DESCRIPTION
- fix storing and getting objects in the cache
With the previous version of the API, it was not able to store objects in the cache.
Example exception:
```
2024-05-07 09:39:45.961 [ERROR] [http-nio-8080-exec-10] [default-tenant] o.e.d.c.e.j.s.JavascriptHandler - Error on processing JavaScript service from project: [codbex-electra], and path: [dao/TestCache.js], with parameters: []
org.graalvm.polyglot.PolyglotException: The Context is already closed.
	at com.oracle.truffle.polyglot.PolyglotEngineException.closedException(PolyglotEngineException.java:137) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotContextImpl.checkClosedOrDisposing(PolyglotContextImpl.java:1453) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotContextImpl.enterThreadChanged(PolyglotContextImpl.java:860) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enterCached(PolyglotEngineImpl.java:2095) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.PolyglotEngineImpl.enter(PolyglotEngineImpl.java:2042) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject.sendImpl(OtherContextGuestObject.java:138) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObject$Send.doCached(OtherContextGuestObject.java:115) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObjectGen$ReflectionLibraryExports$Cached.executeAndSpecialize(OtherContextGuestObjectGen.java:181) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.polyglot.OtherContextGuestObjectGen$ReflectionLibraryExports$Cached.send(OtherContextGuestObjectGen.java:136) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.api.interop.InteropLibraryGen$Proxy.isNull(InteropLibraryGen.java:2479) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.js.runtime.interop.JSInteropUtil.toPrimitiveOrDefaultLossless(JSInteropUtil.java:217) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.cast.JSToPrimitiveNode.doForeignObject(JSToPrimitiveNode.java:229) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.cast.JSToPrimitiveNodeGen.executeAndSpecialize(JSToPrimitiveNodeGen.java:435) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.cast.JSToPrimitiveNodeGen.execute(JSToPrimitiveNodeGen.java:285) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.JSAddNode.doPrimitiveConversion(JSAddNode.java:246) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.JSAddNodeGen.executeAndSpecialize(JSAddNodeGen.java:1185) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.JSAddNodeGen.execute_generic4(JSAddNodeGen.java:747) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.binary.JSAddNodeGen.execute(JSAddNodeGen.java:379) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$Invoke1Node.createArguments(JSFunctionCallNode.java:855) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:746) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:187) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:80) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:55) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.api.impl.DefaultBlockNode.executeGeneric(DefaultBlockNode.java:63) ~[truffle-api-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.execute(AbstractBlockNode.java:75) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.control.ModuleBodyNode.execute(ModuleBodyNode.java:75) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:73) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:156) ~[js-language-24.0.1.jar!/:na]
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:96) ~[js-language-24.0.1.jar!/:na]
	at <js>.:module:eval(Unknown) ~[na:na]
	at org.graalvm.polyglot.Context.eval(Context.java:402) ~[polyglot-24.0.1.jar!/:na]
	at org.eclipse.dirigible.graalium.core.javascript.GraalJSCodeRunner.run(GraalJSCodeRunner.java:148) ~[dirigible-engine-graalium-execution-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.graalium.core.DirigibleJavascriptCodeRunner.run(DirigibleJavascriptCodeRunner.java:165) ~[dirigible-engine-graalium-execution-core-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.javascript.service.JavascriptHandler.handleRequest(JavascriptHandler.java:101) ~[dirigible-components-engine-javascript-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.javascript.service.JavascriptService.handleRequest(JavascriptService.java:92) ~[dirigible-components-engine-javascript-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.executeJavaScript(JavascriptEndpoint.java:304) ~[dirigible-components-engine-javascript-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.executeJavaScript(JavascriptEndpoint.java:227) ~[dirigible-components-engine-javascript-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.javascript.endpoint.JavascriptEndpoint.get(JavascriptEndpoint.java:120) ~[dirigible-components-engine-javascript-11.0.0-SNAPSHOT.jar!/:na]
	at org.eclipse.dirigible.components.engine.typescript.TypeScriptEndpoint.get(TypeScriptEndpoint.java:64) ~[dirigible-components-engine-typescript-11.0.0-SNAPSHOT.jar!/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255) ~[spring-web-6.1.6.jar!/:6.1.6]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188) ~[spring-web-6.1.6.jar!/:6.1.6]
...
```
- support primitive types
