### PR TITLE
rename CamelPlatformHttpTest to make it executable

### DIFF
--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/services/integrations/CamelPlatformHttpIT.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
-class CamelPlatformHttpTest extends IntegrationTest {
+class CamelPlatformHttpIT extends IntegrationTest {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
Currently, test `CamelPlatformHttpTest`wasn't included in the integration tests execution because it had wrong sufix `Test`.
Rename it ti `IT` in order to make it executable.