### PR TITLE
[EDM] Clean-up output model file

### DIFF
--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
@@ -94,10 +94,6 @@ function createModel(graph) {
 					property.dataName = property.dataName ? property.dataName : _.escape(child.value.dataName).toUpperCase() + "_" + JSON.stringify(property.name).replace(/\W/g, '').toUpperCase();
 
 					model.push('    <property name="' + _.escape(property.name) +
-						'" isRequiredProperty="' + _.escape(property.isRequiredProperty) +
-						'" isCalculatedProperty="' + _.escape(property.isCalculatedProperty) +
-						'" calculatedPropertyExpressionCreate="' + _.escape(property.calculatedPropertyExpressionCreate) +
-						'" calculatedPropertyExpressionUpdate="' + _.escape(property.calculatedPropertyExpressionUpdate) +
 						'" dataName="' + _.escape(property.dataName) +
 						'" dataType="' + _.escape(property.dataType) + '"');
 					if (property.dataLength !== null && (property.dataType === 'CHAR' || property.dataType === 'VARCHAR')) {
@@ -125,6 +121,18 @@ function createModel(graph) {
 					}
 					if (property.dataScale !== null && property.dataType === 'DECIMAL') {
 						model.push(' dataScale="' + _.escape(property.dataScale) + '"');
+					}
+					if (property.isRequiredProperty == "true") {
+						model.push(' isRequiredProperty="true"');
+					}
+					if (property.isCalculatedProperty == "true") {
+						model.push(' isCalculatedProperty="true"');
+					}
+					if (property.calculatedPropertyExpressionCreate != null) {
+						model.push(' calculatedPropertyExpressionCreate="' + _.escape(property.calculatedPropertyExpressionCreate) + '"');
+					}
+					if (property.calculatedPropertyExpressionUpdate != null) {
+						model.push(' calculatedPropertyExpressionUpdate="' + _.escape(property.calculatedPropertyExpressionUpdate) + '"');
 					}
 					if (property.relationshipType !== null) {
 						model.push(' relationshipType="' + _.escape(property.relationshipType ? property.relationshipType : 'ASSOCIATION') + '"');

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
@@ -100,10 +100,8 @@ function createModel(graph) {
 						'" calculatedPropertyExpressionUpdate="' + _.escape(property.calculatedPropertyExpressionUpdate) +
 						'" dataName="' + _.escape(property.dataName) +
 						'" dataType="' + _.escape(property.dataType) + '"');
-					if (property.dataLength !== null) {
-						if (property.dataType === 'CHAR' || property.dataType === 'VARCHAR') {
-							model.push(' dataLength="' + _.escape(property.dataLength) + '"');
-						}
+					if (property.dataLength !== null && (property.dataType === 'CHAR' || property.dataType === 'VARCHAR')) {
+						model.push(' dataLength="' + _.escape(property.dataLength) + '"');
 					}
 					if (property.dataNotNull) {
 						model.push(' dataNullable="' + (property.dataNotNull == "false") + '"');
@@ -128,10 +126,10 @@ function createModel(graph) {
 					if (property.dataDefaultValue !== null) {
 						model.push(' dataDefaultValue="' + _.escape(property.dataDefaultValue) + '"');
 					}
-					if (property.dataPrecision !== null) {
+					if (property.dataPrecision !== null && property.dataType === 'DECIMAL') {
 						model.push(' dataPrecision="' + _.escape(property.dataPrecision) + '"');
 					}
-					if (property.dataScale !== null) {
+					if (property.dataScale !== null && property.dataType === 'DECIMAL') {
 						model.push(' dataScale="' + _.escape(property.dataScale) + '"');
 					}
 					if (property.relationshipType !== null) {

--- a/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
+++ b/components/ide/ide-ui-entity/src/main/resources/META-INF/dirigible/ide-entity/js/serializer.js
@@ -108,20 +108,14 @@ function createModel(graph) {
 					} else {
 						model.push(' dataNullable="true"');
 					}
-					if (property.dataPrimaryKey) {
-						model.push(' dataPrimaryKey="' + (property.dataPrimaryKey == "true") + '"');
-					} else {
-						model.push(' dataPrimaryKey="false"');
+					if (property.dataPrimaryKey == "true") {
+						model.push(' dataPrimaryKey="true"');
 					}
-					if (property.dataAutoIncrement) {
-						model.push(' dataAutoIncrement="' + (property.dataAutoIncrement == "true") + '"');
-					} else {
-						model.push(' dataAutoIncrement="false"');
+					if (property.dataAutoIncrement == "true") {
+						model.push(' dataAutoIncrement="true"');
 					}
-					if (property.dataUnique) {
-						model.push(' dataUnique="' + (property.dataUnique == "true") + '"');
-					} else {
-						model.push(' dataUnique="false"');
+					if (property.dataUnique == "true") {
+						model.push(' dataUnique="true"');
 					}
 					if (property.dataDefaultValue !== null) {
 						model.push(' dataDefaultValue="' + _.escape(property.dataDefaultValue) + '"');

--- a/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.ts.template
+++ b/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/entity.ts.template
@@ -205,7 +205,7 @@ export class ${name}Repository {
 #end
 #end
 #foreach ($property in $properties)
-#if($property.isCalculatedProperty && $property.calculatedPropertyExpressionCreate != "")
+#if($property.isCalculatedProperty && $property.calculatedPropertyExpressionCreate)
         // @ts-ignore
         (entity as ${name}Entity).${property.name} = ${property.calculatedPropertyExpressionCreate};
 #end
@@ -253,7 +253,7 @@ export class ${name}Repository {
 #end
 #end
 #foreach ($property in $properties)
-#if($property.isCalculatedProperty && $property.calculatedPropertyExpressionUpdate != "")
+#if($property.isCalculatedProperty && $property.calculatedPropertyExpressionUpdate)
         // @ts-ignore
         (entity as ${name}Entity).${property.name} = ${property.calculatedPropertyExpressionUpdate};
 #end


### PR DESCRIPTION
Skip the creation the following properties in the `*.model` file if they are not needed _(e.g. default or no values)_:
- `dataPrimaryKey`
- `dataAutoIncrement`
- `dataUnique`
- `isRequiredProperty`
- `isCalculatedProperty`
- `calculatedPropertyExpressionCreate`
- `calculatedPropertyExpressionUpdate`

Changes to `*.schema` files:
<img width="1071" alt="Screenshot 2024-06-18 at 18 31 10" src="https://github.com/eclipse/dirigible/assets/4092083/1abaeb41-b665-4677-9505-2fc80c661f93">

Changes to `*.model` files:
<img width="1073" alt="Screenshot 2024-06-18 at 18 31 33" src="https://github.com/eclipse/dirigible/assets/4092083/e798e551-febc-459c-96d6-d3f499298bc2">

Fixes: https://github.com/eclipse/dirigible/issues/4050