### PR TITLE
Generate sbom and expose it via the actuator endpoint

### DIFF
--- a/build/application/pom.xml
+++ b/build/application/pom.xml
@@ -251,6 +251,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,38 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>${maven-gpg-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>2.9.1</version>
+                    <executions>
+                        <execution>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>makeAggregateBom</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <!--                        https://cyclonedx.org/docs/1.6/json/-->
+                        <schemaVersion>1.6</schemaVersion>
+                        <projectType>application</projectType>
+                        <verbose>false</verbose>
+
+                        <includeBomSerialNumber>true</includeBomSerialNumber>
+                        <includeCompileScope>true</includeCompileScope>
+                        <includeProvidedScope>true</includeProvidedScope>
+                        <includeRuntimeScope>true</includeRuntimeScope>
+                        <includeSystemScope>true</includeSystemScope>
+                        <includeTestScope>false</includeTestScope>
+                        <includeLicenseText>false</includeLicenseText>
+
+                        <outputReactorProjects>true</outputReactorProjects>
+                        <outputFormat>all</outputFormat>
+                        <outputName>bom</outputName>
+                        <outputDirectory>${project.build.outputDirectory}/META-INF/sbom</outputDirectory>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/SecurityIT.java
@@ -43,7 +43,7 @@ public class SecurityIT extends IntegrationTest {
 
     @Test
     void testProtectedEndpointWithoutAuthentication() throws Exception {
-        Set<String> paths = Set.of("/spring-admin", "/actuator/info");
+        Set<String> paths = Set.of("/spring-admin", "/actuator/info", "/actuator/sbom", "/actuator/sbom/application");
         for (String path : paths) {
             mvc.perform(get(path))
                .andExpect(status().isUnauthorized());
@@ -53,7 +53,7 @@ public class SecurityIT extends IntegrationTest {
     @Test
     @WithMockUser(username = "user_without_roles", roles = {"SOME_UNUSED_ROLE"})
     void testProtectedEndpointsWithUnauthorizedUser() throws Exception {
-        Set<String> paths = Set.of("/actuator/info");
+        Set<String> paths = Set.of("/actuator/info", "/actuator/sbom", "/actuator/sbom/application");
         for (String path : paths) {
             mvc.perform(get(path))
                .andExpect(status().isForbidden());
@@ -63,7 +63,8 @@ public class SecurityIT extends IntegrationTest {
     @Test
     @WithMockUser(username = "operator", roles = {Roles.RoleNames.OPERATOR})
     void testOperatorEndpointIsAccessible() throws Exception {
-        Map<String, HttpStatus> paths = Map.of("/spring-admin", HttpStatus.NOT_FOUND, "/actuator/info", HttpStatus.OK);
+        Map<String, HttpStatus> paths = Map.of("/spring-admin", HttpStatus.NOT_FOUND, "/actuator/info", HttpStatus.OK, "/actuator/sbom",
+                HttpStatus.OK, "/actuator/sbom/application", HttpStatus.OK);
         for (Map.Entry<String, HttpStatus> entry : paths.entrySet()) {
             mvc.perform(get(entry.getKey()))
                .andExpect(status().is(entry.getValue()


### PR DESCRIPTION
- Generate sbom and expose it via the actuator endpoint http://localhost:8080/actuator/sbom/application
- `actuator/sbom` is protected with the Operator role.
- enhance the existing integration tests

Example response:
[bom.json](https://github.com/user-attachments/files/25124236/bom.json)
