### PR TITLE
Remove unused dev dependencies from editor-monaco LSP package

### DIFF
--- a/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/lsp/package.json
+++ b/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/lsp/package.json
@@ -7,8 +7,6 @@
     },
     "devDependencies": {
         "esbuild": "^0.24.0",
-        "typescript": "^5.7.0",
-        "monaco-editor": "^0.40.0",
-        "vscode-languageserver-types": "^3.17.0"
+        "typescript": "^5.7.0"
     }
 }


### PR DESCRIPTION
The `package.json` for the java-lsp-client lists `monaco-editor` and `vscode-languageserver-types` as devDependencies, but the build output is already provided and these packages are not imported in any TypeScript source. Removing them reduces npm install time, disk usage, and avoids confusion about unused dependencies.