### PR TITLE
[Research] H2 in Postrges like mode

### DIFF
--- a/build/application/src/main/java/org/eclipse/dirigible/AppLifecycleLoggingListener.java
+++ b/build/application/src/main/java/org/eclipse/dirigible/AppLifecycleLoggingListener.java
@@ -10,6 +10,8 @@
 package org.eclipse.dirigible;
 
 import org.eclipse.dirigible.components.base.ApplicationListenersOrder;
+import org.h2.server.Service;
+import org.h2.tools.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -19,6 +21,8 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+
+import java.sql.SQLException;
 
 @Order(ApplicationListenersOrder.APP_LYFECYCLE_LOGGING_LISTENER)
 @Component
@@ -40,7 +44,47 @@ class AppLifecycleLoggingListener implements ApplicationListener<ApplicationEven
             long currentTime = System.currentTimeMillis();
             log("Start time: [{}] milliseconds. Init time: [{}] milliseconds", (currentTime - DirigibleApplication.getStartedAt()),
                     (currentTime - createdContextAt));
+
+            startH2();
         }
+    }
+
+    private void startH2() {
+        try {
+            // Server server =
+            // Server.createPgServer("-baseDir", "./target/dirigible/h2", "-pgAllowOthers", "-pgPort", "5432",
+            // "-key", "testdb");
+
+            // Server server = Server.createPgServer("-baseDir", "./target/dirigible/h2", "-pgAllowOthers",
+            // "-pgPort", "5432", "-ifNotExists");
+
+            // Ensure DB exists
+            // DriverManager.getConnection("jdbc:h2:./target/dirigible/h2/testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+            // "sa", "sa");
+
+            // Start server
+            // Server server =
+            // Server.createPgServer("-baseDir", "./target/dirigible/h2", "-pgAllowOthers", "-pgPort", "5432",
+            // "-key", "testdb",
+            // "testdb");
+
+            // Server server = Server.createPgServer("-baseDir", "./target/dirigible/h2", "-pgAllowOthers",
+            // "-pgPort", "5432");
+
+            Server server = Server.createPgServer("-baseDir", "./target/dirigible/h2", "-pgAllowOthers", "-pgPort", "5432", "-ifNotExists");
+
+            server.start();
+
+            // connect using: psql -h localhost -p 5432 -U sa -d testdb
+
+            LOGGER.info("H2 PG url [{}]", server.getURL());
+            LOGGER.info("H2 PG status [{}]", server.getStatus());
+            Service service = server.getService();
+            LOGGER.info("H2 PG service [{}]", service);
+        } catch (SQLException ex) {
+            throw new RuntimeException("Failed to start H2 PG", ex);
+        }
+
     }
 
     private void log(String messageFormat, Object... argument) {


### PR DESCRIPTION
Research H2 as Postrges for DefaultDB so that nodejs apps can connect to it.

doc: https://www.h2database.com/html/advanced.html#odbc_driver

Connect using psql: `psql -h localhost -p 5432 -U sa -d testdb`
**Note:** DBeaver and pgadmin cannot connect to the database
<img width="997" height="426" alt="image" src="https://github.com/user-attachments/assets/3005506d-fb0f-479d-b507-7430a7e83379" />
<img width="777" height="684" alt="image" src="https://github.com/user-attachments/assets/42d41ee6-430c-4392-b008-3eb8d243f306" />

### NestJS project test project
[my-first-project.zip](https://github.com/user-attachments/files/22655264/my-first-project.zip)

- `Client` from `pg` lib **could be used** with H2 in postgres mode
```shell
curl --location 'http://localhost:3000/pg-client/users/test'
```
<img width="865" height="579" alt="image" src="https://github.com/user-attachments/assets/d0dfb179-99f5-4c12-89e3-d1cb195f9034" />

- ORM logic **cannot be started** with H2 in postgres mode
<img width="1233" height="220" alt="image" src="https://github.com/user-attachments/assets/6b900f24-7fc8-4de5-88a1-3e7532bb0ca1" />

App has been tested with real postgres.
- Create user request
```shell
curl --location 'http://localhost:3000/users' \
--header 'Content-Type: application/json' \
--data '{
    "username": "alice"
}'
```
<img width="717" height="477" alt="image" src="https://github.com/user-attachments/assets/70a2a24f-3418-44cb-9102-8be7d3b785fc" />

- Get users request
```shell
curl --location 'http://localhost:3000/users'
```
<img width="725" height="511" alt="image" src="https://github.com/user-attachments/assets/cef18f73-cf8d-46bf-bf78-ada837e2a17d" />
