### PR TITLE
Add Spring Boot Admin (SBA) to Dirigible

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -14,6 +14,12 @@
 	<artifactId>dirigible-application</artifactId>
 	<packaging>jar</packaging>
 
+
+	<properties>
+		<license.header.location>../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../</parent.pom.folder>
+	</properties>
+
 	<dependencies>
 		<!-- Platform -->
 		<dependency>
@@ -206,6 +212,17 @@
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>de.codecentric</groupId>
+			<artifactId>spring-boot-admin-starter-server</artifactId>
+			<version>${spring.admin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>de.codecentric</groupId>
+			<artifactId>spring-boot-admin-starter-client</artifactId>
+			<version>${spring.admin.version}</version>
+		</dependency>
 	</dependencies>
 
 	<dependencyManagement>
@@ -262,10 +279,4 @@
 			</resource>
 		</resources>
 	</build>
-
-	<properties>
-		<license.header.location>../../licensing-header.txt</license.header.location>
-		<parent.pom.folder>../../</parent.pom.folder>
-	</properties>
-
 </project>

--- a/build/application/src/main/java/org/eclipse/dirigible/DirigibleApplication.java
+++ b/build/application/src/main/java/org/eclipse/dirigible/DirigibleApplication.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible;
 
+import de.codecentric.boot.admin.server.config.EnableAdminServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
@@ -20,6 +21,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
+@EnableAdminServer
 @SpringBootApplication(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
         HibernateJpaAutoConfiguration.class, JdbcTemplateAutoConfiguration.class})
 @EnableScheduling

--- a/build/application/src/main/resources/application-spring-boot-admin-client.properties
+++ b/build/application/src/main/resources/application-spring-boot-admin-client.properties
@@ -7,9 +7,11 @@ EMBEDDED_DIRIGIBLE_SPRING_ADMIN_SERVER_URL=http://localhost:${server.port}/${spr
 spring.boot.admin.client.url=${DIRIGIBLE_SPRING_ADMIN_SERVER_URL:${EMBEDDED_DIRIGIBLE_SPRING_ADMIN_SERVER_URL}}
 
 # credentials which are used by the client to register in the Spring Boot Admin Server
+# in other words, basic credentials for the Spring Boot Admin Server path (/spring-admin/*)
 spring.boot.admin.client.username=${DIRIGIBLE_SPRING_ADMIN_SERVER_USERNAME:admin}
 spring.boot.admin.client.password=${DIRIGIBLE_SPRING_ADMIN_SERVER_PASSWORD:admin}
 
 # credentials for the client which are passed to the Spring Boot Admin Server so that it can call the client
+# in other words, basic credentials for the actuator path (/actuator/*)
 spring.boot.admin.client.instance.metadata.user.name=${DIRIGIBLE_SPRING_ADMIN_CLIENT_USERNAME:admin}
 spring.boot.admin.client.instance.metadata.user.password=${DIRIGIBLE_SPRING_ADMIN_CLIENT_PASSWORD:admin}

--- a/build/application/src/main/resources/application-spring-boot-admin-client.properties
+++ b/build/application/src/main/resources/application-spring-boot-admin-client.properties
@@ -1,0 +1,15 @@
+# spring.boot.admin.client.* documentation
+# https://github.com/codecentric/spring-boot-admin/blob/master/spring-boot-admin-docs/src/site/asciidoc/client.adoc#spring-boot-admin-client
+
+spring.boot.admin.client.enabled=true
+
+EMBEDDED_DIRIGIBLE_SPRING_ADMIN_SERVER_URL=http://localhost:${server.port}/${spring.boot.admin.context-path}
+spring.boot.admin.client.url=${DIRIGIBLE_SPRING_ADMIN_SERVER_URL:${EMBEDDED_DIRIGIBLE_SPRING_ADMIN_SERVER_URL}}
+
+# credentials which are used by the client to register in the Spring Boot Admin Server
+spring.boot.admin.client.username=${DIRIGIBLE_SPRING_ADMIN_SERVER_USERNAME:admin}
+spring.boot.admin.client.password=${DIRIGIBLE_SPRING_ADMIN_SERVER_PASSWORD:admin}
+
+# credentials for the client which are passed to the Spring Boot Admin Server so that it can call the client
+spring.boot.admin.client.instance.metadata.user.name=${DIRIGIBLE_SPRING_ADMIN_CLIENT_USERNAME:admin}
+spring.boot.admin.client.instance.metadata.user.password=${DIRIGIBLE_SPRING_ADMIN_CLIENT_PASSWORD:admin}

--- a/build/application/src/main/resources/application-spring-boot-admin-server.properties
+++ b/build/application/src/main/resources/application-spring-boot-admin-server.properties
@@ -1,0 +1,11 @@
+# spring.boot.admin.server.* documentation
+# https://github.com/codecentric/spring-boot-admin/blob/master/spring-boot-admin-docs/src/site/asciidoc/server.adoc#configuration-options
+
+spring.boot.admin.server.enabled=true
+spring.boot.admin.context-path=spring-admin
+spring.boot.admin.ui.title=${spring.application.name} Admin
+spring.boot.admin.ui.brand=<img src="/services/web/resources/images/dirigible.svg"><span>Eclipse Dirigible Admin</span>
+
+# default credentials when calling the registered clients
+# spring.boot.admin.instance-auth.default-user-name=<username>
+# spring.boot.admin.instance-auth.default-password=<password>

--- a/build/application/src/main/resources/application.properties
+++ b/build/application/src/main/resources/application.properties
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: Eclipse Dirigible contributors
 # SPDX-License-Identifier: EPL-2.0
 #
+spring.application.name=Eclipse Dirigible
 
 server.port=${DIRIGIBLE_SERVER_PORT:8080}
 
@@ -37,6 +38,7 @@ spring.devtools.restart.quiet-period=5s
 cxf.path=/odata/v2
 
 management.endpoints.web.exposure.include=*
+management.endpoints.health.show-details=always
 
 springdoc.api-docs.path=/api-docs
 
@@ -44,3 +46,7 @@ springdoc.api-docs.path=/api-docs
 # quartz properties are manged in quartz.properties don't try to add them here
 spring.quartz.job-store-type=jdbc
 spring.quartz.jdbc.initialize-schema=always
+
+# disable spring boot admin by default
+spring.boot.admin.client.enabled=false
+spring.boot.admin.server.enabled=false

--- a/build/application/src/main/resources/application.properties
+++ b/build/application/src/main/resources/application.properties
@@ -50,3 +50,6 @@ spring.quartz.jdbc.initialize-schema=always
 # disable spring boot admin by default
 spring.boot.admin.client.enabled=false
 spring.boot.admin.server.enabled=false
+
+# enable /actuator/health/liveness and /actuator/health/readiness
+management.health.probes.enabled=true

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -39,6 +39,8 @@ public class HttpSecurityURIConfigurator {
             "/services/js/resources-core/**", //
             "/services/js/resources-core/**", //
             "/services/integrations/**", //
+            "/actuator/health/liveness", //
+            "/actuator/health/readiness", //
             "/actuator/health"};
 
     /** The Constant AUTHENTICATED_PATTERNS. */

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -39,7 +39,7 @@ public class HttpSecurityURIConfigurator {
             "/services/js/resources-core/**", //
             "/services/js/resources-core/**", //
             "/services/integrations/**", //
-            "/actuator/**"};
+            "/actuator/health"};
 
     /** The Constant AUTHENTICATED_PATTERNS. */
     private static final String[] AUTHENTICATED_PATTERNS = {//
@@ -55,6 +55,10 @@ public class HttpSecurityURIConfigurator {
             "/services/bpm/**", //
             "/services/ide/**", //
             "/websockets/ide/**"};
+
+    private static final String[] OPERATOR_PATTERNS = {//
+            "/spring-admin/**", //
+            "/actuator/**"};
 
     /**
      * Configure.
@@ -78,7 +82,11 @@ public class HttpSecurityURIConfigurator {
 
              // "DEVELOPER" role required
              .requestMatchers(DEVELOPER_PATTERNS)
-             .hasRole(Roles.DEVELOPER.name())
+             .hasRole(Roles.DEVELOPER.getRoleName())
+
+             // "OPERATOR" role required
+             .requestMatchers(OPERATOR_PATTERNS)
+             .hasRole(Roles.OPERATOR.getRoleName())
 
              // Authenticated
              .requestMatchers(AUTHENTICATED_PATTERNS)

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/roles/Roles.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/roles/Roles.java
@@ -15,11 +15,11 @@ package org.eclipse.dirigible.components.base.http.roles;
 public enum Roles {
 
     /** The administrator. */
-    ADMINISTRATOR("ADMINISTRATOR"),
+    ADMINISTRATOR(RoleNames.ADMINISTRATOR),
     /** The developer. */
-    DEVELOPER("DEVELOPER"),
+    DEVELOPER(RoleNames.DEVELOPER),
     /** The operator. */
-    OPERATOR("OPERATOR");
+    OPERATOR(RoleNames.OPERATOR);
 
     /** The role name. */
     private final String roleName;
@@ -33,6 +33,14 @@ public enum Roles {
         this.roleName = roleName;
     }
 
+
+    public static class RoleNames {
+        public static final String OPERATOR = "OPERATOR";
+        public static final String DEVELOPER = "DEVELOPER";
+        public static final String ADMINISTRATOR = "ADMINISTRATOR";
+
+    }
+
     /**
      * Gets the role name.
      *
@@ -41,5 +49,4 @@ public enum Roles {
     public String getRoleName() {
         return roleName;
     }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
 
 		<!-- Spring -->
 		<spring.boot.version>3.3.4</spring.boot.version>
+		<spring.admin.version>${spring.boot.version}</spring.admin.version>
 		<springdoc.version>2.6.0</springdoc.version>
 		
 		<!-- Webjars -->

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/IDE.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/IDE.java
@@ -60,26 +60,6 @@ public class IDE {
         this.projectUtil = projectUtil;
     }
 
-    public void login() {
-        login(true);
-    }
-
-    public void login(boolean forceLogin) {
-        if (!forceLogin && !isLoginPageOpened()) {
-            LOGGER.info("Already logged in");
-            return;
-        }
-        LOGGER.info("Logging...");
-        browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, USERNAME_FIELD_ID, username);
-        browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, PASSWORD_FIELD_ID, password);
-        browser.clickOnElementByAttributePatternAndText(HtmlElementType.BUTTON, HtmlAttribute.TYPE, SUBMIT_TYPE, SIGN_IN_BUTTON_TEXT);
-    }
-
-    private boolean isLoginPageOpened() {
-        String pageTitle = browser.getPageTitle();
-        return LOGIN_PAGE_TITLE.equals(pageTitle);
-    }
-
     public void assertPublishingProjectMessage(String projectName) {
         String publishingMessage = "Publishing '/" + projectName + "'...";
         assertStatusBarMessage(publishingMessage);
@@ -112,6 +92,22 @@ public class IDE {
     public void openPath(String path) {
         browser.openPath(path);
         login(true);
+    }
+
+    public void login(boolean forceLogin) {
+        if (!forceLogin && !isLoginPageOpened()) {
+            LOGGER.info("Already logged in");
+            return;
+        }
+        LOGGER.info("Logging...");
+        browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, USERNAME_FIELD_ID, username);
+        browser.enterTextInElementByAttributePattern(HtmlElementType.INPUT, HtmlAttribute.ID, PASSWORD_FIELD_ID, password);
+        browser.clickOnElementByAttributePatternAndText(HtmlElementType.BUTTON, HtmlAttribute.TYPE, SUBMIT_TYPE, SIGN_IN_BUTTON_TEXT);
+    }
+
+    private boolean isLoginPageOpened() {
+        String pageTitle = browser.getPageTitle();
+        return LOGIN_PAGE_TITLE.equals(pageTitle);
     }
 
     public void createAndPublishProjectFromResources(String resourcesFolderPath) {
@@ -149,5 +145,14 @@ public class IDE {
 
     public void assertCreatedProject(String projectName) {
         assertStatusBarMessage("Created project '" + projectName + "'");
+    }
+
+    public void openSpringBootAdmin() {
+        browser.openPath("/spring-admin");
+        login();
+    }
+
+    public void login() {
+        login(true);
     }
 }

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -1,0 +1,83 @@
+package org.eclipse.dirigible.integration.tests.api;
+
+import org.eclipse.dirigible.DirigibleApplication;
+import org.eclipse.dirigible.components.base.http.roles.Roles;
+import org.eclipse.dirigible.integration.tests.IntegrationTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.stream.Stream;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = DirigibleApplication.class)
+class SecurityIT extends IntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @ParameterizedTest
+    @MethodSource("providePublicEndpointsParams")
+    void testPublicEndpoint(String path, HttpStatus expectedStatusCode) throws Exception {
+        mvc.perform(get(path))
+           .andExpect(status().is(expectedStatusCode.value()));
+    }
+
+    private static Stream<Arguments> providePublicEndpointsParams() {
+        return Stream.of(//
+                Arguments.of("/actuator/health", HttpStatus.OK), //
+                Arguments.of("/login", HttpStatus.OK), //
+                Arguments.of("/error.html", HttpStatus.OK));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/spring-admin", "/actuator/info"})
+    void testProtectedEndpointWithoutAuthentication(String path) throws Exception {
+        mvc.perform(get(path))
+           .andExpect(status().isUnauthorized());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/actuator/info"})
+    @WithMockUser(username = "user_without_roles", roles = {"SOME_UNUSED_ROLE"})
+    void testProtectedEndpointsWithUnauthorizedUser(String path) throws Exception {
+        mvc.perform(get(path))
+           .andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideOperatorEndpointsParams")
+    @WithMockUser(username = "operator", roles = {Roles.RoleNames.OPERATOR})
+    void testOperatorEndpointIsAccessible(String path, HttpStatus expectedStatusCode) throws Exception {
+        mvc.perform(get(path))
+           .andExpect(status().is(expectedStatusCode.value()));
+    }
+
+    private static Stream<Arguments> provideOperatorEndpointsParams() {
+        return Stream.of(Arguments.of("/spring-admin", HttpStatus.NOT_FOUND), //
+                Arguments.of("/actuator/info", HttpStatus.OK));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideDeveloperEndpointsParams")
+    @WithMockUser(username = "developer", roles = {Roles.RoleNames.DEVELOPER})
+    void testDeveloperEndpointIsAccessible(String path, HttpStatus expectedStatusCode) throws Exception {
+        mvc.perform(get(path))
+           .andExpect(status().is(expectedStatusCode.value()));
+    }
+
+    private static Stream<Arguments> provideDeveloperEndpointsParams() {
+        return Stream.of(Arguments.of("/services/ide/123", HttpStatus.NOT_FOUND),
+                Arguments.of("/websockets/ide/123", HttpStatus.NOT_FOUND));
+    }
+
+}

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -1,6 +1,5 @@
 package org.eclipse.dirigible.integration.tests.api;
 
-import org.eclipse.dirigible.DirigibleApplication;
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.integration.tests.IntegrationTest;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -8,8 +7,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,7 +16,6 @@ import java.util.stream.Stream;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = WebEnvironment.MOCK, classes = DirigibleApplication.class)
 class SecurityIT extends IntegrationTest {
 
     @Autowired

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -31,6 +31,8 @@ class SecurityIT extends IntegrationTest {
     private static Stream<Arguments> providePublicEndpointsParams() {
         return Stream.of(//
                 Arguments.of("/actuator/health", HttpStatus.OK), //
+                Arguments.of("/actuator/health/liveness", HttpStatus.OK), //
+                Arguments.of("/actuator/health/readiness", HttpStatus.OK), //
                 Arguments.of("/login", HttpStatus.OK), //
                 Arguments.of("/error.html", HttpStatus.OK));
     }

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
@@ -79,8 +79,8 @@ public class CsvimIT extends UserInterfaceIntegrationTest {
     }
 
     /**
-     * Initially the table READERS2 is not defined. However, the other two tables must be imported. Once
-     * the table is created, csvim retry should be able to import data in it as well
+     * Initially the table READERS2 is not defined. However, the other two tables must be imported. Once the table is created, csvim retry
+     * should be able to import data in it as well
      */
     @Test
     void testImportData() throws SQLException {
@@ -120,7 +120,7 @@ public class CsvimIT extends UserInterfaceIntegrationTest {
     }
 
     private void verifyDataInTable(String tableName, List<Reader> expectedReaders) {
-        await().atMost(25, TimeUnit.SECONDS)
+        await().atMost(35, TimeUnit.SECONDS)
                .pollInterval(1, TimeUnit.SECONDS)
                .until(() -> {
                    try {

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/api/java/CsvimIT.java
@@ -79,8 +79,8 @@ public class CsvimIT extends UserInterfaceIntegrationTest {
     }
 
     /**
-     * Initially the table READERS2 is not defined. However, the other two tables must be imported. Once the table is created, csvim retry
-     * should be able to import data in it as well
+     * Initially the table READERS2 is not defined. However, the other two tables must be imported. Once
+     * the table is created, csvim retry should be able to import data in it as well
      */
     @Test
     void testImportData() throws SQLException {

--- a/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/ui/tests/SpringBootAdminIT.java
+++ b/tests/tests-integrations/src/test/java/org/eclipse/dirigible/integration/tests/ui/tests/SpringBootAdminIT.java
@@ -1,0 +1,18 @@
+package org.eclipse.dirigible.integration.tests.ui.tests;
+
+import org.eclipse.dirigible.tests.framework.HtmlElementType;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles({"spring-boot-admin-server", "spring-boot-admin-client"})
+class SpringBootAdminIT extends UserInterfaceIntegrationTest {
+
+    private static final String SPRING_ADMIN_BRAND_TITLE = "Eclipse Dirigible Admin";
+
+    @Test
+    void testSpringBootAdminStarts() {
+        ide.openSpringBootAdmin();
+
+        browser.assertElementExistsByTypeAndText(HtmlElementType.ANCHOR, SPRING_ADMIN_BRAND_TITLE);
+    }
+}


### PR DESCRIPTION
- Spring Boot Admin Server
   To enable the embedded SBA server, activate spring profile `spring-boot-admin-server` using env variable `SPRING_PROFILES_ACTIVE` or via system property `spring.profiles.active` 
   The server could be accessed at path `/spring-admin`. For the local scenario the URL will be http://localhost:8080/spring-admin. The path requires role `OPERATOR`.
- Spring Boot Admin Client
   To enable the SBA client, activate spring profile `spring-boot-admin-client`
   By default it will connect to the embedded SBA server using the default basic credentials. You can configure the client to an external SBA server using the following configurations:

   | Config key | Description |
   | --- | --- |
   | DIRIGIBLE_SPRING_ADMIN_SERVER_URL | SBA Server URL | 
   | DIRIGIBLE_SPRING_ADMIN_SERVER_USERNAME | username which is used by the client to register in the SBA Server | 
   | DIRIGIBLE_SPRING_ADMIN_SERVER_PASSWORD | password which is used by the client to register in the SBA Server | 
   | DIRIGIBLE_SPRING_ADMIN_CLIENT_USERNAME | username for the client application which is passed to the SBA Server so that it can call the client | 
   | DIRIGIBLE_SPRING_ADMIN_CLIENT_PASSWORD | password for the client application which is passed to the SBA Server so that it can call the client | 

- To enable both SBA server and SBA client, you have to activate the both profiles
   Example: 
   ```
   java -jar -Dspring.profiles.active=spring-boot-admin-client,spring-boot-admin-server build/application/target/dirigible-application-*-executable.jar
   ```

- By default, SBA client and server are disabled unless the mentioned profiles are activated explicitly 

- Spring Boot Admin demo:

   https://github.com/user-attachments/assets/53fb4e10-e518-4f4d-ad77-f11111c88521

__Note__ Spring Boot Admin will work only with the default basic authentication since SBA use basic authentication by default. To enable it for different authentication mechanism, an additional customization must be implemented.

- Added authorization check for actuator endpoints. Only `/actuator/health` is publicly available. All other actuator endpoints require role `OPERATOR`