### PR TITLE
Changed analytics API. Related to #5119

### DIFF
--- a/components/resources/resources-dashboard/src/main/resources/META-INF/dirigible/dashboard/index.html
+++ b/components/resources/resources-dashboard/src/main/resources/META-INF/dirigible/dashboard/index.html
@@ -47,6 +47,7 @@
             addExtPoints({ theme: 'application-themes' });
             angular.module('shell', ['blimpKit', 'platformShell']).controller('ApplicationController', ($scope) => {});
         </script>
+        <analytics></analytics>
         <theme></theme>
     </body>
 

--- a/components/ui/platform-branding/src/main/resources/META-INF/dirigible/platform-branding/branding.mjs
+++ b/components/ui/platform-branding/src/main/resources/META-INF/dirigible/platform-branding/branding.mjs
@@ -39,14 +39,11 @@ export function getBrandingJs() {
     },
     logo: '${Configurations.get(BRANDING_LOGO, BRANDING_LOGO_DEFAULT)}',
 	theme: '${Configurations.get(BRANDING_THEME, BRANDING_THEME_DEFAULT)}',
-    prefix: '${Configurations.get(BRANDING_PREFIX, BRANDING_PREFIX_DEFAULT)}'
+    prefix: '${Configurations.get(BRANDING_PREFIX, BRANDING_PREFIX_DEFAULT)}',
+    analytics: '${Configurations.get(BRANDING_ANALYTICS, '')}',
 };`;
 }
 
 export function getKeyPrefix() {
     return Configurations.get(BRANDING_PREFIX, BRANDING_PREFIX_DEFAULT);
-}
-
-export function getAnalyticsLink() {
-    return Configurations.get(BRANDING_ANALYTICS, '');
 }

--- a/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/services/loader.js
+++ b/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/services/loader.js
@@ -12,7 +12,7 @@
 import { request, response } from 'sdk/http';
 import { registry } from 'sdk/platform';
 import { uuid } from 'sdk/utils';
-import { getBrandingJs, getKeyPrefix, getAnalyticsLink } from '/platform-branding/branding.mjs';
+import { getBrandingJs, getKeyPrefix } from '/platform-branding/branding.mjs';
 
 const COOKIE_PREFIX = `${getKeyPrefix()}.ljs.`;
 
@@ -190,14 +190,11 @@ function getScriptList(scriptId) {
                 '/platform-core/ui/platform/layout.js',
             ];
         case 'shell-js':
-            const shell = [
+            return [
                 ...baseJs,
                 cookies,
                 '/platform-core/ui/platform/shell.js',
-                getAnalyticsLink(),
             ];
-            if (!shell[shell.length - 1]) shell.pop();
-            return shell;
         case 'file-upload-js':
             return [
                 '/es5-shim/4.6.7/es5-shim.min.js',

--- a/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/view.js
+++ b/components/ui/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/view.js
@@ -13,6 +13,9 @@ if (typeof viewData === 'undefined' && typeof perspectiveData === 'undefined' &&
     console.error('You must provide one of the following: "viewData", "perspectiveData", "editorData", "shellData"');
 } else angular.module('platformView', ['platformExtensions', 'platformTheming'])
     .constant('clientOS', { isMac: () => navigator.userAgent.includes('Mac') })
+    .config(($sceDelegateProvider) => {
+        $sceDelegateProvider.resourceUrlWhitelist(['self', 'https://www.googletagmanager.com/gtag/js**']);
+    })
     .factory('baseHttpInterceptor', () => {
         let csrfToken = null;
         return {
@@ -182,4 +185,19 @@ if (typeof viewData === 'undefined' && typeof perspectiveData === 'undefined' &&
             } else throw Error('configTitle: missing view data');
         },
         template: '{{::label}}'
+    })).directive('analytics', ($window) => ({
+        restrict: 'E',
+        replace: true,
+        transclude: false,
+        link: (scope) => {
+            scope.gtag = getBrandingInfo().analytics;
+            if (scope.gtag) {
+                scope.link = `https://www.googletagmanager.com/gtag/js?id=${scope.gtag}`;
+                $window.dataLayer = $window.dataLayer || [];
+                function gtag() { dataLayer.push(arguments); }
+                gtag('js', new Date());
+                gtag('config', scope.gtag);
+            }
+        },
+        template: '<script ng-if="::gtag" async ng-src="{{ ::link }}"></script>'
     }));

--- a/components/ui/shell-ide/src/main/resources/META-INF/dirigible/shell-ide/index.html
+++ b/components/ui/shell-ide/src/main/resources/META-INF/dirigible/shell-ide/index.html
@@ -36,7 +36,7 @@
         <script type="text/javascript">
             angular.module('shell', ['blimpKit', 'platformShell']).controller('ShellController', ($scope) => { });
         </script>
-
+        <analytics></analytics>
         <theme></theme>
     </body>
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Changes the way we set the Google analytics script.

Now the env var `DIRIGIBLE_BRANDING_ANALYTICS` should contain the GTag ID and in order to enable analytics for a shell, perspective, view, etc. the user should include the `analytics` tag just before the `theme` tag.

### What issues does this PR fix or reference?

#5119
