### PR TITLE
Fix for missing form title

### DIFF
--- a/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/view.js.template
+++ b/components/template/template-form-builder-angularjs/src/main/resources/META-INF/dirigible/template-form-builder-angularjs/ui/view.js.template
@@ -5,11 +5,11 @@
  */
 const viewData = {
 	id: '$projectName-$fileName',
-	label: '$projectName Form',
+	label: '$fileName Form',
 	translation: {
-		key: '$projectName:default.viewName',
+		key: '$projectName:${tprefix}.default.viewName',
 		options: {
-			name: '$projectName',
+			name: '$metadata.name',
 		}
 	},
 	region: 'bottom',

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -61,6 +61,15 @@ function migrateForm(formData) {
     }
 }
 
+function getFormName(formData) {
+    for (let i = 0; i < formData.length; i++) {
+        if (formData[i].controlId === 'header' && formData[i].headerSize === 1) {
+            return `${formData[i].label} Form`;
+        }
+    }
+    return '';
+}
+
 function migrateReport(report) {
     if (!report.hasOwnProperty('tId')) {
         report['tId'] = getTranslationId(report.alias);
@@ -78,8 +87,15 @@ export function generateGeneric(model, parameters, templateSources) {
     let isReport = false;
     const generatedFiles = []
     const templateParameters = {};
-    if (parameters.filePath.endsWith('.form')) migrateForm(model.form);
-    else if (parameters.filePath.endsWith('.report')) {
+    if (parameters.filePath.endsWith('.form')) {
+        migrateForm(model.form);
+        if (!model.hasOwnProperty('metadata')) {
+            model['metadata'] = {
+                name: getFormName(model.form) || `${parameters['fileName']} Form`
+            }
+        }
+
+    } else if (parameters.filePath.endsWith('.report')) {
         migrateReport(model);
         isReport = true;
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Fixes an issue where the form title was missing during form template generation.

This change introduces a new metadata field in the .form file. For now, it only contains the form title under the name key. The form editor does not yet provide a UI for editing this field, so users who need a custom title must modify the form file manually using the built-in code editor.

The change is fully backward compatible. If the metadata field is not present, the generation tool will attempt to derive the title by first looking for a size 1 header element (`h1`) within the form. If no such element exists, the file name will be used as a fallback.

### What issues does this PR fix or reference?

Fixes # #5631 
