### PR TITLE
[Security] Support OAuth2 Client Credentials (M2M) authorization via scope-to-role Mapping

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/SynchronizersOrder.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/SynchronizersOrder.java
@@ -23,6 +23,9 @@ public interface SynchronizersOrder {
     /** The role. */
     int ROLE = 30;
 
+    /** The scope. */
+    int SCOPE = 35;
+
     /** The access. */
     int ACCESS = 40;
 

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/util/ScopeAuthoritiesUtil.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/util/ScopeAuthoritiesUtil.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Translates OAuth2 {@code scope} claim values into Dirigible role names.
+ *
+ * <p>
+ * OAuth2 Client Credentials (machine-to-machine) tokens carry no user, no groups and no id token -
+ * the only access signal available is the {@code scope} claim. This utility derives Dirigible role
+ * names from those scopes so that the standard {@link AuthoritiesUtil} role-authority machinery can
+ * authorize M2M requests against role-protected endpoints.
+ *
+ * <p>
+ * The logic is intentionally free of any Spring Security / OAuth2 types so it can be reused by
+ * every resource-server security configuration (Cognito, Keycloak, ...) and unit tested in
+ * isolation.
+ */
+public final class ScopeAuthoritiesUtil {
+
+    /**
+     * The separator between a resource-server identifier and the bare scope name in a Cognito scope
+     * value.
+     */
+    private static final char SCOPE_SEPARATOR = '/';
+
+    private ScopeAuthoritiesUtil() {}
+
+    /**
+     * Extracts the bare scope name from a raw scope value.
+     *
+     * <p>
+     * AWS Cognito qualifies custom scopes as {@code <resource-server-identifier>/<scope-name>}, where
+     * the resource-server identifier carries a generated random suffix and therefore must not be
+     * assumed. The bare scope name is the substring after the <em>last</em> {@code /}. Standard OIDC
+     * scopes ({@code openid}, {@code email}, {@code profile}, {@code aws.cognito.signin.user.admin},
+     * ...) contain no {@code /} and are not roles.
+     *
+     * @param rawScope a single raw scope value
+     * @return the bare scope name, or {@code null} if the value carries no {@code /} (i.e. is not a
+     *         role-bearing scope)
+     */
+    public static String extractScopeName(String rawScope) {
+        if (rawScope == null) {
+            return null;
+        }
+        String trimmed = rawScope.trim();
+        int separatorIndex = trimmed.lastIndexOf(SCOPE_SEPARATOR);
+        if (separatorIndex < 0) {
+            return null;
+        }
+        String scopeName = trimmed.substring(separatorIndex + 1);
+        return scopeName.isEmpty() ? null : scopeName;
+    }
+
+    /**
+     * Resolves the Dirigible role names granted by a collection of raw scope values.
+     *
+     * <p>
+     * For each raw scope the bare scope name is derived (see {@link #extractScopeName(String)}); scopes
+     * that are not role-bearing are ignored. Each bare scope name is then mapped to role names:
+     * <ul>
+     * <li>if the scope name has an entry in {@code scopeToRoles}, it expands to the role names declared
+     * there;</li>
+     * <li>otherwise it falls back to a 1:1 mapping - the scope name is the role name.</li>
+     * </ul>
+     *
+     * @param rawScopes the raw scope values (e.g. from the space-delimited {@code scope} claim); may be
+     *        {@code null}
+     * @param scopeToRoles the configured scope-name to role-names mappings; may be {@code null} or
+     *        empty
+     * @return the set of resolved Dirigible role names (never {@code null})
+     */
+    public static Set<String> resolveRoleNames(Collection<String> rawScopes, Map<String, ? extends Collection<String>> scopeToRoles) {
+        if (rawScopes == null || rawScopes.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Map<String, ? extends Collection<String>> mappings = scopeToRoles == null ? Collections.emptyMap() : scopeToRoles;
+        Set<String> roleNames = new LinkedHashSet<>();
+        for (String rawScope : rawScopes) {
+            String scopeName = extractScopeName(rawScope);
+            if (scopeName == null) {
+                continue;
+            }
+            Collection<String> mappedRoles = mappings.get(scopeName);
+            if (mappedRoles != null && !mappedRoles.isEmpty()) {
+                roleNames.addAll(mappedRoles);
+            } else {
+                roleNames.add(scopeName);
+            }
+        }
+        return roleNames;
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/util/ScopeAuthoritiesUtilTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/util/ScopeAuthoritiesUtilTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Class ScopeAuthoritiesUtilTest.
+ */
+class ScopeAuthoritiesUtilTest {
+
+    @Test
+    void extractScopeNameTakesSubstringAfterLastSlash() {
+        assertEquals("ADMINISTRATOR", ScopeAuthoritiesUtil.extractScopeName("sample-resource-server-1a2b3c/ADMINISTRATOR"));
+        assertEquals("sample-app.Orders.OrderFullAccess",
+                ScopeAuthoritiesUtil.extractScopeName("sample-resource-server-1a2b3c/sample-app.Orders.OrderFullAccess"));
+    }
+
+    @Test
+    void extractScopeNameIgnoresStandardOidcScopes() {
+        assertNull(ScopeAuthoritiesUtil.extractScopeName("openid"));
+        assertNull(ScopeAuthoritiesUtil.extractScopeName("email"));
+        assertNull(ScopeAuthoritiesUtil.extractScopeName("profile"));
+        assertNull(ScopeAuthoritiesUtil.extractScopeName("aws.cognito.signin.user.admin"));
+        assertNull(ScopeAuthoritiesUtil.extractScopeName(null));
+    }
+
+    @Test
+    void resolveRoleNamesMapsScopesOneToOneAndIgnoresOidcScopes() {
+        List<String> rawScopes = Arrays.asList("rs-xyz/ADMINISTRATOR", "rs-xyz/sample-app.Orders.OrderFullAccess", "openid");
+
+        Set<String> roleNames = ScopeAuthoritiesUtil.resolveRoleNames(rawScopes, Collections.emptyMap());
+
+        assertEquals(Set.of("ADMINISTRATOR", "sample-app.Orders.OrderFullAccess"), roleNames);
+    }
+
+    @Test
+    void resolveRoleNamesExpandsMappedScopeToMultipleRolesAndFallsBackForUnmapped() {
+        Map<String, List<String>> mappings =
+                Map.of("orders-manage", List.of("sample-app.Orders.OrderFullAccess", "sample-app.Orders.OrderReadOnly"));
+        List<String> rawScopes = Arrays.asList("rs-xyz/orders-manage", "rs-xyz/ADMINISTRATOR");
+
+        Set<String> roleNames = ScopeAuthoritiesUtil.resolveRoleNames(rawScopes, mappings);
+
+        assertTrue(roleNames.contains("sample-app.Orders.OrderFullAccess"));
+        assertTrue(roleNames.contains("sample-app.Orders.OrderReadOnly"));
+        assertTrue(roleNames.contains("ADMINISTRATOR"));
+        assertEquals(3, roleNames.size());
+    }
+
+    @Test
+    void resolveRoleNamesReturnsEmptyForNullOrEmptyInput() {
+        assertTrue(ScopeAuthoritiesUtil.resolveRoleNames(null, Collections.emptyMap())
+                                       .isEmpty());
+        assertTrue(ScopeAuthoritiesUtil.resolveRoleNames(Collections.emptyList(), null)
+                                       .isEmpty());
+    }
+}

--- a/components/engine/engine-security/pom.xml
+++ b/components/engine/engine-security/pom.xml
@@ -25,6 +25,14 @@
             <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-core-repository</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/domain/Scope.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/domain/Scope.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+
+import com.google.gson.annotations.Expose;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+
+/**
+ * The Class Scope.
+ *
+ * <p>
+ * Maps an OAuth2 (M2M / client-credentials) scope name to one or more Dirigible role names. Loaded
+ * from {@code *.scopes} artefacts so that a single scope can grant several roles; scopes without a
+ * mapping fall back to a 1:1 scope-name-is-role-name resolution.
+ */
+@Entity
+@Table(name = "DIRIGIBLE_SECURITY_SCOPES")
+public class Scope extends Artefact {
+
+    /**
+     * The Constant ARTEFACT_TYPE.
+     */
+    public static final String ARTEFACT_TYPE = "scope";
+
+    /**
+     * The id.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "SCOPE_ID", nullable = false)
+    private Long id;
+
+    /**
+     * The bare scope name (the part after the last '/' of an OAuth2 scope value).
+     */
+    @Column(name = "SCOPE_SCOPE", columnDefinition = "VARCHAR", nullable = false, length = 255)
+    @Expose
+    private String scope;
+
+    /**
+     * The role names granted by this scope.
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "DIRIGIBLE_SECURITY_SCOPE_ROLES", joinColumns = @JoinColumn(name = "SCOPEROLE_SCOPE_ID"))
+    @Column(name = "SCOPEROLE_ROLE", columnDefinition = "VARCHAR", length = 255)
+    @Expose
+    private Set<String> roles = new HashSet<>();
+
+    /**
+     * Instantiates a new scope.
+     *
+     * @param location the location
+     * @param name the name
+     * @param description the description
+     * @param scope the scope
+     * @param roles the roles
+     */
+    public Scope(String location, String name, String description, String scope, Set<String> roles) {
+        super(location, name, ARTEFACT_TYPE, description, null);
+        this.scope = scope;
+        this.roles = roles;
+    }
+
+    /**
+     * Instantiates a new scope.
+     */
+    public Scope() {
+        super();
+    }
+
+    /**
+     * Gets the id.
+     *
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the id.
+     *
+     * @param id the new id
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the scope.
+     *
+     * @return the scope
+     */
+    public String getScope() {
+        return scope;
+    }
+
+    /**
+     * Sets the scope.
+     *
+     * @param scope the new scope
+     */
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    /**
+     * Gets the roles.
+     *
+     * @return the roles
+     */
+    public Set<String> getRoles() {
+        return roles;
+    }
+
+    /**
+     * Sets the roles.
+     *
+     * @param roles the new roles
+     */
+    public void setRoles(Set<String> roles) {
+        this.roles = roles;
+    }
+
+    /**
+     * To string.
+     *
+     * @return the string
+     */
+    @Override
+    public String toString() {
+        return "Scope{" + "id=" + id + ", scope='" + scope + '\'' + ", roles=" + roles + ", location='" + location + '\'' + ", name='"
+                + name + '\'' + ", type='" + type + '\'' + ", description='" + description + '\'' + ", key='" + key + '\''
+                + ", dependencies='" + dependencies + '\'' + ", createdBy=" + createdBy + ", createdAt=" + createdAt + ", updatedBy="
+                + updatedBy + ", updatedAt=" + updatedAt + '}';
+    }
+}

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/endpoint/ScopeEndpoint.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/endpoint/ScopeEndpoint.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.endpoint;
+
+import java.util.List;
+
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.security.domain.Scope;
+import org.eclipse.dirigible.components.security.service.ScopeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.annotation.security.RolesAllowed;
+
+/**
+ * The Class ScopeEndpoint.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_SECURITY)
+@RolesAllowed({"ADMINISTRATOR", "OPERATOR"})
+public class ScopeEndpoint extends BaseEndpoint {
+
+    /**
+     * The scope service.
+     */
+    @Autowired
+    private ScopeService scopeService;
+
+    /**
+     * Gets the all.
+     *
+     * @return the all
+     */
+    @GetMapping("/scopes")
+    public ResponseEntity<List<Scope>> getAll() {
+        return ResponseEntity.ok(scopeService.getAll());
+    }
+}

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/oauth/ScopeRoleJwtAuthoritiesConverter.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/oauth/ScopeRoleJwtAuthoritiesConverter.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.http.roles.Roles;
+import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
+import org.eclipse.dirigible.components.base.util.ScopeAuthoritiesUtil;
+import org.eclipse.dirigible.components.security.service.ScopeService;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+/**
+ * Converts the {@code scope} claim of a resource-server (Bearer) JWT into Dirigible role
+ * authorities.
+ *
+ * <p>
+ * OAuth2 Client Credentials (machine-to-machine) tokens carry no user, no groups and no id token,
+ * so the only access signal is the {@code scope} claim. Each scope's bare name (the part after the
+ * last {@code /}) is mapped to Dirigible roles - 1:1 by default, or expanded through a
+ * {@code *.scopes} artefact when one scope must grant several roles. The resulting authorities use
+ * the same {@code ROLE_} convention as {@link AuthoritiesUtil}, so role-protected endpoints
+ * authorize M2M requests exactly as they do interactive ones.
+ *
+ * <p>
+ * Token validation (signature, issuer, jwk-set) is unaffected - this converter only derives
+ * authorities from the already validated claims. It is shared by every resource-server security
+ * configuration (Cognito, Keycloak, ...).
+ */
+@Component
+public class ScopeRoleJwtAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+    /** The standard OAuth2 scope claim. */
+    private static final String SCOPE_CLAIM = "scope";
+
+    /** The alternative scope claim used by some authorization servers. */
+    private static final String SCP_CLAIM = "scp";
+
+    /** The scope service. */
+    private final ScopeService scopeService;
+
+    /** Whether trial mode is enabled. */
+    private final boolean trialModeEnabled;
+
+    /**
+     * Instantiates a new scope-role JWT authorities converter.
+     *
+     * @param scopeService the scope service
+     */
+    public ScopeRoleJwtAuthoritiesConverter(ScopeService scopeService) {
+        this.scopeService = scopeService;
+        this.trialModeEnabled = DirigibleConfig.TRIAL_ENABLED.getBooleanValue();
+    }
+
+    /**
+     * Convert.
+     *
+     * @param jwt the validated JWT
+     * @return the derived role authorities
+     */
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt jwt) {
+        if (trialModeEnabled) {
+            return new HashSet<>(AuthoritiesUtil.toAuthorities(Arrays.stream(Roles.values())
+                                                                     .map(Roles::getRoleName)
+                                                                     .collect(Collectors.toSet())));
+        }
+        Collection<String> rawScopes = extractScopes(jwt);
+        Set<String> roleNames = ScopeAuthoritiesUtil.resolveRoleNames(rawScopes, scopeService.getScopeRolesMappings());
+        return new HashSet<>(AuthoritiesUtil.toAuthorities(roleNames));
+    }
+
+    /**
+     * Extracts the raw scope values from the {@code scope} (or {@code scp}) claim, which may be either
+     * a space-delimited string or a list.
+     *
+     * @param jwt the JWT
+     * @return the raw scope values
+     */
+    private Collection<String> extractScopes(Jwt jwt) {
+        Object scopeClaim = jwt.getClaim(SCOPE_CLAIM);
+        if (scopeClaim == null) {
+            scopeClaim = jwt.getClaim(SCP_CLAIM);
+        }
+        if (scopeClaim instanceof String scopeString) {
+            return Arrays.stream(scopeString.trim()
+                                            .split("\\s+"))
+                         .filter(token -> !token.isEmpty())
+                         .collect(Collectors.toList());
+        }
+        if (scopeClaim instanceof Collection<?> scopeCollection) {
+            return scopeCollection.stream()
+                                  .filter(Objects::nonNull)
+                                  .map(Object::toString)
+                                  .collect(Collectors.toList());
+        }
+        return Collections.<String>emptyList();
+    }
+}

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/repository/ScopeRepository.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/repository/ScopeRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.repository;
+
+import org.eclipse.dirigible.components.base.artefact.ArtefactRepository;
+import org.eclipse.dirigible.components.security.domain.Scope;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The Interface ScopeRepository.
+ */
+@Repository("securityScopeRepository")
+public interface ScopeRepository extends ArtefactRepository<Scope, Long> {
+
+    /**
+     * Sets the running to all.
+     *
+     * @param running the new running to all
+     */
+    @Override
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE Scope SET running = :running")
+    void setRunningToAll(@Param("running") boolean running);
+}

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/service/ScopeService.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/service/ScopeService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.service;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.base.artefact.BaseArtefactService;
+import org.eclipse.dirigible.components.security.domain.Scope;
+import org.eclipse.dirigible.components.security.repository.ScopeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The Class ScopeService.
+ *
+ * <p>
+ * Owns the {@code *.scopes} artefacts that map an OAuth2 scope name to one or more Dirigible role
+ * names. The scope-to-roles view is consulted on every M2M (Bearer) request, so it is cached in
+ * memory and invalidated whenever the underlying artefacts change through synchronization.
+ */
+@Service
+@Transactional
+public class ScopeService extends BaseArtefactService<Scope, Long> {
+
+    /** Cached scope-name to role-names mappings; {@code null} means the cache has to be rebuilt. */
+    private volatile Map<String, Set<String>> scopeRolesCache;
+
+    /**
+     * Instantiates a new scope service.
+     *
+     * @param repository the repository
+     */
+    public ScopeService(ScopeRepository repository) {
+        super(repository);
+    }
+
+    /**
+     * Returns the scope-name to role-names mappings declared by the synchronized {@code *.scopes}
+     * artefacts.
+     *
+     * <p>
+     * The result is cached and rebuilt lazily after a change. A scope absent from this map is resolved
+     * 1:1 (the scope name is the role name) by the caller.
+     *
+     * @return an immutable-by-convention snapshot of the scope-to-roles mappings (never {@code null})
+     */
+    @Transactional(readOnly = true)
+    public Map<String, Set<String>> getScopeRolesMappings() {
+        Map<String, Set<String>> cache = scopeRolesCache;
+        if (cache == null) {
+            cache = buildScopeRolesMappings();
+            scopeRolesCache = cache;
+        }
+        return cache;
+    }
+
+    /**
+     * Builds the scope-to-roles mappings from the persisted scopes.
+     *
+     * @return the freshly built mappings
+     */
+    private Map<String, Set<String>> buildScopeRolesMappings() {
+        Map<String, Set<String>> mappings = new HashMap<>();
+        for (Scope scope : getAll()) {
+            if (scope.getScope() == null || scope.getRoles() == null || scope.getRoles()
+                                                                             .isEmpty()) {
+                continue;
+            }
+            mappings.computeIfAbsent(scope.getScope(), key -> new HashSet<>())
+                    .addAll(scope.getRoles());
+        }
+        return mappings;
+    }
+
+    /**
+     * Invalidates the cached scope-to-roles mappings.
+     */
+    public void clearCache() {
+        scopeRolesCache = null;
+    }
+
+    /**
+     * Save.
+     *
+     * @param scope the scope
+     * @return the scope
+     */
+    @Override
+    public Scope save(Scope scope) {
+        Scope saved = super.save(scope);
+        clearCache();
+        return saved;
+    }
+
+    /**
+     * Delete.
+     *
+     * @param scope the scope
+     */
+    @Override
+    public void delete(Scope scope) {
+        super.delete(scope);
+        clearCache();
+    }
+}

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/synchronizer/ScopesSynchronizer.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/synchronizer/ScopesSynchronizer.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.synchronizer;
+
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.eclipse.dirigible.components.base.artefact.topology.TopologyWrapper;
+import org.eclipse.dirigible.components.base.helpers.JsonHelper;
+import org.eclipse.dirigible.components.base.synchronizer.BaseSynchronizer;
+import org.eclipse.dirigible.components.base.synchronizer.SynchronizerCallback;
+import org.eclipse.dirigible.components.base.synchronizer.SynchronizersOrder;
+import org.eclipse.dirigible.components.security.domain.Scope;
+import org.eclipse.dirigible.components.security.service.ScopeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.List;
+
+/**
+ * The Class ScopesSynchronizer.
+ *
+ * <p>
+ * Loads {@code *.scopes} artefacts from projects into the {@code DIRIGIBLE_SECURITY_SCOPES} table
+ * so that one OAuth2 scope can grant several Dirigible roles. Mirrors {@link RolesSynchronizer}.
+ */
+@Component
+@Order(SynchronizersOrder.SCOPE)
+public class ScopesSynchronizer extends BaseSynchronizer<Scope, Long> {
+
+    /**
+     * The Constant FILE_EXTENSION_SECURITY_SCOPE.
+     */
+    public static final String FILE_EXTENSION_SECURITY_SCOPE = ".scopes";
+
+    /**
+     * The Constant logger.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(ScopesSynchronizer.class);
+
+    /**
+     * The scope service.
+     */
+    private final ScopeService scopeService;
+
+    /**
+     * The synchronization callback.
+     */
+    private SynchronizerCallback callback;
+
+    /**
+     * Instantiates a new scopes synchronizer.
+     *
+     * @param scopeService the scope service
+     */
+    @Autowired
+    public ScopesSynchronizer(ScopeService scopeService) {
+        this.scopeService = scopeService;
+    }
+
+    /**
+     * Checks if is accepted.
+     *
+     * @param type the artefact
+     * @return true, if is accepted
+     */
+    @Override
+    public boolean isAccepted(String type) {
+        return Scope.ARTEFACT_TYPE.equals(type);
+    }
+
+    /**
+     * Parse.
+     *
+     * @param location the location
+     * @param content the content
+     * @return the list
+     * @throws ParseException the parse exception
+     */
+    @Override
+    protected List<Scope> parseImpl(String location, byte[] content) throws ParseException {
+        Scope[] scopes = JsonHelper.fromJson(new String(content, StandardCharsets.UTF_8), Scope[].class);
+        int scopeIndex = 1;
+        for (Scope scope : scopes) {
+            Configuration.configureObject(scope);
+            scope.setLocation(location);
+            scope.setName(scope.getScope());
+            scope.setType(Scope.ARTEFACT_TYPE);
+            scope.updateKey();
+
+            try {
+                Scope maybe = getService().findByKey(scope.getKey());
+                if (maybe != null) {
+                    scope.setId(maybe.getId());
+                }
+                scope = getService().save(scope);
+            } catch (Exception e) {
+                if (logger.isErrorEnabled()) {
+                    logger.error(e.getMessage(), e);
+                }
+                if (logger.isErrorEnabled()) {
+                    logger.error("scope: {}", scope);
+                }
+                if (logger.isErrorEnabled()) {
+                    logger.error("content: {}", new String(content));
+                }
+                throw new ParseException(e.getMessage(), scopeIndex);
+            }
+            scopeIndex++;
+        }
+        return List.of(scopes);
+    }
+
+    /**
+     * Gets the service.
+     *
+     * @return the service
+     */
+    @Override
+    public ArtefactService<Scope, Long> getService() {
+        return scopeService;
+    }
+
+    /**
+     * Retrieve.
+     *
+     * @param location the location
+     * @return the list
+     */
+    @Override
+    public List<Scope> retrieve(String location) {
+        return getService().findByLocation(location);
+    }
+
+    /**
+     * Sets the status.
+     *
+     * @param artefact the artefact
+     * @param lifecycle the lifecycle
+     * @param error the error
+     */
+    @Override
+    public void setStatus(Scope artefact, ArtefactLifecycle lifecycle, String error) {
+        artefact.setLifecycle(lifecycle);
+        artefact.setError(error);
+        getService().save(artefact);
+    }
+
+    /**
+     * Complete.
+     *
+     * @param wrapper the wrapper
+     * @param flow the flow
+     * @return true, if successful
+     */
+    @Override
+    protected boolean completeImpl(TopologyWrapper<Scope> wrapper, ArtefactPhase flow) {
+        callback.registerState(this, wrapper, ArtefactLifecycle.CREATED);
+        return true;
+    }
+
+    /**
+     * Cleanup.
+     *
+     * @param scope the scope
+     */
+    @Override
+    public void cleanupImpl(Scope scope) {
+        try {
+            getService().delete(scope);
+        } catch (Exception e) {
+            callback.addError(e.getMessage());
+            callback.registerState(this, scope, ArtefactLifecycle.DELETED, e);
+        }
+    }
+
+    /**
+     * Sets the callback.
+     *
+     * @param callback the new callback
+     */
+    @Override
+    public void setCallback(SynchronizerCallback callback) {
+        this.callback = callback;
+    }
+
+    /**
+     * Gets the file extension.
+     *
+     * @return the file extension
+     */
+    @Override
+    public String getFileExtension() {
+        return FILE_EXTENSION_SECURITY_SCOPE;
+    }
+
+    /**
+     * Gets the artefact type.
+     *
+     * @return the artefact type
+     */
+    @Override
+    public String getArtefactType() {
+        return Scope.ARTEFACT_TYPE;
+    }
+}

--- a/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/oauth/ScopeRoleJwtAuthoritiesConverterTest.java
+++ b/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/oauth/ScopeRoleJwtAuthoritiesConverterTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.dirigible.components.security.service.ScopeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * The Class ScopeRoleJwtAuthoritiesConverterTest.
+ */
+@ExtendWith(MockitoExtension.class)
+class ScopeRoleJwtAuthoritiesConverterTest {
+
+    @Mock
+    private ScopeService scopeService;
+
+    private Jwt jwt(String scopeClaim) {
+        return Jwt.withTokenValue("token")
+                  .header("alg", "none")
+                  .issuedAt(Instant.EPOCH)
+                  .expiresAt(Instant.EPOCH.plusSeconds(3600))
+                  .claim("scope", scopeClaim)
+                  .build();
+    }
+
+    private Set<String> authorityNames(Collection<GrantedAuthority> authorities) {
+        return authorities.stream()
+                          .map(GrantedAuthority::getAuthority)
+                          .collect(Collectors.toSet());
+    }
+
+    @Test
+    void mapsRoleNamedScopesToRoleAuthoritiesAndIgnoresOidcScopes() {
+        when(scopeService.getScopeRolesMappings()).thenReturn(Collections.emptyMap());
+        ScopeRoleJwtAuthoritiesConverter converter = new ScopeRoleJwtAuthoritiesConverter(scopeService);
+
+        Collection<GrantedAuthority> authorities =
+                converter.convert(jwt("rs-xyz/ADMINISTRATOR rs-xyz/sample-app.Orders.OrderFullAccess openid"));
+
+        Set<String> names = authorityNames(authorities);
+        assertEquals(Set.of("ROLE_ADMINISTRATOR", "ROLE_sample-app.Orders.OrderFullAccess"), names);
+        assertFalse(names.contains("ROLE_openid"));
+        assertFalse(names.contains("SCOPE_openid"));
+    }
+
+    @Test
+    void expandsMappedScopeToMultipleRolesAndFallsBackForUnmapped() {
+        when(scopeService.getScopeRolesMappings()).thenReturn(
+                Map.of("orders-manage", Set.of("sample-app.Orders.OrderFullAccess", "sample-app.Orders.OrderReadOnly")));
+        ScopeRoleJwtAuthoritiesConverter converter = new ScopeRoleJwtAuthoritiesConverter(scopeService);
+
+        Collection<GrantedAuthority> authorities = converter.convert(jwt("rs-xyz/orders-manage rs-xyz/ADMINISTRATOR"));
+
+        Set<String> names = authorityNames(authorities);
+        assertTrue(names.contains("ROLE_sample-app.Orders.OrderFullAccess"));
+        assertTrue(names.contains("ROLE_sample-app.Orders.OrderReadOnly"));
+        assertTrue(names.contains("ROLE_ADMINISTRATOR"));
+        assertEquals(3, names.size());
+    }
+}

--- a/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/synchronizer/SecurityScopesSynchronizerTest.java
+++ b/components/engine/engine-security/src/test/java/org/eclipse/dirigible/components/security/synchronizer/SecurityScopesSynchronizerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.synchronizer;
+
+import jakarta.persistence.EntityManager;
+import org.eclipse.dirigible.components.security.domain.Scope;
+import org.eclipse.dirigible.components.security.repository.ScopeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Class SecurityScopesSynchronizerTest.
+ */
+@SpringBootTest(classes = {ScopeRepository.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ComponentScan(basePackages = {"org.eclipse.dirigible.components"})
+@EntityScan("org.eclipse.dirigible.components")
+@Transactional
+class SecurityScopesSynchronizerTest {
+
+    /** The entity manager. */
+    @Autowired
+    EntityManager entityManager;
+
+    /** The scope repository. */
+    @Autowired
+    private ScopeRepository scopeRepository;
+
+    /** The scopes synchronizer. */
+    @Autowired
+    private ScopesSynchronizer scopesSynchronizer;
+
+    /**
+     * The Class TestConfiguration.
+     */
+    @SpringBootApplication
+    static class TestConfiguration {
+    }
+
+    /**
+     * Cleanup.
+     */
+    @AfterEach
+    public void cleanup() {
+        scopeRepository.deleteAll();
+    }
+
+    /**
+     * Checks if is accepted by path.
+     */
+    @Test
+    public void testIsAcceptedPath() {
+        assertTrue(scopesSynchronizer.isAccepted(Path.of("/a/b/c/test.scopes"), null));
+    }
+
+    /**
+     * Checks if is accepted by artefact type.
+     */
+    @Test
+    public void testIsAcceptedArtefact() {
+        assertTrue(scopesSynchronizer.isAccepted(Scope.ARTEFACT_TYPE));
+    }
+
+    /**
+     * Load the artefact and assert it is parsed and persisted like roles.
+     *
+     * @throws IOException Signals that an I/O exception has occurred.
+     * @throws ParseException the parse exception
+     */
+    @Test
+    public void testLoad() throws IOException, ParseException {
+        byte[] content = SecurityScopesSynchronizerTest.class.getResourceAsStream("/META-INF/dirigible/test/test.scopes")
+                                                             .readAllBytes();
+        List<Scope> list = scopesSynchronizer.parse("/META-INF/dirigible/test/test.scopes", content);
+        assertNotNull(list);
+        assertEquals(2, list.size());
+        assertEquals("/META-INF/dirigible/test/test.scopes", list.get(0)
+                                                                 .getLocation());
+
+        Scope persisted = scopeRepository.findByKey(list.get(0)
+                                                        .getKey())
+                                         .orElseThrow();
+        assertEquals("orders-manage", persisted.getScope());
+        assertEquals(2, persisted.getRoles()
+                                 .size());
+        assertTrue(persisted.getRoles()
+                            .contains("sample-app.Orders.OrderFullAccess"));
+        assertTrue(persisted.getRoles()
+                            .contains("sample-app.Orders.OrderReadOnly"));
+    }
+}

--- a/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.scopes
+++ b/components/engine/engine-security/src/test/resources/META-INF/dirigible/test/test.scopes
@@ -1,0 +1,16 @@
+[
+   {
+      "scope":"orders-manage",
+      "roles":[
+         "sample-app.Orders.OrderFullAccess",
+         "sample-app.Orders.OrderReadOnly"
+      ],
+      "description":"Manage orders"
+   },
+   {
+      "scope":"athena-admin",
+      "roles":[
+         "ADMINISTRATOR"
+      ]
+   }
+]

--- a/components/security/security-cognito/pom.xml
+++ b/components/security/security-cognito/pom.xml
@@ -31,6 +31,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-security</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -22,6 +22,7 @@ import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
 import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -31,6 +32,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -46,8 +49,12 @@ public class CognitoSecurityConfiguration {
 
     private final boolean trialModeEnabled;
 
-    public CognitoSecurityConfiguration() {
-        trialModeEnabled = DirigibleConfig.TRIAL_ENABLED.getBooleanValue();
+    /** The Cognito JWKS endpoint backing the resource-server (Bearer) JWT decoder. */
+    private final String jwkSetUri;
+
+    public CognitoSecurityConfiguration(@Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") String jwkSetUri) {
+        this.trialModeEnabled = DirigibleConfig.TRIAL_ENABLED.getBooleanValue();
+        this.jwkSetUri = jwkSetUri;
     }
 
     /**
@@ -68,8 +75,9 @@ public class CognitoSecurityConfiguration {
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
             })
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(
-                    jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
+                                                                 .jwtAuthenticationConverter(
+                                                                         jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);
@@ -89,6 +97,25 @@ public class CognitoSecurityConfiguration {
         JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(scopeRoleJwtAuthoritiesConverter);
         return jwtAuthenticationConverter;
+    }
+
+    /**
+     * Builds the resource-server JWT decoder explicitly from the Cognito JWKS endpoint (default JWS
+     * algorithm RS256).
+     *
+     * <p>
+     * This must be pinned on the configurer rather than relying on a {@link JwtDecoder} bean: the
+     * embedded Spring Authorization Server publishes its own {@code JwtDecoder} (backed by its
+     * in-memory keys), and the Spring Boot OAuth2 resource-server auto-configuration is not on the
+     * classpath, so {@code getBean(JwtDecoder.class)} would otherwise resolve the authorization
+     * server's decoder and reject every Cognito token. Validation (signature/expiry against
+     * {@code jwk-set-uri}) is unchanged.
+     *
+     * @return the Cognito JWKS-backed JWT decoder
+     */
+    private JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+                               .build();
     }
 
     @Bean

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigurator;
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
+import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -30,6 +31,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -56,7 +58,8 @@ public class CognitoSecurityConfiguration {
      * @throws Exception the exception
      */
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator,
+            ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter) throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -65,12 +68,27 @@ public class CognitoSecurityConfiguration {
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
             })
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(
+                    jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);
 
         return http.build();
+    }
+
+    /**
+     * Builds the JWT authentication converter that derives Dirigible role authorities from the
+     * validated {@code scope} claim (machine-to-machine / client-credentials tokens). Token validation
+     * is unaffected.
+     *
+     * @param scopeRoleJwtAuthoritiesConverter the scope-to-role authorities converter
+     * @return the JWT authentication converter
+     */
+    private JwtAuthenticationConverter jwtAuthenticationConverter(ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter) {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(scopeRoleJwtAuthoritiesConverter);
+        return jwtAuthenticationConverter;
     }
 
     @Bean

--- a/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoResourceServerJwtDecodeTest.java
+++ b/components/security/security-cognito/src/test/java/org/eclipse/dirigible/components/security/cognito/CognitoResourceServerJwtDecodeTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
+import org.eclipse.dirigible.components.security.service.ScopeService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * Regression test for the resource-server (Bearer) JWT decode path.
+ *
+ * <p>
+ * Reproduces the exact mechanism {@code CognitoSecurityConfiguration} now uses: a JWKS-backed
+ * {@link NimbusJwtDecoder} built from a {@code jwk-set-uri} decodes a Cognito-style RS256 access
+ * token, after which the {@link ScopeRoleJwtAuthoritiesConverter} maps its {@code scope} claim to
+ * Dirigible role authorities. This guards against the regression where the resource server resolved
+ * a foreign {@code JwtDecoder} (the embedded authorization server's self-signed one) and rejected
+ * every valid token at decode with "no matching key(s) found".
+ */
+@ExtendWith(MockitoExtension.class)
+class CognitoResourceServerJwtDecodeTest {
+
+    private static final String KEY_ID = "test-signing-key";
+
+    @Mock
+    private ScopeService scopeService;
+
+    @Test
+    void resourceServerDecodesRs256JwtFromJwkSetAndAppliesScopeRoles() throws Exception {
+        RSAKey rsaKey = new RSAKeyGenerator(2048).keyID(KEY_ID)
+                                                 .algorithm(JWSAlgorithm.RS256)
+                                                 .generate();
+        HttpServer jwksServer = startJwksServer(new JWKSet(rsaKey.toPublicJWK()).toString());
+        try {
+            String jwkSetUri = "http://localhost:" + jwksServer.getAddress()
+                                                               .getPort()
+                    + "/.well-known/jwks.json";
+            String token = signRs256(rsaKey,
+                    "sample-resource-server/ADMINISTRATOR sample-resource-server/sample-app.Orders.OrderFullAccess openid");
+
+            // The decoder built exactly as the resource-server config builds it.
+            NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+                                                       .build();
+            Jwt decoded = decoder.decode(token);
+            assertEquals("m2m-client", decoded.getSubject());
+
+            // The scope -> role authorities applied on top of the decoded token.
+            when(scopeService.getScopeRolesMappings()).thenReturn(Collections.emptyMap());
+            Collection<GrantedAuthority> authorities = new ScopeRoleJwtAuthoritiesConverter(scopeService).convert(decoded);
+
+            Set<String> names = authorities.stream()
+                                           .map(GrantedAuthority::getAuthority)
+                                           .collect(Collectors.toSet());
+            assertEquals(Set.of("ROLE_ADMINISTRATOR", "ROLE_sample-app.Orders.OrderFullAccess"), names);
+            assertTrue(names.stream()
+                            .noneMatch(n -> n.contains("openid")));
+        } finally {
+            jwksServer.stop(0);
+        }
+    }
+
+    private HttpServer startJwksServer(String jwksJson) throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        byte[] body = jwksJson.getBytes(StandardCharsets.UTF_8);
+        server.createContext("/.well-known/jwks.json", exchange -> {
+            exchange.getResponseHeaders()
+                    .add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        server.start();
+        return server;
+    }
+
+    private String signRs256(RSAKey rsaKey, String scope) throws Exception {
+        Instant now = Instant.now();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().subject("m2m-client")
+                                                        .claim("token_use", "access")
+                                                        .claim("scope", scope)
+                                                        .issueTime(Date.from(now))
+                                                        .expirationTime(Date.from(now.plusSeconds(3600)))
+                                                        .build();
+        SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(KEY_ID)
+                                                                                     .build(),
+                claims);
+        signedJWT.sign(new RSASSASigner(rsaKey));
+        return signedJWT.serialize();
+    }
+}

--- a/components/security/security-keycloak/pom.xml
+++ b/components/security/security-keycloak/pom.xml
@@ -26,6 +26,10 @@
 			<artifactId>dirigible-components-core-tenants</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-engine-security</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -19,6 +19,7 @@ import org.eclipse.dirigible.commons.config.DirigibleConfig;
 import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigurator;
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
+import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
 import org.eclipse.dirigible.components.tenants.tenant.TenantContextInitFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -64,7 +66,8 @@ public class KeycloakSecurityConfiguration {
      */
     @Bean
     SecurityFilterChain configure(HttpSecurity http, TenantContextInitFilter tenantContextInitFilter,
-            HttpSecurityURIConfigurator httpSecurityURIConfigurator) throws Exception {
+            HttpSecurityURIConfigurator httpSecurityURIConfigurator, ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter)
+            throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -75,12 +78,27 @@ public class KeycloakSecurityConfiguration {
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
             })
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(
+                    jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);
 
         return http.build();
+    }
+
+    /**
+     * Builds the JWT authentication converter that derives Dirigible role authorities from the
+     * validated {@code scope} claim (machine-to-machine / client-credentials tokens). Token validation
+     * is unaffected.
+     *
+     * @param scopeRoleJwtAuthoritiesConverter the scope-to-role authorities converter
+     * @return the JWT authentication converter
+     */
+    private JwtAuthenticationConverter jwtAuthenticationConverter(ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter) {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(scopeRoleJwtAuthoritiesConverter);
+        return jwtAuthenticationConverter;
     }
 
     @Bean

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -33,8 +33,11 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -52,8 +55,12 @@ public class KeycloakSecurityConfiguration {
 
     private final boolean trialModeEnabled;
 
-    public KeycloakSecurityConfiguration() {
-        trialModeEnabled = DirigibleConfig.TRIAL_ENABLED.getBooleanValue();
+    /** The Keycloak JWKS endpoint backing the resource-server (Bearer) JWT decoder. */
+    private final String jwkSetUri;
+
+    public KeycloakSecurityConfiguration(@Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") String jwkSetUri) {
+        this.trialModeEnabled = DirigibleConfig.TRIAL_ENABLED.getBooleanValue();
+        this.jwkSetUri = jwkSetUri;
     }
 
     /**
@@ -78,8 +85,9 @@ public class KeycloakSecurityConfiguration {
             .oauth2Login(oauth2 -> {
                 oauth2.userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig.userAuthoritiesMapper(userAuthoritiesMapper()));
             })
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(
-                    jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
+                                                                 .jwtAuthenticationConverter(
+                                                                         jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);
@@ -99,6 +107,25 @@ public class KeycloakSecurityConfiguration {
         JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
         jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(scopeRoleJwtAuthoritiesConverter);
         return jwtAuthenticationConverter;
+    }
+
+    /**
+     * Builds the resource-server JWT decoder explicitly from the Keycloak JWKS endpoint (default JWS
+     * algorithm RS256).
+     *
+     * <p>
+     * This must be pinned on the configurer rather than relying on a {@link JwtDecoder} bean: the
+     * embedded Spring Authorization Server publishes its own {@code JwtDecoder} (backed by its
+     * in-memory keys), and the Spring Boot OAuth2 resource-server auto-configuration is not on the
+     * classpath, so {@code getBean(JwtDecoder.class)} would otherwise resolve the authorization
+     * server's decoder and reject every Keycloak token. Validation (signature/expiry against
+     * {@code jwk-set-uri}) is unchanged.
+     *
+     * @return the Keycloak JWKS-backed JWT decoder
+     */
+    private JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+                               .build();
     }
 
     @Bean

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
@@ -10,12 +10,15 @@
 package org.eclipse.dirigible.components.security.oauth2;
 
 import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigurator;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -24,6 +27,13 @@ import org.springframework.security.web.SecurityFilterChain;
 @Profile("github")
 @Configuration
 public class OAuth2SecurityConfiguration {
+
+    /** The JWKS endpoint backing the resource-server (Bearer) JWT decoder. */
+    private final String jwkSetUri;
+
+    public OAuth2SecurityConfiguration(@Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") String jwkSetUri) {
+        this.jwkSetUri = jwkSetUri;
+    }
 
     /**
      * Filter chain.
@@ -41,11 +51,30 @@ public class OAuth2SecurityConfiguration {
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.disable()))
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(Customizer.withDefaults())
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);
 
         return http.build();
+    }
+
+    /**
+     * Builds the resource-server JWT decoder explicitly from the configured JWKS endpoint (default JWS
+     * algorithm RS256).
+     *
+     * <p>
+     * This must be pinned on the configurer rather than relying on a {@link JwtDecoder} bean: the
+     * embedded Spring Authorization Server publishes its own {@code JwtDecoder} (backed by its
+     * in-memory keys), and the Spring Boot OAuth2 resource-server auto-configuration is not on the
+     * classpath, so {@code getBean(JwtDecoder.class)} would otherwise resolve the authorization
+     * server's decoder and reject every token. Validation (signature/expiry against
+     * {@code jwk-set-uri}) is unchanged.
+     *
+     * @return the JWKS-backed JWT decoder
+     */
+    private JwtDecoder jwtDecoder() {
+        return NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+                               .build();
     }
 }

--- a/modules/commons/commons-helpers/src/main/java/org/eclipse/dirigible/commons/api/helpers/ContentTypeHelper.java
+++ b/modules/commons/commons-helpers/src/main/java/org/eclipse/dirigible/commons/api/helpers/ContentTypeHelper.java
@@ -473,6 +473,9 @@ public class ContentTypeHelper {
     /** The Constant APPLICATION_JSON_ROLES. */
     public static final String APPLICATION_JSON_ROLES = "application/json+roles";
 
+    /** The Constant APPLICATION_JSON_SCOPES. */
+    public static final String APPLICATION_JSON_SCOPES = "application/json+scopes";
+
     /** The Constant APPLICATION_JSON_CSVIM. */
     public static final String APPLICATION_JSON_CSVIM = "application/json+csvim";
 
@@ -710,6 +713,7 @@ public class ContentTypeHelper {
         TEXT_CONTENT_TYPES.put("extension", APPLICATION_JSON_EXTENSION); //$NON-NLS-1$
         TEXT_CONTENT_TYPES.put("access", APPLICATION_JSON_ACCESS); //$NON-NLS-1$
         TEXT_CONTENT_TYPES.put("roles", APPLICATION_JSON_ROLES); //$NON-NLS-1$
+        TEXT_CONTENT_TYPES.put("scopes", APPLICATION_JSON_SCOPES); //$NON-NLS-1$
         TEXT_CONTENT_TYPES.put("hdbti", APPLICATION_HDBTI); //$NON-NLS-1$
         TEXT_CONTENT_TYPES.put("csvim", APPLICATION_JSON_CSVIM); //$NON-NLS-1$
         TEXT_CONTENT_TYPES.put("command", APPLICATION_JSON_COMMAND); //$NON-NLS-1$


### PR DESCRIPTION
Adds OAuth2 Client Credentials (machine-to-machine) authorization by mapping the validated `scope` claim to Dirigible roles, plus a new `*.scopes` artifact for one-scope-to-many-roles cases. Applies to the Cognito and Keycloak resource-server providers.

Closes #5978
