### PR TITLE
#5744 - Fixed UTF-8 file content is not being correctly returned

### DIFF
--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/io/bytes.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/io/bytes.ts
@@ -4,6 +4,7 @@
  */
 
 const JString = Java.type("java.lang.String");
+const Charset = Java.type("java.nio.charset.Charset");
 const JByte = Java.type("java.lang.Byte");
 const JArray = Java.type("java.lang.reflect.Array");
 const BytesFacade = Java.type("org.eclipse.dirigible.components.api.io.BytesFacade");
@@ -64,8 +65,7 @@ export class Bytes {
 	 * @returns The reconstructed text string.
 	 */
 	public static byteArrayToText(data: any[]): string {
-		const native = Bytes.toJavaBytes(data);
-		return String.fromCharCode.apply(String, Bytes.toJavaScriptBytes(native));
+		return new JString(data, Charset.forName("UTF8"));
 	}
 
 	/**

--- a/components/template/template-application-rest-v2/src/main/resources/META-INF/dirigible/template-application-rest-v2/api/EntityController.ts.template
+++ b/components/template/template-application-rest-v2/src/main/resources/META-INF/dirigible/template-application-rest-v2/api/EntityController.ts.template
@@ -44,7 +44,7 @@ class ${name}Controller {
             const options: Options = {
                 limit: ctx.queryParameters["$limit"] ? parseInt(ctx.queryParameters["$limit"]) : 20,
                 offset: ctx.queryParameters["$offset"] ? parseInt(ctx.queryParameters["$offset"]) : 0,
-                language: request.getLocale().slice(0, 2)
+                language: request.getLocale().split("_")[0]
             };
 #if($layoutType == "MANAGE_DETAILS" || $layoutType == "LIST_DETAILS")
 
@@ -161,7 +161,7 @@ class ${name}Controller {
     #end
 #end
             const options: Options = {
-                language: request.getLocale().slice(0, 2)
+                language: request.getLocale().split("_")[0]
             };
             const entity = this.repository.findById(id, options);
             if (entity) {

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
@@ -37,7 +37,7 @@ class ${name}Service {
             const options: ${name}EntityOptions = {
                 $limit: ctx.queryParameters["$limit"] ? parseInt(ctx.queryParameters["$limit"]) : undefined,
                 $offset: ctx.queryParameters["$offset"] ? parseInt(ctx.queryParameters["$offset"]) : undefined,
-                $language: request.getLocale().slice(0, 2)
+                $language: request.getLocale().split("_")[0]
             };
 #if($layoutType == "MANAGE_DETAILS" || $layoutType == "LIST_DETAILS")
 
@@ -144,7 +144,7 @@ class ${name}Service {
 #end
 #end
             const options: ${name}EntityOptions = {
-                $language: request.getLocale().slice(0, 2)
+                $language: request.getLocale().split("_")[0]
             };
             const entity = this.repository.findById(id, options);
             if (entity) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Dirigible's Contributing Guide: https://github.com/eclipse/dirigible/blob/master/CONTRIBUTING.md

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/dirigible/labels
-->

### What does this PR do?

Fixes UTF-8 file content is not being correctly returned.
The `byteArrayToText` function in the `Bytes` class was updated to use `String` and `Charset` from Java in order to correctly convert the Java byte array to a normal UTF-8 string.

It also fixes a problem where the language was not correctly extracted from the BCP-47 locale tag in the template entity controller.

### What issues does this PR fix or reference?

#5744 