### PR TITLE
[UI] #4134 - Set default theme config

### DIFF
--- a/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/theming.js
+++ b/components/resources/resources-core/src/main/resources/META-INF/dirigible/resources-core/ui/theming.js
@@ -82,7 +82,7 @@ angular.module('ideTheming', ['ngResource', 'ideMessageHub'])
             }
         }];
     })
-    .factory('Theme', function () {
+    .factory('Theme', ['theming', function (_theming) { // Must be injected to set defaults
         let theme = JSON.parse(localStorage.getItem('DIRIGIBLE.theme') || '{}');
         return {
             reload: function () {
@@ -95,7 +95,7 @@ angular.module('ideTheming', ['ngResource', 'ideMessageHub'])
                 return theme.type || 'light';
             }
         }
-    }).directive('theme', ['Theme', 'messageHub', '$document', function (Theme, messageHub, $document) {
+    }]).directive('theme', ['Theme', 'messageHub', '$document', function (Theme, messageHub, $document) {
         return {
             restrict: 'E',
             replace: true,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Makes a small change, where it injects the `theming` provider in the `Theme` factory, so that the default theme config can be set even if Dirigible itself has never been loaded before.

### What issues does this PR fix or reference?

#4134 
