### PR TITLE
[IDE] Add Scope form editor, Scopes view and New-menu template

### DIFF
--- a/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/configs/scopes-editor.js
+++ b/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/configs/scopes-editor.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const editorData = {
+	id: 'scopes',
+	label: 'Scopes',
+	region: 'center',
+	path: '/services/web/editor-security/editors/scopes/editor.html',
+	contentTypes: ['application/json+scopes']
+};
+if (typeof exports !== 'undefined') {
+	exports.getEditor = () => editorData;
+}

--- a/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/editors/scopes/editor.html
+++ b/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/editors/scopes/editor.html
@@ -1,0 +1,68 @@
+<!--
+
+    Copyright (c) 2010-2026 Eclipse Dirigible contributors
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-FileCopyrightText: Eclipse Dirigible contributors
+    SPDX-License-Identifier: EPL-2.0
+
+-->
+<!DOCTYPE HTML>
+<html lang="en" ng-app="page" ng-controller="PageController">
+
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=">
+        <title config-title></title>
+        <script type="text/javascript" src="/services/web/editor-security/configs/scopes-editor.js"></script>
+        <meta name="platform-links" category="ng-view,ng-editor">
+        <script type="text/javascript" src="/services/web/editor-security/editors/scopes/editor.js"></script>
+    </head>
+
+    <body class="bk-vbox" shortcut="'ctrl+s'" shortcut-action="save">
+        <bk-busy-indicator-extended class="bk-fill-parent" ng-hide="state.error || !state.isBusy" size="l">{{state.busyText}}</bk-busy-indicator-extended>
+        <bk-toolbar has-title="true" ng-show="!state.error && !state.isBusy">
+            <bk-toolbar-title>Scope definitions:</bk-toolbar-title>
+            <bk-toolbar-spacer></bk-toolbar-spacer>
+            <bk-button compact="true" label="Add" ng-click="addScope()"></bk-button>
+            <bk-button compact="true" state="emphasized" label="Save" ng-click="save()" ng-disabled="!changed"></bk-button>
+        </bk-toolbar>
+        <bk-scrollbar ng-show="!state.error && !state.isBusy">
+            <table bk-table outer-borders="bottom">
+                <thead bk-table-header interactive="false" sticky="true">
+                    <tr bk-table-row>
+                        <th bk-table-header-cell>Scope</th>
+                        <th bk-table-header-cell>Roles</th>
+                        <th bk-table-header-cell>Description</th>
+                        <th bk-table-header-cell></th>
+                    </tr>
+                </thead>
+                <tbody bk-table-body>
+                    <tr ng-if="scopes.length === 0" bk-table-row>
+                        <td bk-table-cell no-data="true">There are no scope definitions</td>
+                    </tr>
+                    <tr bk-table-row hoverable="false" activable="false" ng-repeat="item in scopes track by $index">
+                        <td bk-table-cell>{{ item.scope }}</td>
+                        <td bk-table-cell>{{ item.roles.join(', ') }}</td>
+                        <td bk-table-cell>{{ item.description }}</td>
+                        <td bk-table-cell fit-content="true">
+                            <bk-button compact="true" glyph="sap-icon--edit" state="transparent" aria-label="Edit" ng-click="editScope($index)"></bk-button>
+                            <bk-button compact="true" glyph="sap-icon--delete" state="transparent" aria-label="Delete" ng-click="deleteScope($index)"></bk-button>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </bk-scrollbar>
+        <bk-message-page glyph="sap-icon--error" ng-if="state.error">
+            <bk-message-page-title>Editor encounterd an error!</bk-message-page-title>
+            <bk-message-page-subtitle>{{errorMessage}}</bk-message-page-subtitle>
+        </bk-message-page>
+        <theme></theme>
+    </body>
+
+</html>

--- a/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/editors/scopes/editor.js
+++ b/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/editors/scopes/editor.js
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+angular.module('page', ['blimpKit', 'platformView', 'platformShortcuts', 'WorkspaceService']).controller('PageController', ($scope, $window, WorkspaceService, ViewParameters, ButtonStates) => {
+    const statusBarHub = new StatusBarHub();
+    const workspaceHub = new WorkspaceHub();
+    const layoutHub = new LayoutHub();
+    const dialogHub = new DialogHub();
+    let contents;
+    $scope.changed = false;
+    $scope.errorMessage = 'An unknown error was encountered. Please see console for more information.';
+    $scope.state = {
+        isBusy: true,
+        error: false,
+        busyText: 'Loading...',
+    };
+    $scope.editScopeIndex = 0;
+
+    angular.element($window).bind('focus', () => { statusBarHub.showLabel('') });
+
+    const loadFileContents = () => {
+        if (!$scope.state.error) {
+            $scope.state.isBusy = true;
+            WorkspaceService.loadContent($scope.dataParameters.filePath).then((response) => {
+                $scope.$evalAsync(() => {
+                    if (response.data === '') $scope.scopes = [];
+                    else $scope.scopes = response.data;
+                    contents = JSON.stringify($scope.scopes, null, 4);
+                    $scope.state.isBusy = false;
+                });
+            }, (response) => {
+                console.error(response);
+                $scope.$evalAsync(() => {
+                    $scope.state.error = true;
+                    $scope.errorMessage = 'Error while loading file. Please look at the console for more information.';
+                    $scope.state.isBusy = false;
+                });
+            });
+        }
+    };
+
+    function saveContents(text) {
+        WorkspaceService.saveContent($scope.dataParameters.filePath, text).then(() => {
+            contents = text;
+            layoutHub.setEditorDirty({
+                path: $scope.dataParameters.filePath,
+                dirty: false,
+            });
+            workspaceHub.announceFileSaved({
+                path: $scope.dataParameters.filePath,
+                contentType: $scope.dataParameters.contentType,
+            });
+            $scope.$evalAsync(() => {
+                $scope.changed = false;
+                $scope.state.isBusy = false;
+            });
+        }, (response) => {
+            console.error(response);
+            $scope.$evalAsync(() => {
+                $scope.state.error = true;
+                $scope.errorMessage = `Error saving '${$scope.dataParameters.filePath}'. Please look at the console for more information.`;
+                $scope.state.isBusy = false;
+            });
+        });
+    }
+
+    $scope.save = (keySet = 'ctrl+s', event) => {
+        event?.preventDefault();
+        if (keySet === 'ctrl+s') {
+            if ($scope.changed && !$scope.state.error) {
+                $scope.state.busyText = 'Saving...';
+                $scope.state.isBusy = true;
+                saveContents(JSON.stringify($scope.scopes, null, 4));
+            }
+        }
+    };
+
+    layoutHub.onFocusEditor((data) => {
+        if (data.path && data.path === $scope.dataParameters.filePath) statusBarHub.showLabel('');
+    });
+
+    layoutHub.onReloadEditorParams((data) => {
+        if (data.path === $scope.dataParameters.filePath) {
+            $scope.$evalAsync(() => {
+                $scope.dataParameters = ViewParameters.get();
+            });
+        };
+    });
+
+    workspaceHub.onSaveAll(() => {
+        if ($scope.changed && !$scope.state.error) {
+            $scope.save();
+        }
+    });
+
+    workspaceHub.onSaveFile((data) => {
+        if (data.path && data.path === $scope.dataParameters.filePath) {
+            if (!$scope.state.error && $scope.changed) {
+                $scope.save();
+            }
+        }
+    });
+
+    $scope.$watch('scopes', () => {
+        if (!$scope.state.error && !$scope.state.isBusy) {
+            const isDirty = contents !== JSON.stringify($scope.scopes, null, 4);
+            if ($scope.changed !== isDirty) {
+                $scope.changed = isDirty;
+                layoutHub.setEditorDirty({
+                    path: $scope.dataParameters.filePath,
+                    dirty: isDirty,
+                });
+            }
+        }
+    }, true);
+
+    $scope.addScope = () => {
+        dialogHub.showFormDialog({
+            title: 'Add scope',
+            form: {
+                'seciScope': {
+                    label: 'Scope name',
+                    controlType: 'input',
+                    placeholder: 'Enter scope name',
+                    type: 'text',
+                    minlength: 1,
+                    maxlength: 255,
+                    inputRules: {
+                        patterns: ['^[a-zA-Z0-9_.-]*$'],
+                    },
+                    focus: true,
+                    required: true
+                },
+                'seciRoles': {
+                    label: 'Roles',
+                    controlType: 'input',
+                    placeholder: 'Comma separated roles',
+                    type: 'text',
+                    required: true,
+                },
+                'seciDescription': {
+                    label: 'Description',
+                    controlType: 'input',
+                    placeholder: 'Enter description',
+                    type: 'text',
+                },
+            },
+            submitLabel: 'Add',
+            cancelLabel: 'Cancel'
+        }).then((form) => {
+            if (form) {
+                $scope.$evalAsync(() => {
+                    $scope.scopes.push({
+                        scope: form['seciScope'],
+                        roles: form['seciRoles'].split(',').map(element => element.trim()).filter(element => element !== ''),
+                        description: form['seciDescription'],
+                    });
+                });
+            }
+        }, (error) => {
+            console.error(error);
+            dialogHub.showAlert({
+                title: 'New scope error',
+                message: 'There was an error while adding the new scope.',
+                type: AlertTypes.Error,
+                preformatted: false,
+            });
+        });
+    };
+
+    $scope.editScope = (index) => {
+        $scope.editScopeIndex = index;
+        dialogHub.showFormDialog({
+            title: 'Edit scope',
+            form: {
+                'seciScope': {
+                    label: 'Scope name',
+                    controlType: 'input',
+                    placeholder: 'Enter scope name',
+                    type: 'text',
+                    minlength: 1,
+                    maxlength: 255,
+                    inputRules: {
+                        patterns: ['^[a-zA-Z0-9_.-]*$'],
+                    },
+                    value: $scope.scopes[index].scope,
+                    focus: true,
+                    required: true
+                },
+                'seciRoles': {
+                    label: 'Roles',
+                    controlType: 'input',
+                    placeholder: 'Comma separated roles',
+                    type: 'text',
+                    value: $scope.scopes[index].roles ? $scope.scopes[index].roles.join(', ') : '',
+                    required: true,
+                },
+                'seciDescription': {
+                    label: 'Description',
+                    controlType: 'input',
+                    placeholder: 'Enter description',
+                    type: 'text',
+                    value: $scope.scopes[index].description,
+                },
+            },
+            submitLabel: 'Update',
+            cancelLabel: 'Cancel'
+        }).then((form) => {
+            if (form) {
+                $scope.$evalAsync(() => {
+                    $scope.scopes[$scope.editScopeIndex].scope = form['seciScope'];
+                    $scope.scopes[$scope.editScopeIndex].roles = form['seciRoles'].split(',').map(element => element.trim()).filter(element => element !== '');
+                    $scope.scopes[$scope.editScopeIndex].description = form['seciDescription'];
+                });
+            }
+        }, (error) => {
+            console.error(error);
+            dialogHub.showAlert({
+                title: 'Scope update error',
+                message: 'There was an error while updating the scope.',
+                type: AlertTypes.Error,
+                preformatted: false,
+            });
+        });
+    };
+
+    $scope.deleteScope = (index) => {
+        dialogHub.showDialog({
+            title: `Delete ${$scope.scopes[index].scope}?`,
+            message: 'This action cannot be undone.',
+            buttons: [{
+                id: 'bd',
+                state: ButtonStates.Negative,
+                label: 'Delete',
+            },
+            {
+                id: 'bc',
+                state: ButtonStates.Transparent,
+                label: 'Cancel',
+            }]
+        }).then((buttonId) => {
+            if (buttonId === 'bd') {
+                $scope.$evalAsync(() => {
+                    $scope.scopes.splice(index, 1);
+                });
+            }
+        });
+    };
+
+    $scope.dataParameters = ViewParameters.get();
+    if (!$scope.dataParameters.hasOwnProperty('filePath')) {
+        $scope.state.error = true;
+        $scope.errorMessage = 'The \'filePath\' data parameter is missing.';
+    } else if (!$scope.dataParameters.hasOwnProperty('contentType')) {
+        $scope.state.error = true;
+        $scope.errorMessage = 'The \'contentType\' data parameter is missing.';
+    } else loadFileContents();
+});

--- a/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/extensions/scopes-editor.extension
+++ b/components/ui/editor-security/src/main/resources/META-INF/dirigible/editor-security/extensions/scopes-editor.extension
@@ -1,0 +1,5 @@
+{
+    "module": "editor-security/configs/scopes-editor.js",
+    "extensionPoint": "platform-editors",
+    "description": "Scopes Editor"
+}

--- a/components/ui/menu-security/src/main/resources/META-INF/dirigible/menu-security/extensions/menu-scopes.extension
+++ b/components/ui/menu-security/src/main/resources/META-INF/dirigible/menu-security/extensions/menu-scopes.extension
@@ -1,0 +1,5 @@
+{
+    "module": "menu-security/templates/menu-scopes.js",
+    "extensionPoint": "platform-templates-menu",
+    "description": "Scopes Definitions Workbench New Menu Extension"
+}

--- a/components/ui/menu-security/src/main/resources/META-INF/dirigible/menu-security/templates/menu-scopes.js
+++ b/components/ui/menu-security/src/main/resources/META-INF/dirigible/menu-security/templates/menu-scopes.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+export function getTemplate() {
+	return {
+		name: 'scopes',
+		label: 'Scopes Definitions',
+		extension: 'scopes',
+		data: JSON.stringify([{
+			scope: 'administration',
+			roles: [
+				'ADMINISTRATOR'
+			],
+			description: 'Administration scope'
+		},
+		{
+			scope: 'operations',
+			roles: [
+				'ADMINISTRATOR',
+				'OPERATOR'
+			],
+			description: 'Operations scope'
+		}], null, 4)
+	};
+};

--- a/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/api/artefacts/security-scopes/artefacts-security-scopes.extension
+++ b/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/api/artefacts/security-scopes/artefacts-security-scopes.extension
@@ -1,0 +1,5 @@
+{
+    "module": "perspective-operations/api/artefacts/security-scopes/artefacts-security-scopes.mjs",
+    "extensionPoint": "platform-operations-artefacts",
+    "description": "Security Scopes Artefacts Extension"
+}

--- a/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/api/artefacts/security-scopes/artefacts-security-scopes.mjs
+++ b/components/ui/perspective-operations/src/main/resources/META-INF/dirigible/perspective-operations/api/artefacts/security-scopes/artefacts-security-scopes.mjs
@@ -1,0 +1,12 @@
+import { query } from "@aerokit/sdk/db";
+import { Utils } from "../Utils.mjs";
+
+export const getArtefacts = () => {
+    const sql = `
+        SELECT
+        ARTEFACT_TYPE, ARTEFACT_LOCATION, ARTEFACT_NAME, ARTEFACT_PHASE, ARTEFACT_RUNNING, ARTEFACT_STATUS
+        FROM DIRIGIBLE_SECURITY_SCOPES
+    `;
+    const resultset = query.execute(sql, [], "SystemDB");
+    return resultset.map(e => Utils.getArtefactStatus(e));
+};

--- a/components/ui/perspective-security/src/main/resources/META-INF/dirigible/perspective-security/index.html
+++ b/components/ui/perspective-security/src/main/resources/META-INF/dirigible/perspective-security/index.html
@@ -28,7 +28,7 @@
         <script type="text/javascript">
             angular.module('security', ['platformView', 'platformLayout', 'blimpKit']).controller('SecurityController', ($scope) => {
                 $scope.layoutConfig = {
-                    views: ['access', 'roles', 'tenants', 'client-registrations', 'users'],
+                    views: ['access', 'roles', 'scopes', 'tenants', 'client-registrations', 'users'],
                     viewSettings: {},
                     layoutSettings: {
                         leftPaneMinSize: 340

--- a/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/configs/scopes-view.js
+++ b/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/configs/scopes-view.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const viewData = {
+	id: 'scopes',
+	region: 'bottom',
+	label: 'Scopes',
+	lazyLoad: true,
+	autoFocusTab: false,
+	path: '/services/web/view-security/views/scopes.html'
+};
+if (typeof exports !== 'undefined') {
+	exports.getView = () => viewData;
+}

--- a/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/extensions/scopes.extension
+++ b/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/extensions/scopes.extension
@@ -1,0 +1,5 @@
+{
+    "module": "view-security/configs/scopes-view.js",
+    "extensionPoint": "platform-views",
+    "description": "Scopes View"
+}

--- a/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/views/scopes.html
+++ b/components/ui/view-security/src/main/resources/META-INF/dirigible/view-security/views/scopes.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (c) 2010-2026 Eclipse Dirigible contributors
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-FileCopyrightText: Eclipse Dirigible contributors
+    SPDX-License-Identifier: EPL-2.0
+
+-->
+<!DOCTYPE HTML>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" ng-app="scopes" ng-controller="ScopesController">
+
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=">
+        <title config-title></title>
+        <script type="text/javascript" src="/services/web/view-security/configs/scopes-view.js"></script>
+        <meta name="platform-links" category="ng-view">
+    </head>
+
+    <body bk-scrollbar>
+        <table bk-table display-mode="compact" outer-borders="bottom">
+            <thead bk-table-header sticky="true" interactive="false">
+                <tr bk-table-row>
+                    <th bk-table-header-cell>Name</th>
+                    <th bk-table-header-cell>Location</th>
+                    <th bk-table-header-cell>Description</th>
+                    <th bk-table-header-cell>Created</th>
+                    <th bk-table-header-cell>Creator</th>
+                </tr>
+            </thead>
+            <tbody bk-table-body>
+                <tr bk-table-row ng-repeat="next in list track by $index" hoverable="true" activable="false">
+                    <td bk-table-cell>{{::next.name}}</td>
+                    <td bk-table-cell>{{::next.location}}</td>
+                    <td bk-table-cell>{{::next.description}}</td>
+                    <td bk-table-cell fit-content="true">{{::next.createdAt | date:'yyyy-MM-dd HH:mm:ss'}}</td>
+                    <td bk-table-cell fit-content="true">{{::next.createdBy}}</td>
+                </tr>
+            </tbody>
+        </table>
+        <script type="text/javascript">
+            angular.module('scopes', ['platformView', 'blimpKit']).controller('ScopesController', ($scope, $http) => {
+                $http.get('/services/security/scopes').then((response) => {
+                    $scope.list = response.data;
+                }, (error) => {
+                    console.error(error);
+                });
+            });
+        </script>
+        <theme></theme>
+    </body>
+
+</html>


### PR DESCRIPTION
Adds IDE tooling for the `*.scopes` artifact: a Scopes form editor, a Scopes view in the Security perspective, a Scopes entry in the Operations Artefacts view, and a "Scopes Definitions" Workbench New-menu template — mirroring the existing Roles and Access surfaces.

Closes #5984
