### PR TITLE
Disable "Upload Docker Scout SARIF Report to GitHub Security tab" step from release and build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,6 +275,7 @@ jobs:
           path: sast_docker_scout_sarif_trimmed.json
 
       - name: Upload Docker Scout SARIF Report to GitHub Security tab
+        if: false # uncomment when the sast_docker_scout_sarif.json has allowed number of related locations < 1000
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: sast_docker_scout_sarif_trimmed.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,7 @@ jobs:
           path: sast_docker_scout_sarif.json
 
       - name: Upload Docker Scout SARIF Report to GitHub Security tab
+        if: false # uncomment when the sast_docker_scout_sarif.json has allowed number of related locations < 1000
         uses: github/codeql-action/upload-sarif@v3
         if: ${{ inputs.upload-scanned-sarif-report }}
         with:


### PR DESCRIPTION
Temp disable `Upload Docker Scout SARIF Report to GitHub Security tab` step in build and release workflows due to `Error: Code Scanning could not process the submitted SARIF file:
rejecting SARIF, as there are more related locations per result than allowed (1626 > 1000)`
<img width="2118" height="382" alt="image" src="https://github.com/user-attachments/assets/ecd3b112-09ab-44af-bf82-576f5df989e9" />

The error is thrown for the rule with id [CVE-2025-64756](https://nvd.nist.gov/vuln/detail/CVE-2025-64756) which has `1626` `locations`.
The locations count is expected to be reduced when the fix for the `glob` lib is available in the Docker image.