### PR TITLE
Add Java handlers for BPMN service tasks (${JavaTask} + flowable:class)

### DIFF
--- a/CLAUDE_BPMN.md
+++ b/CLAUDE_BPMN.md
@@ -512,7 +512,100 @@ java -DDIRIGIBLE_SFTP_SERVER_ENABLED=false \
 
 ---
 
-## 5. Project version pinning
+## 5. Java handlers on BPMN service tasks (`${JavaTask}` + `flowable:class="..."`)
+
+Counterpart of the long-standing `${JSTask}` JavaScript delegate (`DirigibleCallDelegate`, bean
+name `JSTask`). Lets a service task in a `.bpmn` file invoke a client `.java` class compiled by
+`engine-java` instead of a `.ts`/`.mjs` script. Two entry points, both shipped together:
+
+| Style | BPMN syntax | Resolution path |
+|---|---|---|
+| Delegate expression (mirrors `${JSTask}`) | `flowable:delegateExpression="${JavaTask}"` + `<flowable:field name="handler"><flowable:string>com.acme.MyTask</flowable:string></flowable:field>` | `DirigibleJavaCallDelegate` (`@Component("JavaTask")`) reads the `handler` field, calls `ClientClassLoaderHolder.current().loadClass(fqn)`, instantiates per execution, invokes Flowable's `JavaDelegate.execute(...)` |
+| Pure Flowable class binding | `flowable:class="com.acme.MyTask"` | Flowable's `ReflectUtil.loadClass` → custom CL set on the engine config = `ClientAwareClassLoader` (parent = platform CL, `findClass` defers to `ClientClassLoaderHolder.current()`) |
+
+### Why both
+
+The user's editor UX is set up for the delegate-expression + handler-field pattern (same UI as
+`${JSTask}`). The pure-class path is the idiomatic Flowable way and what BPMN modellers from other
+projects expect. Adding the engine-config classloader was a one-line change once the delegating
+CL existed, so we shipped both.
+
+### Hot-reload caveat — read before relying on `flowable:class="..."`
+
+`ClientAwareClassLoader` is a Spring **singleton**. Once Flowable's `Class.forName(name, true,
+clientAwareCL)` succeeds for a given FQN, the JVM records `clientAwareCL` as an *initiating
+loader* for that name and pins the result. Subsequent calls return the cached class even after
+the underlying `ClientClassLoader` has been hot-swapped by `JavaLoader.rebuild()`. Effect:
+
+- **`${JavaTask}` is hot-reload-safe** — `DirigibleJavaCallDelegate` calls
+  `holder.current().loadClass(fqn)` directly each execution, so it always sees the latest
+  generation.
+- **`flowable:class="..."` resolves the *first* generation only** — a restart is required to
+  pick up a recompiled class.
+
+Documented on `ClientAwareClassLoader`'s class-level JavaDoc; users that need hot-reload should
+prefer the `${JavaTask}` path.
+
+### User contract
+
+The client class must implement Flowable's `org.flowable.engine.delegate.JavaDelegate` (one
+method: `execute(DelegateExecution)`). It must have a public no-arg constructor. It runs in the
+same compiled class space as every other client `.java` in the registry — it can reference
+sibling classes by FQN, and `engine-java`'s annotations / repositories / controllers are visible
+on its compile classpath.
+
+Example client source:
+
+```java
+package com.acme;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+public class MyJavaTask implements JavaDelegate {
+    @Override
+    public void execute(DelegateExecution execution) {
+        execution.setVariable("myResult", computeSomething());
+    }
+}
+```
+
+### Files touched
+
+- `components/engine/engine-bpm-flowable/pom.xml` — adds dep on `dirigible-components-engine-java`.
+- `components/engine/engine-bpm-flowable/src/main/java/.../delegate/DirigibleJavaCallDelegate.java` *(new)* — the `JavaTask` Spring bean. Mirrors `DirigibleCallDelegate` (OpenTelemetry span, `TracingFacade` hooks, tenant-context wrap, `DIRIGIBLE_BPM_INTERNAL_SKIP_STEP` short-circuit). Wraps loader lookup with a clear `BpmnRuntimeException` when the holder is empty (no rebuild yet) or the class isn't a `JavaDelegate`.
+- `components/engine/engine-bpm-flowable/src/main/java/.../config/ClientAwareClassLoader.java` *(new)* — delegating `ClassLoader`; parent = platform CL, `findClass` defers to the holder.
+- `components/engine/engine-bpm-flowable/src/main/java/.../config/BpmFlowableConfig.java` — `config.setClassLoader(new ClientAwareClassLoader(parent, clientClassLoaderHolder))` inside `createProcessEngineConfig`.
+- `tests/tests-integrations/src/main/java/.../api/JavaBpmnIT.java` *(new)* — HTTP-only IT (no Selenide). Drops two `JavaDelegate`-implementing `.java` sources and a `.bpmn` with two service tasks (one per style), calls `SynchronizationProcessor.forceProcessSynchronizers()`, posts to `/services/bpm/bpm-processes/instance`, then asserts both delegates wrote their side-effect variables on the historic process instance. Runs in ~25 s.
+
+### Don't repeat these dead-ends
+
+- **Don't add a `findByFqn(...)` to `JavaClassRegistry`.** That registry is populated by
+  `HandlerClassConsumer`, which only accepts classes implementing `JavaHandler` (the HTTP-handler
+  SPI). A class that implements *only* Flowable's `JavaDelegate` is compiled into
+  `ClientClassLoader` but never enters `JavaClassRegistry`. Look it up via
+  `ClientClassLoaderHolder.current().loadClass(fqn)` instead — that's what
+  `DirigibleJavaCallDelegate` does.
+- **Don't fall into the trap that `parameters` on `StartProcessInstanceData` is a Map.** It's a
+  `String` (a JSON-string of variables, deserialized by Gson inside `BpmProviderFlowable`). The IT
+  body must be `"parameters":"{}"` not `"parameters":{}` — the latter triggers
+  `HttpMessageNotReadableException` and a 400.
+- **`HistoricVariableInstance` JSON field is `variableName`, not `name`.** Jackson serialises
+  using the getter name (`getVariableName()` → `variableName`). Test assertions on `name` silently
+  match nothing.
+- **Don't expect `flowable:class="..."` to hot-reload.** Documented above — JVM caches
+  `(initiatingLoader, name) → class`, and our `ClientAwareClassLoader` is a singleton. Tell
+  users to restart or use `${JavaTask}`.
+
+### What the editor needs (not implemented in this PR)
+
+The Flowable BPMN editor currently only knows about the `${JSTask}` delegate-expression pattern
+for the property-panel "delegate" entry. To make the `${JavaTask}` flow first-class in the UI,
+the property-panel template that today writes `${JSTask}` + `handler` field would also need a
+"Java" option that writes `${JavaTask}` + `handler` field with the FQN. Until that's done, users
+type the delegate expression manually — both styles work at runtime regardless.
+
+---
+
+## 6. Project version pinning
 
 - AngularJS: **1.8.2** via `org.webjars:angularjs` (in `components/resources/platform-core/pom.xml`).
 - jQuery: **2.0.3** (bundled in `components/ui/editor-bpm/.../scripts/jquery-2.0.3.min.js`). Upgrade is decoupled from the BlimpKit migration but the jQuery 2.x → 3.x upgrade is a candidate follow-up.

--- a/components/engine/engine-bpm-flowable/pom.xml
+++ b/components/engine/engine-bpm-flowable/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-engine-javascript</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-java</artifactId>
+        </dependency>
 
         <!-- IDE -->
         <dependency>

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmFlowableConfig.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/BpmFlowableConfig.java
@@ -15,6 +15,7 @@ import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.components.engine.bpm.BpmProvider;
 import org.eclipse.dirigible.components.engine.bpm.flowable.diagram.DirigibleProcessDiagramGenerator;
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoaderHolder;
 import org.flowable.engine.ProcessEngine;
 import org.flowable.engine.ProcessEngineConfiguration;
 import org.flowable.spring.SpringProcessEngineConfiguration;
@@ -46,6 +47,13 @@ public class BpmFlowableConfig {
      */
     @Autowired
     private DataSourcesManager datasourceManager;
+
+    /**
+     * Holder of the currently-installed client {@code .java} ClassLoader. Used to teach Flowable's
+     * delegate-class resolution about user-compiled classes.
+     */
+    @Autowired
+    private ClientClassLoaderHolder clientClassLoaderHolder;
 
     @Bean("BPM_PROVIDER")
     BpmProvider getBpmProvider(BpmProviderFlowable bpmProviderFlowable) {
@@ -95,6 +103,12 @@ public class BpmFlowableConfig {
 
         List<VariableType> customPreVariableTypes = List.of(new SimpleCollectionVariableType());
         config.setCustomPreVariableTypes(customPreVariableTypes);
+
+        // Allow flowable:class="my.fqn.MyClass" on a service task to resolve to client .java code
+        // compiled by engine-java. The parent stays the platform CL so Flowable + Dirigible classes
+        // remain reachable; the ClientClassLoader is consulted only when the parent fails.
+        ClassLoader parent = BpmFlowableConfig.class.getClassLoader();
+        config.setClassLoader(new ClientAwareClassLoader(parent, clientClassLoaderHolder));
 
         return config;
     }

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/ClientAwareClassLoader.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/ClientAwareClassLoader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.config;
+
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoader;
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoaderHolder;
+
+/**
+ * ClassLoader handed to Flowable so {@code flowable:class="my.fqn.MyClass"} on a service task can
+ * resolve to a class compiled from a {@code .java} file in the user's project.
+ *
+ * <p>
+ * Resolution order on {@link #findClass(String)}:
+ * <ol>
+ * <li>Defer to the parent (platform) classloader — every {@code dirigible-*} class and every
+ * Flowable / Spring class is reachable here.</li>
+ * <li>If the parent does not have it, consult the current {@link ClientClassLoader} (or fail with
+ * {@link ClassNotFoundException} if no rebuild has happened yet).</li>
+ * </ol>
+ *
+ * <p>
+ * The holder is hot-swapped on every client rebuild, so {@link #findClass(String)} sees the latest
+ * generation on first resolution. The JVM, however, records this loader as an <em>initiating
+ * loader</em> for every name it has resolved through {@code findClass}; subsequent
+ * {@code Class.forName(name, true, this)} calls from Flowable bypass {@code findClass} and return
+ * the cached class from the previous generation. Hot-reload safety for the {@code class=} path
+ * therefore requires a process restart. Users that need bulletproof hot-reload should use the
+ * {@code ${JavaTask}} delegate-expression path (see {@code DirigibleJavaCallDelegate}) which
+ * resolves through the holder every execution.
+ */
+final class ClientAwareClassLoader extends ClassLoader {
+
+    private final ClientClassLoaderHolder holder;
+
+    ClientAwareClassLoader(ClassLoader parent, ClientClassLoaderHolder holder) {
+        super(parent);
+        this.holder = holder;
+    }
+
+    @Override
+    protected Class<?> findClass(String name) throws ClassNotFoundException {
+        ClientClassLoader current = holder.current();
+        if (current == null) {
+            throw new ClassNotFoundException(name);
+        }
+        return current.loadClass(name);
+    }
+
+}

--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/delegate/DirigibleJavaCallDelegate.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/delegate/DirigibleJavaCallDelegate.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.bpm.flowable.delegate;
+
+import static org.eclipse.dirigible.components.engine.bpm.flowable.dto.ActionData.Action.SKIP;
+import static org.eclipse.dirigible.components.engine.bpm.flowable.service.BpmService.DIRIGIBLE_BPM_INTERNAL_SKIP_STEP;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
+import org.eclipse.dirigible.components.open.telemetry.OpenTelemetryProvider;
+import org.eclipse.dirigible.components.tracing.TaskState;
+import org.eclipse.dirigible.components.tracing.TaskStateUtil;
+import org.eclipse.dirigible.components.tracing.TaskType;
+import org.eclipse.dirigible.components.tracing.TracingFacade;
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoader;
+import org.eclipse.dirigible.engine.java.runtime.ClientClassLoaderHolder;
+import org.flowable.common.engine.impl.el.FixedValue;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+
+/**
+ * Counterpart of {@link DirigibleCallDelegate} for client Java tasks.
+ *
+ * <p>
+ * Bound to the Spring bean name {@code JavaTask} so BPMN service tasks can use
+ * {@code flowable:delegateExpression="${JavaTask}"} together with a {@code handler} field whose
+ * value is the fully-qualified class name of a client class implementing {@link JavaDelegate}. The
+ * class is resolved through the currently-installed {@link ClientClassLoader} (managed by
+ * {@link ClientClassLoaderHolder}), instantiated via its public no-arg constructor on every
+ * execution, and invoked with the engine-provided {@link DelegateExecution}.
+ *
+ * <p>
+ * For the alternative {@code flowable:class="..."} approach, see the classloader configured on the
+ * {@code SpringProcessEngineConfiguration} in
+ * {@code org.eclipse.dirigible.components.engine.bpm.flowable.config.BpmFlowableConfig}.
+ */
+// don't change the name of the bean or the class name and package
+// otherwise processes will stop working
+@Component("JavaTask")
+public class DirigibleJavaCallDelegate implements JavaDelegate {
+
+    private final TenantContext tenantContext;
+    private final ClientClassLoaderHolder clientClassLoaderHolder;
+
+    /** The handler. */
+    private FixedValue handler;
+
+    DirigibleJavaCallDelegate(TenantContext tenantContext, ClientClassLoaderHolder clientClassLoaderHolder) {
+        this.tenantContext = tenantContext;
+        this.clientClassLoaderHolder = clientClassLoaderHolder;
+    }
+
+    public FixedValue getHandler() {
+        return handler;
+    }
+
+    public void setHandler(FixedValue handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        TaskState taskState = null;
+        if (TracingFacade.isTracingEnabled()) {
+            Map<String, String> input = TaskStateUtil.getVariables(execution.getVariables());
+            taskState = TracingFacade.taskStarted(TaskType.BPM,
+                    execution.getProcessInstanceBusinessKey() != null ? execution.getProcessInstanceBusinessKey()
+                            : execution.getProcessInstanceId(),
+                    execution.getCurrentFlowElement()
+                             .getName(),
+                    input);
+            taskState.setDefinition(execution.getProcessDefinitionId());
+            taskState.setInstance(execution.getProcessInstanceId());
+            taskState.setTenant(execution.getTenantId());
+        }
+        Tracer tracer = OpenTelemetryProvider.get()
+                                             .getTracer("eclipse-dirigible");
+        Span span = tracer.spanBuilder("flowable_java_task_execution")
+                          .startSpan();
+        try (Scope scope = span.makeCurrent()) {
+            addSpanAttributes(execution, span);
+
+            executeInternal(execution);
+
+            if (TracingFacade.isTracingEnabled()) {
+                Map<String, String> output = TaskStateUtil.getVariables(execution.getVariables());
+                TracingFacade.taskSuccessful(taskState, output);
+            }
+        } catch (RuntimeException e) {
+            if (TracingFacade.isTracingEnabled()) {
+                Map<String, String> output = TaskStateUtil.getVariables(execution.getVariables());
+                TracingFacade.taskFailed(taskState, output, e.getMessage());
+            }
+            span.recordException(e);
+            span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR, "Exception occurred during Java task execution");
+
+            throw e;
+        } finally {
+            span.end();
+        }
+    }
+
+    private void addSpanAttributes(DelegateExecution execution, Span span) {
+        span.setAttribute("execution.id", execution.getId());
+        span.setAttribute("process.instance.id", execution.getProcessInstanceId());
+        span.setAttribute("process.instance.business.key", execution.getProcessInstanceBusinessKey());
+        span.setAttribute("process.definition.id", execution.getProcessDefinitionId());
+    }
+
+    private void executeInternal(DelegateExecution execution) {
+        String action = (String) execution.getVariable(DIRIGIBLE_BPM_INTERNAL_SKIP_STEP);
+        if (SKIP.getActionName()
+                .equals(action)) {
+            execution.removeVariable(DIRIGIBLE_BPM_INTERNAL_SKIP_STEP);
+            return;
+        }
+
+        if (handler == null) {
+            throw new BpmnRuntimeException("Handler cannot be null at the Java call delegate.");
+        }
+        String fqn = handler.getExpressionText();
+        if (fqn == null || fqn.isBlank()) {
+            throw new BpmnRuntimeException("Handler cannot be blank at the Java call delegate.");
+        }
+        String tenantId = getTenantId(execution);
+        executeJavaHandlerInTenantContext(tenantId, fqn.trim(), execution);
+    }
+
+    private static String getTenantId(DelegateExecution execution) {
+        String tenantId = execution.getTenantId();
+        if (null == tenantId) {
+            throw new IllegalStateException("Missing tenant id for execution with id [" + execution.getId() + "], process instance id ["
+                    + execution.getProcessInstanceId() + "] and process definition id [" + execution.getProcessDefinitionId() + "]");
+        }
+        return tenantId;
+    }
+
+    @Transactional
+    private void executeJavaHandlerInTenantContext(String tenantId, String fqn, DelegateExecution execution) {
+        tenantContext.execute(tenantId, () -> {
+            executeJavaHandler(fqn, execution);
+            return null;
+        });
+    }
+
+    private void executeJavaHandler(String fqn, DelegateExecution execution) {
+        Span.current()
+            .setAttribute("handler", fqn)
+            .setAttribute("tenantId", tenantContext.getCurrentTenant()
+                                                   .getId());
+
+        ClientClassLoader loader = clientClassLoaderHolder.current();
+        if (loader == null) {
+            throw new BpmnRuntimeException("No client Java code has been compiled yet; cannot resolve handler [" + fqn
+                    + "]. Add a .java source under " + "the project's registry path and let the synchronizer pick it up.");
+        }
+
+        Class<?> handlerClass;
+        try {
+            handlerClass = loader.loadClass(fqn);
+        } catch (ClassNotFoundException e) {
+            throw new BpmnRuntimeException("Client Java class [" + fqn + "] is not loaded. Ensure the source is present under "
+                    + "/registry/public/<project>/ and compiles successfully.", e);
+        }
+
+        if (!JavaDelegate.class.isAssignableFrom(handlerClass)) {
+            throw new BpmnRuntimeException("Client Java class [" + fqn + "] does not implement " + JavaDelegate.class.getName() + ".");
+        }
+
+        JavaDelegate delegate;
+        try {
+            delegate = (JavaDelegate) handlerClass.getDeclaredConstructor()
+                                                  .newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new BpmnRuntimeException(
+                    "Failed to instantiate client Java class [" + fqn + "]. A public no-arg " + "constructor is required.", e);
+        }
+
+        delegate.execute(execution);
+    }
+
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaBpmnIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaBpmnIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.restassured.http.ContentType;
+
+/**
+ * End-to-end test for the Java BPMN handler integration: drops a {@code .java} delegate and a
+ * {@code .bpmn} process into the registry, lets the synchronizers compile + deploy, then starts the
+ * process through the public BPM REST endpoint and asserts that both delegate paths ran.
+ *
+ * <p>
+ * Two service tasks exercise both handler styles within the same process:
+ * <ul>
+ * <li>{@code flowable:delegateExpression="${JavaTask}"} with a {@code handler} field carrying the
+ * FQN — resolved by {@code DirigibleJavaCallDelegate} via {@code ClientClassLoaderHolder}.</li>
+ * <li>{@code flowable:class="com.acme.PureJavaTask"} — resolved through Flowable's own
+ * {@code ReflectUtil.loadClass} via the {@code ClientAwareClassLoader} installed on the engine
+ * config.</li>
+ * </ul>
+ * Each delegate writes a process variable; the test asserts both variables made it into the
+ * historic record, proving end-to-end execution.
+ */
+class JavaBpmnIT extends IntegrationTest {
+
+    private static final String PROJECT = "java-bpmn-it";
+    private static final String PROCESS_KEY = "java-bpmn-it-process";
+
+    private static final String JAVA_TASK_FQN = "com.acme.MyJavaTask";
+    private static final String PURE_TASK_FQN = "com.acme.PureJavaTask";
+
+    private static final String JAVA_TASK_SOURCE_LOCATION = "/" + PROJECT + "/" + JAVA_TASK_FQN.replace('.', '/') + ".java";
+    private static final String PURE_TASK_SOURCE_LOCATION = "/" + PROJECT + "/" + PURE_TASK_FQN.replace('.', '/') + ".java";
+    private static final String BPMN_LOCATION = "/" + PROJECT + "/process.bpmn";
+
+    private static final String JAVA_TASK_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + JAVA_TASK_SOURCE_LOCATION;
+    private static final String PURE_TASK_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + PURE_TASK_SOURCE_LOCATION;
+    private static final String BPMN_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + BPMN_LOCATION;
+
+    private static final long ASSERTION_TIMEOUT_SECONDS = 60;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void start_process_executes_both_java_delegate_styles() {
+        write(JAVA_TASK_REGISTRY_PATH, javaTaskSource(), "text/x-java");
+        write(PURE_TASK_REGISTRY_PATH, pureTaskSource(), "text/x-java");
+        write(BPMN_REGISTRY_PATH, bpmnSource(), "application/xml");
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        String processInstanceId = startProcess();
+        assertHistoricVariable(processInstanceId, "javaTaskRan", "yes");
+        assertHistoricVariable(processInstanceId, "pureTaskRan", "yes");
+    }
+
+    @AfterEach
+    void cleanup() {
+        boolean removed = false;
+        for (String path : new String[] {BPMN_REGISTRY_PATH, JAVA_TASK_REGISTRY_PATH, PURE_TASK_REGISTRY_PATH}) {
+            if (repository.hasResource(path)) {
+                repository.removeResource(path);
+                removed = true;
+            }
+        }
+        if (removed) {
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private void write(String path, String content, String contentType) {
+        repository.createResource(path, content.getBytes(StandardCharsets.UTF_8), false, contentType, true);
+    }
+
+    private String startProcess() {
+        String body = "{\"processDefinitionKey\":\"" + PROCESS_KEY + "\",\"businessKey\":\"java-bpmn-it\",\"parameters\":\"{}\"}";
+        return restAssuredExecutor.executeWithResult(() -> given().contentType(ContentType.JSON)
+                                                                  .body(body)
+                                                                  .when()
+                                                                  .post("/services/bpm/bpm-processes/instance")
+                                                                  .then()
+                                                                  .statusCode(200)
+                                                                  .extract()
+                                                                  .asString());
+    }
+
+    private void assertHistoricVariable(String processInstanceId, String name, String expectedValue) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/bpm/bpm-processes/historic-instances/" + processInstanceId + "/variables")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("variableName", hasItem(name))
+                                                 .body("find { it.variableName == '" + name + "' }.value", equalTo(expectedValue)),
+                ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    private static String javaTaskSource() {
+        return """
+                package com.acme;
+                import org.flowable.engine.delegate.DelegateExecution;
+                import org.flowable.engine.delegate.JavaDelegate;
+                public class MyJavaTask implements JavaDelegate {
+                    @Override
+                    public void execute(DelegateExecution execution) {
+                        execution.setVariable("javaTaskRan", "yes");
+                    }
+                }
+                """;
+    }
+
+    private static String pureTaskSource() {
+        return """
+                package com.acme;
+                import org.flowable.engine.delegate.DelegateExecution;
+                import org.flowable.engine.delegate.JavaDelegate;
+                public class PureJavaTask implements JavaDelegate {
+                    @Override
+                    public void execute(DelegateExecution execution) {
+                        execution.setVariable("pureTaskRan", "yes");
+                    }
+                }
+                """;
+    }
+
+    private static String bpmnSource() {
+        return """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                             xmlns:flowable="http://flowable.org/bpmn"
+                             targetNamespace="http://www.flowable.org/processdef">
+                  <process id="%s" name="Java BPMN IT" isExecutable="true">
+                    <startEvent id="start"/>
+                    <sequenceFlow id="f1" sourceRef="start" targetRef="java-task"/>
+                    <serviceTask id="java-task" name="JavaTask delegate" flowable:delegateExpression="${JavaTask}">
+                      <extensionElements>
+                        <flowable:field name="handler">
+                          <flowable:string><![CDATA[%s]]></flowable:string>
+                        </flowable:field>
+                      </extensionElements>
+                    </serviceTask>
+                    <sequenceFlow id="f2" sourceRef="java-task" targetRef="pure-task"/>
+                    <serviceTask id="pure-task" name="Pure class delegate" flowable:class="%s"/>
+                    <sequenceFlow id="f3" sourceRef="pure-task" targetRef="end"/>
+                    <endEvent id="end"/>
+                  </process>
+                </definitions>
+                """.formatted(PROCESS_KEY, JAVA_TASK_FQN, PURE_TASK_FQN);
+    }
+
+}


### PR DESCRIPTION
## Summary

Mirrors the existing `${JSTask}` JavaScript delegate for the Java side. Lets a BPMN service task invoke a client `.java` class compiled by `engine-java`. Two complementary entry points ship together:

- **Delegate expression** (same UI as `${JSTask}`):
  `flowable:delegateExpression="${JavaTask}"` + `<flowable:field name="handler"><flowable:string>com.acme.MyTask</flowable:string></flowable:field>`
  → handled by `DirigibleJavaCallDelegate` (`@Component("JavaTask")`).
- **Pure Flowable class binding** (idiomatic Flowable):
  `flowable:class="com.acme.MyTask"` → resolved via Flowable's `ReflectUtil.loadClass` through a delegating `ClientAwareClassLoader` installed on `SpringProcessEngineConfiguration`.

User classes implement `org.flowable.engine.delegate.JavaDelegate` (no new abstraction layer). Public no-arg constructor required. Instantiated per execution.

## Findings — does pure `flowable:class="..."` work out of the box?

No. Flowable's `ReflectUtil.loadClass` only consults: the engine's `customClassLoader` → TCCL → its own classloader. None of those reach Dirigible's `ClientClassLoader` (managed by `ClientClassLoaderHolder`, hot-swapped on every rebuild). This PR installs a one-line wrapper (`ClientAwareClassLoader`) on the engine config so Flowable's lookup chain includes the user-compiled classes.

**Hot-reload caveat for the `class=` path:** `ClientAwareClassLoader` is a Spring singleton. Once the JVM records it as an *initiating loader* for an FQN, `Class.forName` returns the cached class indefinitely — a rebuild won't be visible until restart. The `\${JavaTask}` path doesn't have this limitation (it goes through the holder every execution). Documented on the classloader's JavaDoc.

## Files

- `components/engine/engine-bpm-flowable/pom.xml` — adds dep on `dirigible-components-engine-java` (no circular dep).
- `.../engine/bpm/flowable/delegate/DirigibleJavaCallDelegate.java` *(new)* — `JavaTask` bean. Same OpenTelemetry/tracing/tenant-context plumbing as `DirigibleCallDelegate`.
- `.../engine/bpm/flowable/config/ClientAwareClassLoader.java` *(new)*.
- `.../engine/bpm/flowable/config/BpmFlowableConfig.java` — `config.setClassLoader(new ClientAwareClassLoader(parent, clientClassLoaderHolder))`.
- `tests/tests-integrations/.../api/JavaBpmnIT.java` *(new)* — HTTP-only IT (no Selenide). Drops two `JavaDelegate`-implementing `.java` sources and a `.bpmn` with two service tasks (one per style), calls `SynchronizationProcessor.forceProcessSynchronizers()`, posts to `/services/bpm/bpm-processes/instance`, asserts both delegates wrote their side-effect variables on the historic record. Runs in ~25 s.
- `CLAUDE_BPMN.md` §5 — context + dead-ends (in particular: `JavaClassRegistry` only holds `JavaHandler` implementations, `StartProcessInstanceData.parameters` is a JSON-string not an Object, `HistoricVariableInstance` JSON field is `variableName` not `name`).

## Test plan

- [x] `mvn formatter:validate` on touched modules — clean.
- [x] `mvn -pl tests/tests-integrations install -P integration-tests -Dit.test=JavaBpmnIT -Dselenide.headless=true` — passes (~25 s).
- [x] `mvn -pl tests/tests-integrations install -P integration-tests -Dit.test="JavaEngineIT,BpmnMultitenancyIT" -Dselenide.headless=true` — 5/5 pass, no regressions.

## What's not in this PR

The Flowable BPMN editor's property panel doesn't yet offer a "Java" option that auto-writes `\${JavaTask}` + handler-field with the FQN — for now users type the delegate expression by hand (both styles work at runtime regardless). UI surface change is its own follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)