### PR TITLE
[Templates] Support for multiple generation definition files in the same project

### DIFF
--- a/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/generate.mjs
+++ b/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/generate.mjs
@@ -68,10 +68,11 @@ function onGenerateModel(context, request, response) {
     if (parameters.fileName.indexOf(".") > 0) {
         parameters.fileName = parameters.fileName.substring(0, path.indexOf("."))
     }
+    parameters.genFolderName = parameters.fileName;
 
     let generatedFiles = template.generate(model, parameters);
 
-    cleanGenFolder(workspace, project);
+    cleanGenFolder(workspace, project, parameters.genFolderName);
 
     for (let i = 0; i < generatedFiles.length; i++) {
         createFile(workspace, project, generatedFiles[i].path, generatedFiles[i].content);
@@ -103,12 +104,13 @@ function getModel(workspaceName, projectName, path) {
     return model.getText();
 }
 
-function cleanGenFolder(workspaceName, projectName) {
+function cleanGenFolder(workspaceName, projectName, genFolderName) {
     let projectWorkspace = workspace.getWorkspace(workspaceName);
     let project = projectWorkspace.getProject(projectName);
 
-    if (project.existsFolder("gen")) {
-        project.deleteFolder("gen");
+    const genFolder = project.getFolder("gen");
+    if (genFolder.exists() && genFolder.existsFolder(genFolderName)) {
+        genFolder.deleteFolder(genFolderName);
     }
     lifecycle.unpublish(projectName);
 }

--- a/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
+++ b/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
@@ -121,7 +121,7 @@ exports.process = function (model, parameters) {
             })
 
             if (p.widgetType == "DROPDOWN") {
-                let projectNameString = "\"/services/ts/" + `${parameters.projectName}` + "/gen/api/" + `${p.relationshipEntityPerspectiveName}` + "/" + `${p.relationshipEntityName}` + "Service.ts\"";
+                let projectNameString = `/services/ts/${parameters.projectName}/gen/${parameters.genFolderName}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Service.ts`;
 
                 e.hasDropdowns = true;
 
@@ -129,7 +129,7 @@ exports.process = function (model, parameters) {
                     let foundReferenceProjection = false;
                     e.referencedProjections.forEach(referencedProjection => {
                         if (referencedProjection.name === p.relationshipEntityName && !foundReferenceProjection) {
-                            p.widgetDropdownUrl = "\"/services/ts/" + `${referencedProjection.project}` + "/gen/api/" + `${p.relationshipEntityPerspectiveName}` + "/" + `${p.relationshipEntityName}` + "Service.ts\"";
+                            p.widgetDropdownUrl = `/services/ts/${referencedProjection.project}/gen/${parameters.genFolderName}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Service.ts`;
                             foundReferenceProjection = true;
                         }
                     });

--- a/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
+++ b/components/ide/ide-ui-generate-service/src/main/resources/META-INF/dirigible/ide-generate-service/template/parameterUtils.js
@@ -112,9 +112,11 @@ exports.process = function (model, parameters) {
             model.entities.forEach(ep => {
                 if (p.relationshipEntityName === ep.name) {
                     if (ep.projectionReferencedModel) {
+                        const tokens = ep.projectionReferencedModel.split('/');
                         e.referencedProjections.push({
                             name: ep.name,
-                            project: ep.projectionReferencedModel.split('/')[2]
+                            project: tokens[2],
+                            genFolderName: tokens[3].substring(0, tokens[3].indexOf('.'))
                         })
                     }
                 }
@@ -129,7 +131,7 @@ exports.process = function (model, parameters) {
                     let foundReferenceProjection = false;
                     e.referencedProjections.forEach(referencedProjection => {
                         if (referencedProjection.name === p.relationshipEntityName && !foundReferenceProjection) {
-                            p.widgetDropdownUrl = `/services/ts/${referencedProjection.project}/gen/${parameters.genFolderName}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Service.ts`;
+                            p.widgetDropdownUrl = `/services/ts/${referencedProjection.project}/gen/${referencedProjection.genFolderName}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Service.ts`;
                             foundReferenceProjection = true;
                         }
                     });

--- a/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/template/template.js
+++ b/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/template/template.js
@@ -21,19 +21,19 @@ exports.getTemplate = function (parameters) {
         sources: [{
             location: "/template-application-dao/dao/entity.ts.template",
             action: "generate",
-            rename: "gen/dao/{{perspectiveName}}/{{name}}Repository.ts",
+            rename: "gen/{{genFolderName}}/dao/{{perspectiveName}}/{{name}}Repository.ts",
             engine: "velocity",
             collection: "daoModels"
         }, {
             location: "/template-application-dao/dao/entity.extensionpoint.template",
             action: "generate",
-            rename: "gen/dao/{{perspectiveName}}/{{name}}.extensionpoint",
+            rename: "gen/{{genFolderName}}/dao/{{perspectiveName}}/{{name}}.extensionpoint",
             engine: "velocity",
             collection: "daoModels"
         }, {
             location: "/template-application-dao/dao/reportEntity.ts.template",
             action: "generate",
-            rename: "gen/dao/{{perspectiveName}}/{{name}}Repository.ts",
+            rename: "gen/{{genFolderName}}/dao/{{perspectiveName}}/{{name}}Repository.ts",
             engine: "velocity",
             collection: "reportModels"
         }, {
@@ -49,7 +49,7 @@ exports.getTemplate = function (parameters) {
         }, {
             location: "/template-application-dao/dao/utils/EntityUtils.ts.template",
             action: "copy",
-            rename: "gen/dao/utils/EntityUtils.ts"
+            rename: "gen/{{genFolderName}}/dao/utils/EntityUtils.ts"
         }],
         parameters: [{
             name: "tablePrefix",

--- a/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeed.job.template
+++ b/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeed.job.template
@@ -9,6 +9,6 @@
 #else
 	"expression": "0 0 0 1 * ? *",
 #end
-	"handler": "${projectName}/gen/{{genFolderName}}/feed/${perspectiveName}/${name}FeedSynchronizer.js",
+	"handler": "${projectName}/gen/${genFolderName}/feed/${perspectiveName}/${name}FeedSynchronizer.js",
 	"description": "${name}FeedSynchronizer Job"
 }

--- a/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeed.job.template
+++ b/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeed.job.template
@@ -9,6 +9,6 @@
 #else
 	"expression": "0 0 0 1 * ? *",
 #end
-	"handler": "${projectName}/gen/feed/${perspectiveName}/${name}FeedSynchronizer.js",
+	"handler": "${projectName}/gen/{{genFolderName}}/feed/${perspectiveName}/${name}FeedSynchronizer.js",
 	"description": "${name}FeedSynchronizer Job"
 }

--- a/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeedSynchronizer.js.template
+++ b/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeedSynchronizer.js.template
@@ -1,5 +1,5 @@
 #if($feedUrl)
-var dao = require("${projectName}/gen/{{genFolderName}}/dao/${perspectiveName}/${name}");
+var dao = require("${projectName}/gen/${genFolderName}/dao/${perspectiveName}/${name}");
 var httpClient = require("http/client");
 var base64 = require("utils/base64");
 var bytes = require("io/bytes");

--- a/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeedSynchronizer.js.template
+++ b/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/feed/entityFeedSynchronizer.js.template
@@ -1,5 +1,5 @@
 #if($feedUrl)
-var dao = require("${projectName}/gen/dao/${perspectiveName}/${name}");
+var dao = require("${projectName}/gen/{{genFolderName}}/dao/${perspectiveName}/${name}");
 var httpClient = require("http/client");
 var base64 = require("utils/base64");
 var bytes = require("io/bytes");

--- a/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/template/template.js
+++ b/components/template/template-application-feed/src/main/resources/META-INF/dirigible/template-application-feed/template/template.js
@@ -20,13 +20,13 @@ exports.getTemplate = function (parameters) {
     let templateSources = [{
         location: "/template-application-feed/feed/entityFeedSynchronizer.js.template",
         action: "generate",
-        rename: "gen/feed/{{perspectiveName}}/{{name}}FeedSynchronizer.js",
+        rename: "gen/{{genFolderName}}/feed/{{perspectiveName}}/{{name}}FeedSynchronizer.js",
         engine: "velocity",
         collection: "feedModels"
     }, {
         location: "/template-application-feed/feed/entityFeed.job.template",
         action: "generate",
-        rename: "gen/feed/{{perspectiveName}}/{{name}}Feed.job",
+        rename: "gen/{{genFolderName}}/feed/{{perspectiveName}}/{{name}}Feed.job",
         engine: "velocity",
         collection: "feedModels"
     }];

--- a/components/template/template-application-odata/src/main/resources/META-INF/dirigible/template-application-odata/template/template.js
+++ b/components/template/template-application-odata/src/main/resources/META-INF/dirigible/template-application-odata/template/template.js
@@ -22,7 +22,7 @@ exports.getTemplate = function (parameters) {
         sources: [{
             location: "/template-application-odata/odata/application.odata.template",
             action: "generate",
-            rename: "gen/odata/{{projectName}}.odata",
+            rename: "gen/{{genFolderName}}/odata/{{projectName}}.odata",
             engine: "velocity"
         }],
         parameters: [{

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/api.openapi.template
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/api.openapi.template
@@ -63,7 +63,7 @@ paths:
       #set($hasStringProperty = "true")
     #end
   #end
-  /$projectName/gen/api/$model.perspectiveName/${model.name}Service.ts:
+  /$projectName/gen/$genFolderName/api/$model.perspectiveName/${model.name}Service.ts:
     get:
       summary: List $model.name
       parameters:
@@ -147,7 +147,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /$projectName/gen/api/$model.perspectiveName/${model.name}Service.ts/{id}:
+  /$projectName/gen/$genFolderName/api/$model.perspectiveName/${model.name}Service.ts/{id}:
     get:
       summary: Get $model.name by Id
       parameters:
@@ -266,7 +266,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /$projectName/gen/api/$model.perspectiveName/${model.name}Service.ts/count:
+  /$projectName/gen/$genFolderName/api/$model.perspectiveName/${model.name}Service.ts/count:
     get:
       summary: Count the number of $model.name
       tags:
@@ -388,7 +388,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-  /$projectName/gen/api/$model.perspectiveName/${model.name}Service.ts/search:
+  /$projectName/gen/$genFolderName/api/$model.perspectiveName/${model.name}Service.ts/search:
     post:
       summary: Search ${model.name} by ${model.name}FilterOptions
       tags:

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
@@ -75,7 +75,7 @@ class ${name}Service {
             entity = { ...originalEntity, ...modifiedEntity };
 #end
             entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end = this.repository.create(entity);
-            response.setHeader("Content-Location", "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts/" + entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end);
+            response.setHeader("Content-Location", "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts/" + entity.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end);
             response.setStatus(response.CREATED);
             return entity;
         } catch (error: any) {

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/template/template.js
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/template/template.js
@@ -20,30 +20,30 @@ exports.getTemplate = function (parameters) {
     let templateSources = [{
         location: "/template-application-rest/api/utils/HttpUtils.ts.template",
         action: "copy",
-        rename: "gen/api/utils/HttpUtils.ts",
+        rename: "gen/{{genFolderName}}/api/utils/HttpUtils.ts",
     }, {
         location: "/template-application-rest/api/utils/ForbiddenError.ts.template",
         action: "copy",
-        rename: "gen/api/utils/ForbiddenError.ts",
+        rename: "gen/{{genFolderName}}/api/utils/ForbiddenError.ts",
     }, {
         location: "/template-application-rest/api/utils/ValidationError.ts.template",
         action: "copy",
-        rename: "gen/api/utils/ValidationError.ts",
+        rename: "gen/{{genFolderName}}/api/utils/ValidationError.ts",
     }, {
         location: "/template-application-rest/api/api.openapi.template",
         action: "generate",
-        rename: "gen/{{fileName}}.openapi",
+        rename: "gen/{{genFolderName}}/{{fileName}}.openapi",
         engine: "velocity"
     }, {
         location: "/template-application-rest/api/entity.ts.template",
         action: "generate",
-        rename: "gen/api/{{perspectiveName}}/{{name}}Service.ts",
+        rename: "gen/{{genFolderName}}/api/{{perspectiveName}}/{{name}}Service.ts",
         engine: "velocity",
         collection: "apiModels"
     }, {
         location: "/template-application-rest/api/reportEntity.ts.template",
         action: "generate",
-        rename: "gen/api/{{perspectiveName}}/{{name}}Service.ts",
+        rename: "gen/{{genFolderName}}/api/{{perspectiveName}}/{{name}}Service.ts",
         engine: "velocity",
         collection: "reportModels"
     }, {

--- a/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/template/template.js
+++ b/components/template/template-application-schema/src/main/resources/META-INF/dirigible/template-application-schema/template/template.js
@@ -21,7 +21,7 @@ exports.getTemplate = function (parameters) {
         sources: [{
             location: "/template-application-schema/data/application.schema.template",
             action: "generate",
-            rename: "gen/schema/{{projectName}}.schema",
+            rename: "gen/{{genFolderName}}/schema/{{projectName}}.schema",
             engine: "velocity"
         }],
         parameters: [{

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/launchpad.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/launchpad.js
@@ -5,94 +5,94 @@
  */
 exports.getSources = function (parameters) {
 	return [
-		// Location: "gen/index.html"
+		// Location: "gen/{{genFolderName}}/index.html"
 		{
 			location: "/template-application-ui-angular/index.html",
 			action: "generate",
-			rename: "gen/index.html"
+			rename: "gen/{{genFolderName}}/index.html"
 		},
-		// Location: "gen/ui/launchpad/Home"
+		// Location: "gen/{{genFolderName}}/ui/launchpad/Home"
 		{
 			location: "/template-application-ui-angular/ui/launchpad/Home/controller.js",
 			action: "generate",
-			rename: "gen/ui/launchpad/Home/controller.js"
+			rename: "gen/{{genFolderName}}/ui/launchpad/Home/controller.js"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/Home/index.html",
 			action: "generate",
-			rename: "gen/ui/launchpad/Home/index.html",
+			rename: "gen/{{genFolderName}}/ui/launchpad/Home/index.html",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/Home/tiles.js",
 			action: "generate",
-			rename: "gen/ui/launchpad/Home/tiles.js",
+			rename: "gen/{{genFolderName}}/ui/launchpad/Home/tiles.js",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/Home/view.extension.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/Home/view.extension",
+			rename: "gen/{{genFolderName}}/ui/launchpad/Home/view.extension",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/Home/view.js",
 			action: "generate",
-			rename: "gen/ui/launchpad/Home/view.js",
+			rename: "gen/{{genFolderName}}/ui/launchpad/Home/view.js",
 			engine: "velocity"
 		},
-		// Location: "gen/ui/launchpad"
+		// Location: "gen/{{genFolderName}}/ui/launchpad"
 		{
 			location: "/template-application-ui-angular/ui/launchpad/dialog-window.extensionpoint.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/dialog-window.extensionpoint",
+			rename: "gen/{{genFolderName}}/ui/launchpad/dialog-window.extensionpoint",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/menu-help.extension.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/menu-help.extension",
+			rename: "gen/{{genFolderName}}/ui/launchpad/menu-help.extension",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/menu-help.js",
 			action: "copy",
-			rename: "gen/ui/launchpad/menu-help.js"
+			rename: "gen/{{genFolderName}}/ui/launchpad/menu-help.js"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/menu.extensionpoint.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/menu.extensionpoint",
+			rename: "gen/{{genFolderName}}/ui/launchpad/menu.extensionpoint",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/perspective.extension.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/launchpad/perspective.extension",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/perspective.extensionpoint.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/perspective.extensionpoint",
+			rename: "gen/{{genFolderName}}/ui/launchpad/perspective.extensionpoint",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/perspective.js",
 			action: "generate",
-			rename: "gen/ui/launchpad/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/launchpad/perspective.js",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/tile.extensionpoint.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/tile.extensionpoint",
+			rename: "gen/{{genFolderName}}/ui/launchpad/tile.extensionpoint",
 			engine: "velocity"
 		},
 		{
 			location: "/template-application-ui-angular/ui/launchpad/view.extensionpoint.template",
 			action: "generate",
-			rename: "gen/ui/launchpad/view.extensionpoint",
+			rename: "gen/{{genFolderName}}/ui/launchpad/view.extensionpoint",
 			engine: "velocity"
 		}];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/list.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/list.js
@@ -5,132 +5,132 @@
  */
 exports.getSources = function (parameters) {
 	return [
-		// Location: "gen/ui/perspective"
+		// Location: "gen/{{genFolderName}}/ui/perspective"
 		{
 			location: "/template-application-ui-angular/ui/perspective/index.html",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
 			collection: "uiListModels"
 		},
-		// Location: "gen/ui/perspective/list"
+		// Location: "gen/{{genFolderName}}/ui/perspective/list"
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-window/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-window/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-window/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-window/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/dialog-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/tile.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/tile-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/tile.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
 			collection: "uiListModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/list/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
 			collection: "uiListModels"
 		}];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/manage.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/manage.js
@@ -5,132 +5,132 @@
  */
 exports.getSources = function (parameters) {
     return [
-        // Location: "gen/ui/perspective"
+        // Location: "gen/{{genFolderName}}/ui/perspective"
         {
             location: "/template-application-ui-angular/ui/perspective/index.html",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/perspective.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
             collection: "uiManageModels"
         },
-        // Location: "gen/ui/perspective/manage"
+        // Location: "gen/{{genFolderName}}/ui/perspective/manage"
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-window/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-window/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-window/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-window/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-filter/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-filter/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/tile.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/tile-portal.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/tile.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
             collection: "uiManageModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/manage/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
             collection: "uiManageModels"
         }];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsList.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsList.js
@@ -12,131 +12,131 @@ exports.getSources = function (parameters) {
 
 function getMaster(parameters) {
     return [
-        // Location: "gen/ui/perspective"
+        // Location: "gen/{{genFolderName}}/ui/perspective"
         {
             location: "/template-application-ui-angular/ui/perspective/index.html",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/perspective.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/tile.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/tile-portal.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/tile.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/main-details/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/controller.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/main-details/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/index.html",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/main-details/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/main-details/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/dialog-filter/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/dialog-filter/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
             collection: "uiListMasterModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
             collection: "uiListMasterModels"
         }
     ];
@@ -148,83 +148,83 @@ function getDetails(parameters) {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/controller.js",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/index.html",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/view.extension.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/controller.js",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/index.html",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/controller.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/controller.js",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/index.html",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/index.html",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.extension",
             action: "generate",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.extension",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.extension",
             collection: "uiListDetailsModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
+            rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
             collection: "uiListDetailsModels"
         }
     ];

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsManage.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/masterDetailsManage.js
@@ -12,131 +12,131 @@ exports.getSources = function (parameters) {
 
 function getMaster(parameters) {
 	return [
-		// Location: "gen/ui/perspective"
+		// Location: "gen/{{genFolderName}}/ui/perspective"
 		{
 			location: "/template-application-ui-angular/ui/perspective/index.html",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/tile.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/tile-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/tile.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/main-details/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/controller.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/main-details/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/index.html",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/main-details/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/main-details/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/main-details/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/controller.js",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/index.html",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.extension",
 			collection: "uiManageMasterModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
 			collection: "uiManageMasterModels"
 		}
 	];
@@ -148,83 +148,83 @@ function getDetails(parameters) {
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/controller.js",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/index.html",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.extension",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/view.js",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/controller.js",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/index.html",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.extension",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-window/view.js",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/controller.js",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/index.html",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.extension",
 			collection: "uiManageDetailsModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
 			collection: "uiManageDetailsModels"
 		}
 	];

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/perspective.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/perspective.js
@@ -7,25 +7,25 @@ exports.getSources = function (parameters) {
 	return [{
 		location: "/template-application-ui-angular/ui/perspectives/index.html.template",
 		action: "generate",
-		rename: "gen/ui/{{perspectiveName}}/index.html",
+		rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
 		engine: "velocity",
 		collection: "uiPerspectives"
 	}, {
 		location: "/template-application-ui-angular/ui/perspectives/extensions/perspective/perspective.extension.template",
 		action: "generate",
-		rename: "gen/ui/{{perspectiveName}}/extensions/perspective/perspective.extension",
+		rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/extensions/perspective/perspective.extension",
 		engine: "velocity",
 		collection: "uiPerspectives"
 	}, {
 		location: "/template-application-ui-angular/ui/perspectives/extensions/perspective/perspective.js.template",
 		action: "generate",
-		rename: "gen/ui/{{perspectiveName}}/extensions/perspective/perspective.js",
+		rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/extensions/perspective/perspective.js",
 		engine: "velocity",
 		collection: "uiPerspectives"
 	}, {
 		location: "/template-application-ui-angular/ui/perspectives/extensions/view.extensionpoint.template",
 		action: "generate",
-		rename: "gen/ui/{{perspectiveName}}/extensions/view.extensionpoint",
+		rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/extensions/view.extensionpoint",
 		engine: "velocity",
 		collection: "uiPerspectives"
 	}];

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/report.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/report.js
@@ -5,158 +5,158 @@
  */
 exports.getSources = function (parameters) {
 	return [
-		// Location: "gen/ui/perspective"
+		// Location: "gen/{{genFolderName}}/ui/perspective"
 		{
 			location: "/template-application-ui-angular/ui/perspective/index-report.html",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/index.html",
+			rename: "gen/{{genFolderName}}/ui/Reports/index.html",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-report.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/perspective.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-portal-report.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/perspective-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/perspective-portal.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-report.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/perspective.js",
 			collection: "generateReportModels"
 		},
-		// Location: "gen/ui/perspective/list"
+		// Location: "gen/{{genFolderName}}/ui/perspective/list"
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-window/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-window/controller.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/controller.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-window/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-window/index.html",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/index.html",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-window/view.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/dialog-window/view.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-window/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-window/view.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/controller.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/index.html",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/dialog-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/controller.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/index.html",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/tile.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/tile.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/tile-portal.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/tile-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile-portal.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/tile.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/tile.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/view.extension",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/view.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/view.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-print/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-print/controller.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/controller.js",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-print/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/Reports/{{name}}/dialog-print/index.html",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/index.html",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-print/print.extension.template",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/dialog-print/print.extension",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.extension",
 			collection: "generateReportModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report/dialog-print/print.js.template",
 			action: "generate",
-			rename: "gen/ui/Reports/{{name}}/dialog-print/print.js",
+			rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.js",
 			collection: "generateReportModels"
 		}];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportChart.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportChart.js
@@ -5,105 +5,105 @@
  */
 exports.getSources = function (parameters) {
 	return [
-		// Location: "gen/ui/perspective"
+		// Location: "gen/{{genFolderName}}/ui/perspective"
 		{
 			location: "/template-application-ui-angular/ui/perspective/index.html",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
 			collection: "uiReportChartModels"
 		},
-		// Location: "gen/ui/perspective/list"
+		// Location: "gen/{{genFolderName}}/ui/perspective/list"
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/controller.js",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/index.html",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/tile.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/tile-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/tile.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
 			collection: "uiReportChartModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-chart/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
 			collection: "uiReportChartModels"
 		}];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportFile.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportFile.js
@@ -16,31 +16,31 @@ exports.getSources = function (parameters) {
 
 function getReportPerspectiveSources() {
     return [
-        // Location: "gen/ui/perspective"
+        // Location: "gen/{{genFolderName}}/ui/perspective"
         {
             location: "/template-application-ui-angular/ui/perspective/index-report-file.html",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/index.html",
+            rename: "gen/{{genFolderName}}/ui/Reports/index.html",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective-report-file.extension",
             action: "generate",
-            rename: "gen/ui/Reports/perspective.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/perspective.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective-portal-report.extension",
             action: "generate",
-            rename: "gen/ui/Reports/perspective-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/perspective-portal.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/perspective-report-file.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/perspective.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/perspective.js",
             collection: "generateReportModels"
         },
     ];
@@ -51,26 +51,26 @@ function getTableReportBackendSources() {
         {
             location: "/template-application-dao/dao/reportFileEntity.ts.template",
             action: "generate",
-            rename: "gen/dao/{{perspectiveName}}/{{name}}Repository.ts",
+            rename: "gen/{{genFolderName}}/dao/{{perspectiveName}}/{{name}}Repository.ts",
             engine: "velocity",
             collection: "reportModels"
         },
         {
             location: "/template-application-rest/api/utils/HttpUtils.ts.template",
             action: "copy",
-            rename: "gen/api/utils/HttpUtils.ts",
+            rename: "gen/{{genFolderName}}/api/utils/HttpUtils.ts",
         }, {
             location: "/template-application-rest/api/utils/ForbiddenError.ts.template",
             action: "copy",
-            rename: "gen/api/utils/ForbiddenError.ts",
+            rename: "gen/{{genFolderName}}/api/utils/ForbiddenError.ts",
         }, {
             location: "/template-application-rest/api/utils/ValidationError.ts.template",
             action: "copy",
-            rename: "gen/api/utils/ValidationError.ts",
+            rename: "gen/{{genFolderName}}/api/utils/ValidationError.ts",
         }, {
             location: "/template-application-rest/api/reportFileEntity.ts.template",
             action: "generate",
-            rename: "gen/api/{{perspectiveName}}/{{name}}Service.ts",
+            rename: "gen/{{genFolderName}}/api/{{perspectiveName}}/{{name}}Service.ts",
             engine: "velocity",
             collection: "reportModels"
         }, {
@@ -89,131 +89,131 @@ function getTableReportBackendSources() {
 
 function getTableReportUISource() {
     return [
-        // Location: "gen/ui/perspective/list"
+        // Location: "gen/{{genFolderName}}/ui/perspective/list"
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-window/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-window/controller.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/controller.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-window/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-window/index.html",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/index.html",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.extension",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/dialog-window/view.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-window/view.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-filter/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-filter/controller.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/controller.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-filter/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-filter/index.html",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/index.html",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.extension",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/dialog-filter/view.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-filter/view.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/controller.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/controller.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/index.html",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/index.html",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/tile.extension",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/tile.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/tile-portal.extension",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/tile-portal.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile-portal.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/tile.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/tile.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/view.extension",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/view.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/view.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/view.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/view.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/view.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-print/controller.js.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-print/controller.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/controller.js",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-print/index.html.template",
             action: "generate",
             engine: "velocity",
-            rename: "gen/ui/Reports/{{name}}/dialog-print/index.html",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/index.html",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.extension.template",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/dialog-print/print.extension",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.extension",
             collection: "generateReportModels"
         },
         {
             location: "/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.js.template",
             action: "generate",
-            rename: "gen/ui/Reports/{{name}}/dialog-print/print.js",
+            rename: "gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.js",
             collection: "generateReportModels"
         }];
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportTable.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/template/ui/reportTable.js
@@ -5,132 +5,132 @@
  */
 exports.getSources = function (parameters) {
 	return [
-		// Location: "gen/ui/perspective"
+		// Location: "gen/{{genFolderName}}/ui/perspective"
 		{
 			location: "/template-application-ui-angular/ui/perspective/index.html",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/index.html",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/perspective-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective-portal.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/perspective.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/perspective.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js",
 			collection: "uiReportTableModels"
 		},
-		// Location: "gen/ui/perspective/list"
+		// Location: "gen/{{genFolderName}}/ui/perspective/list"
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/controller.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/index.html",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/controller.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/index.html",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/controller.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/controller.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/controller.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/index.html.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/index.html",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/index.html",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/tile.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/tile-portal.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile-portal.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/tile.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/tile.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/view.extension",
 			action: "generate",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.extension",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.extension",
 			collection: "uiReportTableModels"
 		},
 		{
 			location: "/template-application-ui-angular/ui/perspective/report-table/view.js.template",
 			action: "generate",
 			engine: "velocity",
-			rename: "gen/ui/{{perspectiveName}}/{{name}}/view.js",
+			rename: "gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js",
 			collection: "uiReportTableModels"
 		}];
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/controller.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/controller.js
@@ -8,7 +8,7 @@ angular.module('page', ['ideUI', 'ideView', 'entityApi'])
 		messageHubProvider.eventIdPrefix = '{{projectName}}.launchpad.Home';
 	}])
 	.config(['entityApiProvider', function (entityApiProvider) {
-		entityApiProvider.baseUrl = '/services/js/{{projectName}}/gen/ui/launchpad/Home/tiles.js';
+		entityApiProvider.baseUrl = '/services/js/{{projectName}}/gen/{{genFolderName}}/ui/launchpad/Home/tiles.js';
 	}])
 	.controller('PageController', ['$scope', 'messageHub', 'entityApi', function ($scope, messageHub, entityApi) {
 		$scope.state = {

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/launchpad/Home/view.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/launchpad/Home/view.js",
     "extensionPoint": "${projectName}-view",
     "description": "${projectName} - Application View"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/Home/view.js
@@ -8,7 +8,7 @@ const viewData = {
     label: "Home Launchpad",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/launchpad/Home/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/launchpad/Home/index.html",
     isLaunchpad: true,
 };
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/menu-help.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/menu-help.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/launchpad/menu-help.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/launchpad/menu-help.js",
     "extensionPoint": "${projectName}-menu",
     "description": "${projectName} - Application Menu"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/perspective.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/perspective.extension.template
@@ -1,1 +1,1 @@
-{"module":"${projectName}/gen/ui/launchpad/perspective.js","extensionPoint":"${projectName}","description":"${projectName} - Application Perspective"}
+{"module":"${projectName}/gen/${genFolderName}/ui/launchpad/perspective.js","extensionPoint":"${projectName}","description":"${projectName} - Application Perspective"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/perspective.js
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/launchpad/perspective.js
@@ -6,7 +6,7 @@
 const perspectiveData = {
 	id: 'home',
 	name: 'Home',
-	link: '/services/web/${projectName}/gen/index.html',
+	link: '/services/web/${projectName}/gen/${genFolderName}/index.html',
 	icon: '/services/web/resources/unicons/estate.svg',
 	order: 1,
 };

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function (${dollar}scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/controller.js.template
@@ -146,7 +146,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-window/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-window/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-window/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/list/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function (${dollar}scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/controller.js.template
@@ -213,7 +213,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if ($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope', 'messageHub', 'ViewParameters', 'entityApi', function ($scope, messageHub, ViewParameters, entityApi) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-window/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/manage/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function ($scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/controller.js.template
@@ -146,7 +146,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function ($scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/controller.js.template
@@ -163,7 +163,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
     "extensionPoint": "${projectName}-dialog-window",
     "description": "${projectName} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/index.html",
     perspectiveName: "#if($hasReferencedProjection)${referencedProjectionPerspectiveName}#else${perspectiveName}#end",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
     "extensionPoint": "${projectName}-view",
     "description": "${projectName} - Application View - Details"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/detail/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "bottom",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/index.html",
     perspectiveName: "#if($hasReferencedProjection)${referencedProjectionPerspectiveName}#else${perspectiveName}#end",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/main-details/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/main-details/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/main-details/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Main Details"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Main Details"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/main-details/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/main-details/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/main-details/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/main-details/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-list/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "left",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/controller.js.template
@@ -218,7 +218,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if ($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function ($scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function ($scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 		//-----------------Custom Actions-------------------//

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/controller.js.template
@@ -234,7 +234,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if ($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{masterEntity}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope', 'messageHub', 'ViewParameters', 'entityApi', function ($scope, messageHub, ViewParameters, entityApi) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/view.js",
     "extensionPoint": "#if($hasReferencedProjection)${referencedProjectionProjectName}#else${projectName}#end-dialog-window",
     "description": "${projectName} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/dialog-window/index.html",
     perspectiveName: "#if($hasReferencedProjection)${referencedProjectionPerspectiveName}#else${perspectiveName}#end",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.extension.template
@@ -1,5 +1,5 @@
 {
-    "module": "${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
+    "module": "${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/view.js",
     "extensionPoint": "#if($hasReferencedProjection)${referencedProjectionProjectName}#else${projectName}#end-view",
     "description": "${projectName} - Application View - Details"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/detail/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "bottom",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${masterEntity}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${masterEntity}/${name}/index.html",
     perspectiveName: "#if($hasReferencedProjection)${referencedProjectionPerspectiveName}#else${perspectiveName}#end",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-filter",
     label: "${name} Filter",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['$scope', 'Extensions', 'messageHub', 'entityApi', function ($scope, Extensions, messageHub, entityApi) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/main-details/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Main Details"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/main-details/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View - Main Details"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/main-details/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/main-details/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/main-details/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/master-manage/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "left",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-portal-report.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-portal-report.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/perspective.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/perspective.js",
     "extensionPoint": "portal",
     "description": "{{projectName}} - Perspective - Reports"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/perspective.js","extensionPoint":"portal","description":"{{projectName}} - Perspective - {{perspectiveName}}"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js","extensionPoint":"portal","description":"{{projectName}} - Perspective - {{perspectiveName}}"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report-file.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report-file.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/perspective.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/perspective.js",
     "extensionPoint": "{{extensionPoint}}",
     "description": "{{extensionPoint}} - Perspective - Reports"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report-file.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report-file.js.template
@@ -6,7 +6,7 @@
 const perspectiveData = {
 	id: '${projectName}-${fileName}',
 	name: 'Reports',
-	link: '/services/web/${projectName}/gen/ui/Reports/index.html',
+	link: '/services/web/${projectName}/gen/${genFolderName}/ui/Reports/index.html',
 	order: 999,
 	icon: '/services/web/resources/unicons/dashboard.svg',
 #if($perspectiveRole)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/perspective.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/perspective.js",
     "extensionPoint": "{{projectName}}",
     "description": "{{projectName}} - Perspective - Reports"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective-report.js.template
@@ -6,7 +6,7 @@
 const perspectiveData = {
 	id: 'Reports',
 	name: 'Reports',
-	link: '/services/web/${projectName}/gen/ui/Reports/index.html',
+	link: '/services/web/${projectName}/gen/${genFolderName}/ui/Reports/index.html',
 	order: 999,
 	icon: '/services/web/resources/unicons/dashboard.svg',
 #if($perspectiveRole)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/perspective.js","extensionPoint":"{{projectName}}","description":"{{projectName}} - Perspective - {{perspectiveName}}"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/perspective.js","extensionPoint":"{{projectName}}","description":"{{projectName}} - Perspective - {{perspectiveName}}"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/perspective.js.template
@@ -6,7 +6,7 @@
 const perspectiveData = {
 	id: '${perspectiveName}',
 	name: '${perspectiveLabel}',
-	link: '/services/web/${projectName}/gen/ui/${perspectiveName}/index.html',
+	link: '/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html',
 	order: ${perspectiveOrder},
 	icon: '${perspectiveIcon}',
 #if($perspectiveRole)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/controller.js.template
@@ -15,7 +15,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', function (${dollar}scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/controller.js.template
@@ -133,7 +133,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},
@@ -146,7 +146,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $filter.properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window Filter"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window Filter"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/dialog-window-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details-filter",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-window-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-window-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-chart/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.Reports.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope', 'messageHub', 'entityApi', 'Extensions', function (${dollar}scope, messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-Report-filter",
     label: "${name} Rerport Filter",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/dialog-filter/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
         messageHubProvider.eventIdPrefix = '${projectName}.Reports.${name}';
     }])
     .config(["entityApiProvider", function (entityApiProvider) {
-        entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+        entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
     }])
     .controller('PageController', ['$scope', 'messageHub', 'entityApi', 'ViewParameters', function ($scope, messageHub, entityApi, ViewParameters) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.extension.template
@@ -1,5 +1,5 @@
 {
     "extensionPoint": "{{projectName}}-custom-action",
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-print/print.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.js",
     "description": "Print {{name}} Report"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-print/print.js.template
@@ -1,7 +1,7 @@
 const viewData = {
     id: '{{projectName}}-Reports-{{name}}-print',
     label: 'Print',
-    link: '/services/web/{{projectName}}/gen/ui/Reports/{{name}}/dialog-print/index.html',
+    link: '/services/web/{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/index.html',
     perspective: 'Reports',
     view: '{{name}}',
     type: 'page',

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-window/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-Report-details",
     label: "${name} Report",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/dialog-window/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile-portal.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/tile.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
     "extensionPoint": "portal-tile",
     "description": "{{projectName}} - Application Tile"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/tile.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
     "extensionPoint": "{{projectName}}-tile",
     "description": "{{projectName}} - Application Tile"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/tile.js.template
@@ -10,7 +10,7 @@ exports.getTile = function () {
         caption: "Report for entity ${name}",
         tooltip: "${tooltip}",
         // icon: "file-o",
-        location: "/services/web/${projectName}/gen/ui/Reports/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/index.html",
         order: "${menuIndex}",
         groupOrder: "999",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/view.js",
     "extensionPoint": "{{projectName}}-view",
     "description": "{{projectName}} - Application View"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name} Report",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/{{genFolderName}}/ui/Reports/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-file/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name} Report",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/index.html",
+    link: "/services/web/${projectName}/gen/{{genFolderName}}/ui/Reports/${name}/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/controller.js.template
@@ -122,7 +122,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},
@@ -135,7 +135,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},
@@ -148,7 +148,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $filter.properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/controller.js.template
@@ -15,7 +15,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.${perspectiveName}.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', function (${dollar}scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window Filter"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window-filter/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window Filter"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details-filter",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-window-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-window-filter/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/dialog-window/view.js","extensionPoint":"{{projectName}}-dialog-window","description":"{{projectName}} - Application Dialog Window"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-details",
     label: "${name}",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/dialog-window/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile-portal.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"portal-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/tile.js","extensionPoint":"{{projectName}}-tile","description":"{{projectName}} - Application Tile"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/${perspectiveName}/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/index.html",
         order: "${menuIndex}",
         groupOrder: "${perspectiveOrder}",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/view.extension
@@ -1,1 +1,1 @@
-{"module":"{{projectName}}/gen/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}
+{"module":"{{projectName}}/gen/{{genFolderName}}/ui/{{perspectiveName}}/{{name}}/view.js","extensionPoint":"{{projectName}}-view","description":"{{projectName}} - Application View"}

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report-table/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name}",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/${perspectiveName}/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/${perspectiveName}/${name}/index.html",
     perspectiveName: "${perspectiveName}",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/controller.js.template
@@ -155,7 +155,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 #foreach ($property in $properties)
 #if($property.widgetType == "DROPDOWN")
 
-		${dollar}http.get(${property.widgetDropdownUrl}).then(function (response) {
+		${dollar}http.get("${property.widgetDropdownUrl}").then(function (response) {
 			${dollar}scope.options${property.name} = response.data.map(e => {
 				return {
 					value: e.${property.widgetDropDownKey},

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
 		messageHubProvider.eventIdPrefix = '${projectName}.Reports.${name}';
 	}])
 	.config(["entityApiProvider", function (entityApiProvider) {
-		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+		entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
 	}])
 	.controller('PageController', ['${dollar}scope',#if($hasDropdowns) '${dollar}http',#end 'messageHub', 'entityApi', 'Extensions', function (${dollar}scope,#if($hasDropdowns) ${dollar}http,#end messageHub, entityApi, Extensions) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-filter/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-filter/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-filter/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-filter/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-filter/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-filter/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-Report-filter",
     label: "${name} Rerport Filter",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/dialog-filter/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/dialog-filter/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/controller.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/controller.js.template
@@ -4,7 +4,7 @@ angular.module('page', ["ideUI", "ideView", "entityApi"])
         messageHubProvider.eventIdPrefix = '${projectName}.Reports.${name}';
     }])
     .config(["entityApiProvider", function (entityApiProvider) {
-        entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/api/${perspectiveName}/${name}Service.ts";
+        entityApiProvider.baseUrl = "/services/ts/${projectName}/gen/${genFolderName}/api/${perspectiveName}/${name}Service.ts";
     }])
     .controller('PageController', ['$scope', 'messageHub', 'entityApi', 'ViewParameters', function ($scope, messageHub, entityApi, ViewParameters) {
 

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/print.extension.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/print.extension.template
@@ -1,5 +1,5 @@
 {
     "extensionPoint": "{{projectName}}-custom-action",
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-print/print.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/print.js",
     "description": "Print {{name}} Report"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/print.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-print/print.js.template
@@ -1,7 +1,7 @@
 const viewData = {
     id: '{{projectName}}-Reports-{{name}}-print',
     label: 'Print',
-    link: '/services/web/{{projectName}}/gen/ui/Reports/{{name}}/dialog-print/index.html',
+    link: '/services/web/{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-print/index.html',
     perspective: 'Reports',
     view: '{{name}}',
     type: 'page',

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-window/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-window/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/dialog-window/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/dialog-window/view.js",
     "extensionPoint": "{{projectName}}-dialog-window",
     "description": "{{projectName}} - Application Dialog Window"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-window/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/dialog-window/view.js.template
@@ -6,7 +6,7 @@
 const viewData = {
     id: "${name}-Report-details",
     label: "${name} Report",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/dialog-window/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/dialog-window/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile-portal.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile-portal.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/tile.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
     "extensionPoint": "portal-tile",
     "description": "{{projectName}} - Application Tile"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/tile.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/tile.js",
     "extensionPoint": "{{projectName}}-tile",
     "description": "{{projectName}} - Application Tile"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/tile.js.template
@@ -12,7 +12,7 @@ exports.getTile = function () {
         type: "${type}",
         report: "${generateReport}",
         icon: "${icon}",
-        location: "/services/web/${projectName}/gen/ui/Reports/index.html",
+        location: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/index.html",
         order: "${menuIndex}",
         groupOrder: "999",
 #if($perspectiveRole || $roleRead)

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/view.extension
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/view.extension
@@ -1,5 +1,5 @@
 {
-    "module": "{{projectName}}/gen/ui/Reports/{{name}}/view.js",
+    "module": "{{projectName}}/gen/{{genFolderName}}/ui/Reports/{{name}}/view.js",
     "extensionPoint": "{{projectName}}-view",
     "description": "{{projectName}} - Application View"
 }

--- a/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/view.js.template
+++ b/components/template/template-application-ui-angular/src/main/resources/META-INF/dirigible/template-application-ui-angular/ui/perspective/report/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
     label: "${name} Report",
     factory: "frame",
     region: "center",
-    link: "/services/web/${projectName}/gen/ui/Reports/${name}/index.html",
+    link: "/services/web/${projectName}/gen/${genFolderName}/ui/Reports/${name}/index.html",
     perspectiveName: "Reports",
 #if($perspectiveRole || $roleRead)
     roles: [

--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/template/template.js
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/template/template.js
@@ -23,19 +23,19 @@ exports.getTemplate = function (parameters) {
             {
                 location: "/template-form-builder-angularjs/ui/controller.js.template",
                 action: "generate",
-                rename: "gen/forms/{{fileName}}/controller.js",
+                rename: "gen/{{genFolderName}}/forms/{{fileName}}/controller.js",
                 engine: "velocity",
             },
             {
                 location: "/template-form-builder-angularjs/ui/index.html.template",
                 action: "generate",
-                rename: "gen/forms/{{fileName}}/index.html",
+                rename: "gen/{{genFolderName}}/forms/{{fileName}}/index.html",
                 engine: "velocity",
             },
             {
                 location: "/template-form-builder-angularjs/ui/view.js.template",
                 action: "generate",
-                rename: "gen/forms/{{fileName}}/view.js",
+                rename: "gen/{{genFolderName}}/forms/{{fileName}}/view.js",
                 engine: "velocity",
             },
         ],

--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/view.js.template
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/view.js.template
@@ -8,7 +8,7 @@ const viewData = {
 	label: "$projectName Form",
 	factory: "frame",
 	region: "bottom",
-	link: "$projectName/gen/forms/$fileName/index.html",
+	link: "$projectName/gen/$genFolderName/forms/$fileName/index.html",
 };
 if (typeof exports !== 'undefined') {
 	exports.getView = function () {

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/ui/TestProject.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/ui/TestProject.java
@@ -9,8 +9,13 @@
  */
 package org.eclipse.dirigible.integration.tests.ui;
 
-import ch.qos.logback.classic.Level;
-import io.restassured.http.ContentType;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.awaitility.Awaitility;
 import org.eclipse.dirigible.commons.config.DirigibleConfig;
@@ -29,21 +34,14 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.TimeUnit;
-
-import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
+import ch.qos.logback.classic.Level;
+import io.restassured.http.ContentType;
 
 @Lazy
 @Component
 public class TestProject {
-    public static final String UI_HOME_PATH = "/services/web/dirigible-test-project/gen/index.html";
-    public static final String BOOKS_SERVICE_PATH = "/services/ts/dirigible-test-project/gen/api/Books/BookService.ts";
+    public static final String UI_HOME_PATH = "/services/web/dirigible-test-project/gen/edm/index.html";
+    public static final String BOOKS_SERVICE_PATH = "/services/ts/dirigible-test-project/gen/edm/api/Books/BookService.ts";
     public static final String EDM_FILE_NAME = "edm.edm";
     public static final String READERS_ODATA_ENTITY_PATH = "/odata/v2/Readers";
     public static final String READERS_VIEW_SERVICE_PATH = "/services/ts/dirigible-test-project/views/ReaderViewService.ts";

--- a/tests/tests-integrations/src/test/resources/dirigible-test-project/jobs/test-job-handler.ts
+++ b/tests/tests-integrations/src/test/resources/dirigible-test-project/jobs/test-job-handler.ts
@@ -1,4 +1,4 @@
-import { BookRepository } from "../gen/dao/Books/BookRepository";
+import { BookRepository } from "../gen/edm/dao/Books/BookRepository";
 import { logging } from "sdk/log";
 
 const logger = logging.getLogger("test-job-handler.ts");

--- a/tests/tests-integrations/src/test/resources/dirigible-test-project/listeners/entity/book-entity-events-handler.ts
+++ b/tests/tests-integrations/src/test/resources/dirigible-test-project/listeners/entity/book-entity-events-handler.ts
@@ -1,4 +1,4 @@
-import { BookRepository } from "../../gen/dao/Books/BookRepository";
+import { BookRepository } from "../../gen/edm/dao/Books/BookRepository";
 import { logging } from "sdk/log";
 
 const logger = logging.getLogger("book-entity-events-handler.ts");


### PR DESCRIPTION
## Overview
Add support for multiple definition files _(e.g.`*.edm`, `*.report`, `*.form`, etc.)_ in the same project.

Demo:

https://github.com/eclipse/dirigible/assets/4092083/88b72f99-444e-44cd-a3a4-687dcc68bf0a

Demo project:

- [demo-20240620041910.zip](https://github.com/user-attachments/files/15914621/demo-20240620041910.zip)


## Note
For applications generated with older versions of the Eclipse Dirigible platform, the `gen` folder has to be manually deleted and the definition files _(e.g.`*.edm`, `*.report`, `*.form`, etc.)_ have to be **regenerated**.

Fixes: https://github.com/eclipse/dirigible/issues/4037