### PR TITLE
#5621 - Disable hidden autofill of feed username and password data in the EDM editor

### DIFF
--- a/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/templates/dialogs.html
+++ b/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/templates/dialogs.html
@@ -57,7 +57,7 @@
                         <bk-form-input-message state="{{formDialog.form['n' + id].$valid ? '' : 'error'}}" message="item.errorMsg || 'Invalid input'" message-fixed="true">
                             <bk-input id="{{id}}" type="{{item.type}}" ng-attr-placeholder="{{item.placeholder}}" name="{{ 'n' + id }}" ng-trim="false" ng-model="item.value" bk-focus="{{item.focus}}"
                                 state="{{ formDialog.form['n' + id].$valid ? '' : 'error' }}" ng-required="item.required" ng-minlength="item.minlength || 0" ng-disabled="formItemDisabled(item.enabledOn, item.disabledOn)"
-                                ng-maxlength="item.maxlength || -1" ng-attr-min="{{item.min}}" ng-attr-max="{{item.max}}" input-rules="item.inputRules || {}"
+                                ng-maxlength="item.maxlength || -1" ng-attr-min="{{item.min}}" ng-attr-max="{{item.max}}" ng-attr-autocomplete="{{item.type === 'password' ? 'new-password' : undefined}}" input-rules="item.inputRules || {}"
                                 ng-keyup="$event.keyCode == 13 && item.submitOnEnter && formDialog.form.$valid && closeFormDialog(true)">
                             </bk-input>
                         </bk-form-input-message>

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/details.html
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/dialogs/details.html
@@ -472,7 +472,7 @@
                             <bk-form-label for="fun" colon="true">Username</bk-form-label>
                         </div>
                         <div class="fd-col fd-col-md--4">
-                            <bk-input id="fun" type="text" ng-model="dataParameters.feedUsername"></bk-input>
+                            <bk-input id="fun" name="feedUsername" type="text" ng-model="dataParameters.feedUsername" autocomplete="off" ng-readonly="selectedTab !== 'feed'"></bk-input>
                         </div>
                     </bk-form-item>
                     <bk-form-item class="fd-row fd-margin-top--tiny">
@@ -480,7 +480,7 @@
                             <bk-form-label for="fp" colon="true">Password</bk-form-label>
                         </div>
                         <div class="fd-col fd-col-md--4">
-                            <bk-input id="fp" type="password" ng-model="dataParameters.feedPassword"></bk-input>
+                            <bk-input id="fp" name="feedPassword" type="password" ng-model="dataParameters.feedPassword" autocomplete="new-password" ng-readonly="selectedTab !== 'feed'"></bk-input>
                         </div>
                     </bk-form-item>
                     <bk-form-item class="fd-row fd-margin-top--tiny">

--- a/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/staging.html
+++ b/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/staging.html
@@ -72,10 +72,10 @@
           <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
             <div class="fd-row">
               <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
-                <bk-form-label for="username" colon="true" title="Username" autocomplete="git-username">Username</bk-form-label>
+                <bk-form-label for="username" colon="true" title="Username">Username</bk-form-label>
               </div>
               <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
-                <bk-input id="username" type="text" placeholder="Username" ng-required="true" ng-model="commitData.username"></bk-input>
+                <bk-input id="username" name="gitUsername" type="text" placeholder="Username" ng-required="true" ng-model="commitData.username" autocomplete="git-username"></bk-input>
               </div>
             </div>
           </div>
@@ -83,10 +83,10 @@
           <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
             <div class="fd-row">
               <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
-                <bk-form-label for="email" colon="true" title="Email" autocomplete="git-email">Email</bk-form-label>
+                <bk-form-label for="email" colon="true" title="Email">Email</bk-form-label>
               </div>
               <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
-                <bk-input id="email" type="email" placeholder="email@example.com" ng-required="true" ng-model="commitData.email"></bk-input>
+                <bk-input id="email" name="gitEmail" type="email" placeholder="email@example.com" ng-required="true" ng-model="commitData.email" autocomplete="git-email"></bk-input>
               </div>
             </div>
           </div>
@@ -94,10 +94,10 @@
           <div class="fd-col fd-col-lg--6 fd-col-xl--4 fd-col--wrap">
             <div class="fd-row">
               <div class="fd-col fd-col-md--2 fd-col-lg--4 fd-col-xl--12">
-                <bk-form-label for="password" colon="true" title="Password or Token" autocomplete="git-pass" style="white-space: break-spaces;">Password or Token</bk-form-label>
+                <bk-form-label for="password" colon="true" title="Password or Token" style="white-space: break-spaces;">Password or Token</bk-form-label>
               </div>
               <div class="fd-col fd-col-md--10 fd-col-lg--8 fd-col-xl--12">
-                <bk-input id="password" type="password" ng-required="true" ng-model="commitData.password"></bk-input>
+                <bk-input id="password" name="gitPassword" type="password" ng-required="true" ng-model="commitData.password" autocomplete="git-password"></bk-input>
               </div>
             </div>
           </div>
@@ -106,16 +106,13 @@
       <div class="fd-container fd-padding-begin-end--tiny" ng-hide="loadingGitState">
         <div class="fd-row">
           <div class="fd-col fd-col--6 fd-col-md--4 fd-col-lg--4 fd-col-xl--4">
-            <bk-button class="bk-full-width" label="Commit" ng-click="commit()" ng-disabled="!commitData.commitMessage || !forms.credentialsFieldset.$valid || !stagedFiles.length">
-            </bk-button>
+            <bk-button class="bk-full-width" label="Commit" ng-click="commit()" ng-disabled="!commitData.commitMessage || !forms.credentialsFieldset.$valid || !stagedFiles.length"></bk-button>
           </div>
           <div class="fd-col fd-col--6 fd-col-md--4 fd-col-lg--4 fd-col-xl--4">
-            <bk-button class="bk-full-width" label="Push" ng-click="push()" ng-disabled="!forms.credentialsFieldset.$valid">
-            </bk-button>
+            <bk-button class="bk-full-width" label="Push" ng-click="push()" ng-disabled="!forms.credentialsFieldset.$valid"></bk-button>
           </div>
           <div class="fd-col fd-col--12 fd-col-md--4 fd-col-lg--4 fd-col-xl--4">
-            <bk-button class="bk-full-width" state="emphasized" label="Commit & Push" ng-click="commit(true)" ng-disabled="!commitData.commitMessage || !forms.credentialsFieldset.$valid || !stagedFiles.length">
-            </bk-button>
+            <bk-button class="bk-full-width" state="emphasized" label="Commit & Push" ng-click="commit(true)" ng-disabled="!commitData.commitMessage || !forms.credentialsFieldset.$valid || !stagedFiles.length"></bk-button>
           </div>
         </div>
       </div>

--- a/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/dialogs/user-dialog.html
+++ b/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/dialogs/user-dialog.html
@@ -40,7 +40,7 @@
                     <bk-form-item>
                         <bk-form-label for="password" required colon="true">Password</bk-form-label>
                         <bk-input id="password" name="password" type="password" placeholder="Enter password" ng-model="user.password" input-rules="inputRules" ng-trim="false" state="{{ forms.userForm['password'].$valid ? '' : 'error' }}"
-                            ng-required="true">
+                            ng-required="true" autocomplete="new-password">
                         </bk-input>
                     </bk-form-item>
                 </bk-form-group>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

This PR adds the `autocomplete` attribute to several inputs and sets the EDM feed username and password fields to `readonly` while the **Feed** tab is not focused.

The goal is to reduce the risk of browsers silently autofilling the feed credentials. In some cases, browsers automatically populate these fields without user awareness, and the credentials are then persisted in the EDM file, creating a security concern.

The changes in this PR only partially address the issue. Support for the `autocomplete` attribute is inconsistent across browsers and is often ignored altogether. Browser vendors argue that `autocomplete` is frequently misused and therefore justify this behavior. Some browsers factor in the `name` and/or `id` attributes when deciding whether to autofill, others sometimes honor `autocomplete="new-password"`, and some ignore all related attributes and autofill regardless.

To further mitigate the issue, this PR also makes the feed inputs `readonly` until the user focuses the **Feed** tab. This does not fully prevent autofill, but it ensures that any autofilled values become visible to the user, placing the responsibility on them to clear unintended credentials before they are saved.


### What issues does this PR fix or reference?

Partially fixes #5621 
