### PR TITLE
Improve BPMStarterTemplateIT stability - unpublish only the corresponding  gen folder on form regeneration

### DIFF
--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/generate.mjs
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/generate.mjs
@@ -117,7 +117,7 @@ function cleanGenFolder(workspaceName, projectName, genFolderName) {
     const genFolder = project.getFolder("gen");
     if (genFolder.exists() && genFolder.existsFolder(genFolderName)) {
         genFolder.deleteFolder(genFolderName);
-        lifecycle.unpublish(projectName + "/gen");
+        lifecycle.unpublish(projectName + "/gen/" + genFolderName);
     }
 }
 


### PR DESCRIPTION
Unpublish only the corresponding gen folder (not the entire project) on form regeneration to prevent unnecessary unpublishing of artifacts (like bpm processes undeployment for example) which may happen depending on the execution time.

This happens from time to time during the `BPMStarterTemplateIT` execution and as result the test fails because the process is missing.
Example BPMStarterTemplateIT execution: [h2-failures-bpmstarter.log](https://github.com/user-attachments/files/24166781/h2-failures-bpmstarter.log)
