### PR TITLE
safely delete screenshots if they are present

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/browser/impl/BrowserImpl.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/browser/impl/BrowserImpl.java
@@ -11,6 +11,7 @@ package org.eclipse.dirigible.tests.framework.browser.impl;
 
 import com.codeborne.selenide.*;
 import com.codeborne.selenide.ex.ListSizeMismatch;
+import com.codeborne.selenide.impl.Screenshot;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.dirigible.tests.base.IntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.Browser;
@@ -237,10 +238,18 @@ class BrowserImpl implements Browser {
                     "Found ZERO elements with selector [{}] and conditions [{}] but expected ONLY ONE. Consider using more precise selector and conditions.\nFound elements: {}.\nCause error message: {}",
                     by, allConditions, describeCollection(by, foundElements, conditions), ex.getMessage());
 
-            FileUtil.deleteFile(ex.getScreenshot()
-                                  .getImage());
-            FileUtil.deleteFile(ex.getScreenshot()
-                                  .getSource());
+            Screenshot exceptionScreenshot = ex.getScreenshot();
+            if (null != exceptionScreenshot && exceptionScreenshot.isPresent()) {
+
+                if (null != exceptionScreenshot.getImage()) {
+                    FileUtil.deleteFile(exceptionScreenshot.getImage());
+                }
+
+                if (null != exceptionScreenshot.getSource()) {
+                    FileUtil.deleteFile(exceptionScreenshot.getSource());
+                }
+            }
+
             return Collections.emptySet();
         }
     }


### PR DESCRIPTION
to prevent errors like the following:
```log
[ERROR] org.eclipse.dirigible.integration.tests.ui.tests.sample.WebsocketDecoratorSampleProjectIT.testSampleProject -- Time elapsed: 6.064 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "String.startsWith(String)" because "filePath" is null
        at org.eclipse.dirigible.tests.framework.util.FileUtil.deleteFile(FileUtil.java:120)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.findFirstMatchingElements(BrowserImpl.java:240)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.findElementsInFramesRecursively(BrowserImpl.java:173)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.findOptionalElementInAllFrames(BrowserImpl.java:353)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.findOptionalElementInAllFrames(BrowserImpl.java:336)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.findElementInAllFrames(BrowserImpl.java:149)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.handleElementInAllFrames(BrowserImpl.java:143)
        at org.eclipse.dirigible.tests.framework.browser.impl.BrowserImpl.clickOnElementById(BrowserImpl.java:636)
        at org.eclipse.dirigible.tests.framework.ide.IDE.openGitPerspective(IDE.java:123)
        at org.eclipse.dirigible.integration.tests.ui.tests.sample.SampleProjectRepositoryIT.cloneProject(SampleProjectRepositoryIT.java:46)
        at org.eclipse.dirigible.integration.tests.ui.tests.sample.SampleProjectRepositoryIT.testSampleProject(SampleProjectRepositoryIT.java:31)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)

```