### PR TITLE
Do not expose TS APIs publicly + allow having public TS APIs

### DIFF
--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/config/SecurityFilterConfig.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/config/SecurityFilterConfig.java
@@ -34,7 +34,7 @@ public class SecurityFilterConfig {
         filterRegistrationBean.addUrlPatterns("/services/js/*", "/services/public/*", "/services/web/*", "/services/wiki/*",
                 "/services/command/*",
 
-                "/public/js/*", "/public/public/*", "/public/web/*", "/public/wiki/*", "/public/command/*",
+                "/public/js/*", "/public/ts/*", "/public/public/*", "/public/web/*", "/public/wiki/*", "/public/command/*",
 
                 "/odata/v2/*");
 


### PR DESCRIPTION
To expose TS REST API publicly add access file with role `PUBLIC`.

Example:
API `/snowflake-project/api/snowflake-api.ts`:
![image](https://github.com/user-attachments/assets/92d763df-7415-4ef5-9c0e-16c3b1cda398)
Access `/ts/snowflake-project/api/snowflake-api.ts/test`:
![image](https://github.com/user-attachments/assets/d433883d-eaca-498d-b64f-5f92c3abc2e2)
Used path `http://localhost:8080/public/ts/snowflake-project/api/snowflake-api.ts/test`.
It does **NOT** require authentication.
![image](https://github.com/user-attachments/assets/60040b7d-80ea-4840-a7e2-e6da489ea2c6)
