### PR TITLE
Rerun failing integration tests (up to 3 times) to resolve flaky tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,9 @@
                                 <goal>integration-test</goal>
                                 <goal>verify</goal>
                             </goals>
+                            <configuration>
+                                <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
                                 <goal>verify</goal>
                             </goals>
                             <configuration>
-                                <rerunFailingTestsCount>2</rerunFailingTestsCount>
+                                <rerunFailingTestsCount>3</rerunFailingTestsCount>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Integration tests will be run until they pass or the number of reruns (3) has been exhausted.
Documentation: https://maven.apache.org/surefire/maven-failsafe-plugin/examples/rerun-failing-tests.html

