### PR TITLE
Manage SystemDB schema via Liquibase, not Hibernate hbm2ddl

### DIFF
--- a/components/core/core-database/src/main/java/org/eclipse/dirigible/components/database/DataSourceSystemConfig.java
+++ b/components/core/core-database/src/main/java/org/eclipse/dirigible/components/database/DataSourceSystemConfig.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 import org.springframework.boot.quartz.autoconfigure.QuartzDataSource;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -68,13 +69,20 @@ public class DataSourceSystemConfig {
     }
 
     /**
-     * Entity manager factory.
+     * Entity manager factory. Schema for SystemDB is owned by {@code core-liquibase} (changelogs under
+     * {@code db/changelog/dirigible-system.json}); Hibernate is configured with {@code hbm2ddl=none} so
+     * it issues no DDL and performs no schema probes at boot — that eliminates the historical
+     * {@code SYS}-lock race when multiple Spring contexts hit the same file-backed H2 during DDL
+     * planning. The {@code @DependsOn("liquibaseSystemDB")} forces Liquibase to apply the changelogs
+     * before this factory wires Hibernate. Override {@code DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO} only as
+     * a temporary escape hatch.
      *
      * @param dataSource the data source
      * @return the local container entity manager factory bean
      */
     @Primary
     @Bean(name = "entityManagerFactory")
+    @DependsOn("liquibaseSystemDB")
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Qualifier("SystemDB") DataSource dataSource) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource);
@@ -86,7 +94,7 @@ public class DataSourceSystemConfig {
 
         Properties properties = new Properties();
         String configuredDialect = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DIALECT", "org.hibernate.dialect.H2Dialect");
-        String configDDLAuto = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO", "update");
+        String configDDLAuto = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO", "none");
 
         properties.setProperty("hibernate.dialect", configuredDialect);
         properties.setProperty("hibernate.hbm2ddl.auto", configDDLAuto);

--- a/components/core/core-database/src/main/java/org/eclipse/dirigible/components/database/DataSourceSystemConfig.java
+++ b/components/core/core-database/src/main/java/org/eclipse/dirigible/components/database/DataSourceSystemConfig.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
 import org.springframework.boot.quartz.autoconfigure.QuartzDataSource;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -69,20 +68,21 @@ public class DataSourceSystemConfig {
     }
 
     /**
-     * Entity manager factory. Schema for SystemDB is owned by {@code core-liquibase} (changelogs under
-     * {@code db/changelog/dirigible-system.json}); Hibernate is configured with {@code hbm2ddl=none} so
-     * it issues no DDL and performs no schema probes at boot — that eliminates the historical
-     * {@code SYS}-lock race when multiple Spring contexts hit the same file-backed H2 during DDL
-     * planning. The {@code @DependsOn("liquibaseSystemDB")} forces Liquibase to apply the changelogs
-     * before this factory wires Hibernate. Override {@code DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO} only as
-     * a temporary escape hatch.
+     * Entity manager factory. The default {@code hbm2ddl=update} stays so any JPA-using module's unit
+     * tests (which boot a slim Spring context without {@code core-liquibase}) can still bootstrap their
+     * schema. When {@code core-liquibase} is on the classpath (the full app),
+     * {@code LiquibaseEntityManagerFactoryDependsOnPostProcessor} forces Liquibase to apply
+     * {@code db/changelog/dirigible-system.json} BEFORE this factory wires Hibernate — by the time
+     * Hibernate's update pass runs, every table already exists and no CREATE statements are emitted,
+     * which is exactly what eliminates the historical SYS-lock race between racing Spring contexts.
+     * Override {@code DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO} only when you specifically need a different
+     * Hibernate mode (e.g. {@code validate} after Liquibase has been adopted).
      *
      * @param dataSource the data source
      * @return the local container entity manager factory bean
      */
     @Primary
     @Bean(name = "entityManagerFactory")
-    @DependsOn("liquibaseSystemDB")
     public LocalContainerEntityManagerFactoryBean entityManagerFactory(@Qualifier("SystemDB") DataSource dataSource) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource);
@@ -94,7 +94,7 @@ public class DataSourceSystemConfig {
 
         Properties properties = new Properties();
         String configuredDialect = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DIALECT", "org.hibernate.dialect.H2Dialect");
-        String configDDLAuto = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO", "none");
+        String configDDLAuto = Configuration.get("DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO", "update");
 
         properties.setProperty("hibernate.dialect", configuredDialect);
         properties.setProperty("hibernate.hbm2ddl.auto", configDDLAuto);

--- a/components/core/core-liquibase/CLAUDE.md
+++ b/components/core/core-liquibase/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md — components/core/core-liquibase
+
+Source of truth for the **SystemDB schema** (the `DIRIGIBLE_*` platform tables JPA-scanned out of `org.eclipse.dirigible.components` + `org.eclipse.dirigible.engine`). Every CREATE TABLE / ALTER TABLE / index / FK that ends up in SystemDB is declared as a Liquibase JSON changeset in `src/main/resources/db/changelog/dirigible-system.json`.
+
+## Why this module exists
+
+Before this module existed, the platform schema was bootstrapped by Hibernate's `hbm2ddl=update` on the SystemDB EntityManagerFactory. That had two structural problems:
+
+- **The SYS-lock race.** When several Spring contexts in one JVM (e.g. consecutive `@SpringBootTest`s in the integration suite) each started Hibernate against the same file-backed H2, their CREATE TABLE batches collided over H2's `SYS` catalog lock and one or more contexts timed out. Once that started cascading, every IT after the first crashed in 0.001s with `Failed to load ApplicationContext`. See [run 27256937543](https://github.com/eclipse-dirigible/dirigible/actions/runs/27256937543) — `DependsOnScenariosIT` racked up 468 `Timeout trying to lock table "SYS"` errors before giving up.
+- **No versioning.** Hibernate's `update` is purely a forward-merge of the current entity model into whatever is in the DB. There's no record of *when* a column appeared, no review path for schema changes, no rollback, and no way to make Postgres/MSSQL emit different DDL than H2 in the same release.
+
+`core-liquibase` replaces that bootstrap. Liquibase applies the changelog under its own `DATABASECHANGELOGLOCK`, so even with N concurrent Spring contexts only one ever issues DDL. Hibernate's `update` pass then sees a fully-populated schema and emits zero CREATE statements — the race window is gone.
+
+## Architecture
+
+```
+LiquibaseSystemConfig (@Configuration)
+├── liquibaseSystemDB             (SpringLiquibase bean, applies the changelog at boot)
+│   └── LegacyAwareSpringLiquibase (extends SpringLiquibase)
+│         performUpdate() → if DIRIGIBLE_SECURITY_ACCESS exists but DATABASECHANGELOG doesn't,
+│                           call changeLogSync() to mark every changeset applied without
+│                           re-running DDL, then fall through to super.performUpdate()
+└── LiquibaseEntityManagerFactoryDependsOnPostProcessor (BFPP)
+      extends Spring Boot's EntityManagerFactoryDependsOnPostProcessor("liquibaseSystemDB")
+      → dynamically adds dependsOn to every EntityManagerFactory bean at startup,
+        but ONLY when core-liquibase is on the classpath
+```
+
+**Why a BFPP and not `@DependsOn` on the EMF bean.** A literal `@DependsOn("liquibaseSystemDB")` in `core-database/DataSourceSystemConfig` makes Liquibase a *required* dependency of the EMF. Every JPA-using module's unit tests (engine-javascript, data-sources, ide-problems, ...) boot a slim Spring context that doesn't pull `core-liquibase`. With a hard `@DependsOn`, the missing bean fails the entire context. Spring Boot's `LiquibaseAutoConfiguration` already solves this exact problem with `EntityManagerFactoryDependsOnPostProcessor` — we reuse it. Lives in this module → only registered when this module is loaded → slim test contexts boot clean.
+
+**Hibernate's `hbm2ddl=update` stays the default** (`DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO=update` in `DataSourceSystemConfig`). The BFPP forces Liquibase to run first, so in the full app Hibernate's `update` finds every table already created and emits no DDL. In unit-test contexts without Liquibase, `update` still works as the bootstrap. Switching the default to `validate`/`none` is reserved for a future PR once every JPA test in the repo grows a Liquibase-aware setup — flipping it now blows up every `@SpringBootTest` repo test that boots its own context (see commit `7244f92f` for the regression that justified reverting that part).
+
+## ⚠️ Adding a new system artefact / table / column — MANDATORY
+
+**Every new JPA entity (or `@Column` on an existing one) that goes into SystemDB MUST be accompanied by a new changeset appended to `db/changelog/dirigible-system.json`.** Hibernate's `hbm2ddl=update` will silently create the new column on a fresh local H2 in development, hiding the omission — but **production / Postgres / MSSQL deployments may run with Liquibase strictly authoritative** (`hbm2ddl=validate`), in which case the missing changeset is a deployment outage.
+
+The checklist for any PR that touches a `@Entity` class under `components/*` or `modules/*`:
+
+- [ ] **Added or modified a `@Entity` class** under one of the JPA scan packages? You owe a changeset.
+- [ ] **Added a `@Column`** (even with a default Hibernate type)? You owe a changeset (`addColumn`).
+- [ ] **Changed an existing column's name, length, nullability, type, or default**? You owe a changeset (`renameColumn` / `modifyDataType` / `dropNotNullConstraint` / `addNotNullConstraint` / `addDefaultValue` / `dropDefaultValue`).
+- [ ] **Added a `@JoinColumn` / FK / `@OneToMany`** between system entities? `addForeignKeyConstraint` changeset.
+- [ ] **Added a unique constraint or index**? `addUniqueConstraint` / `createIndex` changeset.
+- [ ] **Deleted an entity or column**? `dropTable` / `dropColumn` changeset (irreversible in production data — coordinate with whoever owns the upgrade story).
+- [ ] **The changeset id is descriptive and unique** (`add-DIRIGIBLE_NEW_TABLE_NEW_COLUMN`, `rename-DIRIGIBLE_FOO_BAR`, ...) — not `1781080528852-1`-style timestamps.
+- [ ] **The changeset author is `dirigible`** (we don't track individual authorship in the changelog).
+- [ ] **Types are vendor-portable** — see "Portability gotchas" below.
+- [ ] **The changeset is APPENDED, never inserted in the middle.** Existing changesets ship to customers' DBs with a content checksum; reordering or editing an applied changeset trips Liquibase's checksum validator on next startup. New work always goes at the end of the file.
+
+A typical follow-up changeset looks like this — it's tiny:
+
+```json
+{
+  "changeSet": {
+    "id": "add-DIRIGIBLE_BPMN_BPMN_PRIORITY",
+    "author": "dirigible",
+    "changes": [
+      {
+        "addColumn": {
+          "tableName": "DIRIGIBLE_BPMN",
+          "columns": [
+            { "column": { "name": "BPMN_PRIORITY", "type": "INT" } }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+If you're not sure what DDL Hibernate would emit, the fastest way to find out is to boot the app once locally with hbm2ddl=update, then run `H2 SCRIPT` on `target/dirigible/h2/SystemDB.mv.db` and transcribe the `CREATE TABLE` / `ALTER TABLE` it produced. The very first changelog in this repo was generated exactly that way.
+
+## Portability gotchas (H2 + Postgres + MSSQL)
+
+Liquibase translates `type` strings per-vendor, but only for a fixed alias set. Use these conventions:
+
+- **`VARCHAR(n)`** — portable on all three. Use for bounded text. Always bounded when a column participates in any index/UK/FK/PK — H2 cannot index a CLOB, so `VARCHAR(2000)` is the right ceiling for artefact keys/locations/names/paths.
+- **`CLOB`** — for unbounded content (`*_CONTENT`, `*_DESCRIPTION` when truly large). Liquibase emits `CLOB` on H2, `TEXT` on Postgres, `NVARCHAR(MAX)` on MSSQL. **Do not put CLOB columns in indexes / UKs / FKs**, H2 will reject the index DDL.
+- **`BIGINT`, `INT`, `BOOLEAN`, `TIMESTAMP`, `CHAR(n)`** — portable, no surprises.
+- **`ENUM(...)`** — DO NOT USE. H2-only; Postgres needs `CREATE TYPE`, MSSQL has no equivalent. Persist enums as `VARCHAR(50)` (and optionally enforce values via a CHECK constraint in a separate changeset).
+- **Auto-increment**: `"autoIncrement": true` + `"type": "BIGINT"` translates to H2 `IDENTITY`, Postgres `GENERATED BY DEFAULT AS IDENTITY`, MSSQL `IDENTITY(1,1)`. Always set this on the primary key column rather than emitting raw DDL.
+- **Constraint names matter** — they end up in error messages and migration logs. Use `PK_<table>`, `UK_<table>_<col>`, `FK_<base>__<col>`, `IX_<table>_<col>`. The first baseline was post-processed to replace H2's `CONSTRAINT_18`/`CONSTRAINT_CB` autonames; don't reintroduce them.
+
+When you change anything non-trivial, the CI matrix is your safety net: integration-tests run against H2, Postgres, and MSSQL with the same changelog (see `.github/workflows/build.yml`). A change that lands green on H2 locally still has to survive the three-DB matrix on the PR — keep the changeset minimal so any vendor-specific failure is easy to pin.
+
+## Legacy-deployment path (`LegacyAwareSpringLiquibase`)
+
+Existing deployments built up via the old `hbm2ddl=update` have every `DIRIGIBLE_*` table but no `DATABASECHANGELOG` ledger. On their first boot with this module:
+
+1. `performUpdate()` checks for the sentinel `DIRIGIBLE_SECURITY_ACCESS` (every deployment has it; it's the very first artefact synchronizer's table) and the absence of `DATABASECHANGELOG`.
+2. If both hold, it calls `Liquibase.changeLogSync(...)`. Every changeset in the file is recorded as applied without re-running its DDL.
+3. Then it falls through to the normal `super.performUpdate()` which is now a no-op for that DB.
+4. The next startup is indistinguishable from a fresh install — `DATABASECHANGELOG` is populated, the normal update path runs, and any newly-appended changeset gets applied.
+
+If you change the sentinel-detection logic (e.g. add a new precondition, change the table name), audit existing deployments — there is no second chance to recover from a misdetection that re-runs a CREATE TABLE on a populated DB.
+
+## Regenerating the baseline
+
+You shouldn't need to regenerate the existing 131 changesets — appending new ones is the workflow. If you ever do (e.g. for a schema rewrite), the process is:
+
+1. Boot the app fresh against an empty H2 with the current `@Entity` set and `hbm2ddl=update` (no `core-liquibase` on the classpath, or temporarily skip the BFPP).
+2. Run `liquibase generate-changelog --url=jdbc:h2:file:./target/dirigible/h2/SystemDB --changelog-file=baseline.json --include-objects='table:DIRIGIBLE_.*' --default-schema-name=PUBLIC`.
+3. Post-process to: rename `CONSTRAINT_xx` → `PK_/UK_/FK_/IX_<table>_<col>`, replace `VARCHAR(1000000000)` → `VARCHAR(2000)` for indexed columns or `CLOB` for content, replace `ENUM(...)` → `VARCHAR(50)`, give each changeset a descriptive id and `dirigible` author.
+4. The transformer script that produced the current baseline is documented in PR #6003's commit history — start from that rather than reinventing.
+
+## Wiring summary (where this module touches the rest of the build)
+
+- `components/pom.xml` lists `core/core-liquibase` as a module and pins its version in `<dependencyManagement>`.
+- `components/group/group-core/pom.xml` depends on `core-liquibase` so the full app picks it up (the BFPP only does its work when the bean is on the classpath, so this is the gate).
+- No source-level dependency on `core-database` — only the bean name `SystemDB` is referenced via `@Qualifier`. The two modules are independent; the wiring happens at Spring boot time via bean name resolution.
+- User-data stores (`components/data/data-store` for TS `@Entity`, `components/data/data-store-java` for Java `@Entity`) are out of scope. Those are dynamic, user-authored entities — they correctly keep `hbm2ddl=update` because their schema comes from user code at runtime, not from versioned changelogs.

--- a/components/core/core-liquibase/pom.xml
+++ b/components/core/core-liquibase/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.eclipse.dirigible</groupId>
+        <artifactId>dirigible-components-parent</artifactId>
+        <version>14.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>dirigible-components-core-liquibase</artifactId>
+    <packaging>jar</packaging>
+    <name>Components - Core - Liquibase</name>
+    <description>
+        Source of truth for the Dirigible system schema (DIRIGIBLE_*) running in SystemDB.
+        Liquibase JSON changelogs in src/main/resources/db/changelog/ create and version every
+        platform table; Hibernate is reduced to schema validation (DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO
+        defaults to "validate") and no longer issues DDL during application startup.
+        Dynamic user entities (TypeScript @Entity via data-store, Java @Entity via
+        data-store-java) continue to use Hibernate's hbm2ddl=update because their schema is
+        authored by end-user code, not by changelogs.
+    </description>
+
+    <properties>
+        <license.header.location>../../../licensing-header.txt</license.header.location>
+        <parent.pom.folder>../../../</parent.pom.folder>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-liquibase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components/core/core-liquibase/pom.xml
+++ b/components/core/core-liquibase/pom.xml
@@ -34,6 +34,10 @@
             <artifactId>spring-boot-liquibase</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-jpa</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/components/core/core-liquibase/src/main/java/org/eclipse/dirigible/components/core/liquibase/LiquibaseSystemConfig.java
+++ b/components/core/core-liquibase/src/main/java/org/eclipse/dirigible/components/core/liquibase/LiquibaseSystemConfig.java
@@ -16,6 +16,7 @@ import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryDependsOnPostProcessor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import liquibase.Contexts;
@@ -27,9 +28,11 @@ import liquibase.integration.spring.SpringLiquibase;
 /**
  * Wires Liquibase against the {@code SystemDB} so the DIRIGIBLE_* platform schema is created and
  * versioned by JSON changelogs in {@code db/changelog/} rather than by Hibernate's
- * {@code hbm2ddl=update}. The {@code entityManagerFactory} bean in {@code DataSourceSystemConfig}
- * must {@code @DependsOn("liquibaseSystemDB")} so Hibernate's (validate-only) startup runs after
- * the changelogs have been applied.
+ * {@code hbm2ddl=update}. {@link LiquibaseEntityManagerFactoryDependsOnPostProcessor} adds a
+ * {@code dependsOn("liquibaseSystemDB")} to every {@code EntityManagerFactory} bean at startup so
+ * Hibernate sees the schema only after Liquibase has applied the changelogs. The dependency is
+ * registered from this module — when {@code core-liquibase} is absent (e.g. slim unit-test
+ * contexts), no dependency is declared and the EMF wires normally.
  *
  * <p>
  * Legacy deployments that were originally bootstrapped via {@code hbm2ddl=update} already have
@@ -56,6 +59,20 @@ public class LiquibaseSystemConfig {
         liquibase.setDataSource(systemDB);
         liquibase.setChangeLog(CHANGELOG);
         return liquibase;
+    }
+
+    /**
+     * Dynamically adds {@code dependsOn("liquibaseSystemDB")} to every {@code EntityManagerFactory}
+     * bean so Hibernate's startup runs strictly after Liquibase's changelog application. Modeled on
+     * Spring Boot's own {@code LiquibaseAutoConfiguration} pattern — by living in
+     * {@code core-liquibase} the BFPP is registered only when this module is on the classpath, so slim
+     * unit-test contexts that omit it still boot.
+     */
+    @Configuration
+    static class LiquibaseEntityManagerFactoryDependsOnPostProcessor extends EntityManagerFactoryDependsOnPostProcessor {
+        LiquibaseEntityManagerFactoryDependsOnPostProcessor() {
+            super("liquibaseSystemDB");
+        }
     }
 
     static final class LegacyAwareSpringLiquibase extends SpringLiquibase {

--- a/components/core/core-liquibase/src/main/java/org/eclipse/dirigible/components/core/liquibase/LiquibaseSystemConfig.java
+++ b/components/core/core-liquibase/src/main/java/org/eclipse/dirigible/components/core/liquibase/LiquibaseSystemConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.core.liquibase;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.exception.LiquibaseException;
+import liquibase.integration.spring.SpringLiquibase;
+
+/**
+ * Wires Liquibase against the {@code SystemDB} so the DIRIGIBLE_* platform schema is created and
+ * versioned by JSON changelogs in {@code db/changelog/} rather than by Hibernate's
+ * {@code hbm2ddl=update}. The {@code entityManagerFactory} bean in {@code DataSourceSystemConfig}
+ * must {@code @DependsOn("liquibaseSystemDB")} so Hibernate's (validate-only) startup runs after
+ * the changelogs have been applied.
+ *
+ * <p>
+ * Legacy deployments that were originally bootstrapped via {@code hbm2ddl=update} already have
+ * every system table but no {@code DATABASECHANGELOG} entries. {@link #liquibaseSystemDB} extends
+ * {@link SpringLiquibase} to detect that case and call
+ * {@link Liquibase#changeLogSync(Contexts, LabelExpression)} first — every changeset is recorded as
+ * applied without re-running its DDL, preserving the existing data. Fresh deployments fall through
+ * to the normal {@code update()} flow and create the schema from scratch.
+ */
+@Configuration
+public class LiquibaseSystemConfig {
+
+    private static final String CHANGELOG = "classpath:db/changelog/dirigible-system.json";
+
+    /** Sentinel table from the very first changeset — if it exists, the schema is already populated. */
+    private static final String SENTINEL_TABLE = "DIRIGIBLE_SECURITY_ACCESS";
+
+    /** Liquibase's tracking table. Absence indicates the schema was bootstrapped some other way. */
+    private static final String DATABASECHANGELOG_TABLE = "DATABASECHANGELOG";
+
+    @Bean
+    public SpringLiquibase liquibaseSystemDB(@Qualifier("SystemDB") DataSource systemDB) {
+        SpringLiquibase liquibase = new LegacyAwareSpringLiquibase();
+        liquibase.setDataSource(systemDB);
+        liquibase.setChangeLog(CHANGELOG);
+        return liquibase;
+    }
+
+    static final class LegacyAwareSpringLiquibase extends SpringLiquibase {
+
+        private static final Logger logger = LoggerFactory.getLogger(LegacyAwareSpringLiquibase.class);
+
+        @Override
+        protected void performUpdate(Liquibase liquibase) throws LiquibaseException {
+            if (isLegacyDeployment()) {
+                logger.info("Legacy deployment detected — DIRIGIBLE_* tables already exist but DATABASECHANGELOG is empty; "
+                        + "marking every changeset as applied via changelogSync() to preserve existing data.");
+                liquibase.changeLogSync(new Contexts(getContexts()), new LabelExpression(getLabelFilter()));
+            }
+            super.performUpdate(liquibase);
+        }
+
+        private boolean isLegacyDeployment() {
+            try (Connection connection = getDataSource().getConnection()) {
+                return tableExists(connection, SENTINEL_TABLE) && !tableExists(connection, DATABASECHANGELOG_TABLE);
+            } catch (Exception e) {
+                logger.warn("Could not probe for legacy deployment state; proceeding with normal Liquibase update", e);
+                return false;
+            }
+        }
+
+        private boolean tableExists(Connection connection, String tableName) throws Exception {
+            DatabaseMetaData metadata = connection.getMetaData();
+            for (String candidate : new String[] {tableName, tableName.toLowerCase()}) {
+                try (ResultSet rs = metadata.getTables(null, null, candidate, new String[] {"TABLE"})) {
+                    if (rs.next()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/components/core/core-liquibase/src/main/resources/db/changelog/dirigible-system.json
+++ b/components/core/core-liquibase/src/main/resources/db/changelog/dirigible-system.json
@@ -1,0 +1,7714 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_BPMN",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_BPMN"
+                    },
+                    "name": "BPMN_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_CONTENT",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_DEPLOYMENT_ID",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_CATEGORY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_ID",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_KEY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_TENANT_ID",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "BPMN_PROCESS_DEFINITION_VERSION",
+                    "type": "INT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_BPMN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_CAMEL",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_CAMEL"
+                    },
+                    "name": "CAMEL_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CAMEL_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_CAMEL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_CLIENT_REGISTRATIONS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_CLIENT_REGISTRATIONS"
+                    },
+                    "name": "CLIENT_REGISTRATION_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_AUTHORIZATION_GRANT_TYPE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_AUTHORIZATION_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_CLIENT_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_CLIENT_SECRET",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_ISSUER_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_JWK_SET_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_REDIRECT_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_SCOPE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_TOKEN_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_USER_INFO_URI",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CLIENT_REGISTRATION_USER_NAME_ATTRIBUTE_NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_CLIENT_REGISTRATIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_COMPONENTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_COMPONENTS"
+                    },
+                    "name": "COMPONENT_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COMPONENT_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_COMPONENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_CONFLUENCE",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_CONFLUENCE"
+                    },
+                    "name": "CONFLUENCE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "MARKDOWN_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_CONFLUENCE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_CSVIM",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_CSVIM"
+                    },
+                    "name": "CSVIM_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSVIM_DATASOURCE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSVIM_VERSION",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_CSVIM"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_CSV_FILE",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_CSV_FILE"
+                    },
+                    "name": "CSV_FILE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_DELIM_ENCLOSING",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_DELIM_FIELD",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_DISTINGUISH_EMPTY_FROM_NULL",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSV_FILE_FILE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_HEADER",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSV_FILE_IMPORTED",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_LOCALE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSV_FILE_SCHEMA",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_SEQUENCE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSV_FILE_TABLE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_TRIM",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSV_FILE_UPSERT",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CSV_FILE_USE_HEADER_NAMES",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CSVIM_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_CSV_FILE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_SCHEMAS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_SCHEMAS"
+                    },
+                    "name": "SCHEMA_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DATASOURCE",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_SCHEMAS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_SOURCES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_SOURCES"
+                    },
+                    "name": "DS_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DS_DRIVER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DS_PASSWORD",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DS_SCHEMA",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DS_URL",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DS_USERNAME",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_SOURCES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_SOURCE_PROPERTIES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_SOURCE_PROPERTIES"
+                    },
+                    "name": "DSP_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DSP_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DSP_VALUE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DS_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_SOURCE_PROPERTIES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLES"
+                    },
+                    "name": "TABLE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_KIND",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_SCHEMA",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SCHEMA_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_CHECKS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_CHECKS"
+                    },
+                    "name": "CHECK_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_MODIFIERS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CHECK_EXPRESSION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CONSTRAINTS_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_CHECKS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_COLUMNS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_COLUMNS"
+                    },
+                    "name": "COLUMN_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_AUTOINCREMENT",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_DEFAULT_VALUE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_LENGTH",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "COLUMN_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_NULLABLE",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_PRECISION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_PRIMARY_KEY",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_SCALE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "COLUMN_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "COLUMN_UNIQUE",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TABLE_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_COLUMNS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_CONSTRAINTS"
+                    },
+                    "name": "CONSTRAINTS_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TABLE_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_FOREIGNKEYS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_FOREIGNKEYS"
+                    },
+                    "name": "FOREIGNKEY_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_MODIFIERS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "FOREIGNKEY_REF_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "FOREIGNKEY_REF_SCHEMA",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "FOREIGNKEY_REF_TABLE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CONSTRAINTS_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_FOREIGNKEYS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_INDEXES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_INDEXES"
+                    },
+                    "name": "INDEX_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "INDEX_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "INDEX_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "INDEX_ORDER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "INDEX_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "INDEX_UNIQUE",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TABLE_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_INDEXES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_PRIMARYKEYS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_PRIMARYKEYS"
+                    },
+                    "name": "PRIMARYKEY_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_MODIFIERS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CONSTRAINTS_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_PRIMARYKEYS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_TABLE_UNIQUES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_TABLE_UNIQUES"
+                    },
+                    "name": "UNIQUE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_COLUMNS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_MODIFIERS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CONSTRAINT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UNIQUE_INDEXTYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UNIQUE_ORDER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "CONSTRAINTS_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_TABLE_UNIQUES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DATA_VIEWS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DATA_VIEWS"
+                    },
+                    "name": "VIEW_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "VIEW_KIND",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "VIEW_QUERY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "VIEW_SCHEMA",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SCHEMA_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DATA_VIEWS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_DEFINITIONS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_DEFINITIONS"
+                    },
+                    "name": "DEFINITION_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DEFINITION_CHECKSUM",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DEFINITION_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DEFINITION_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DEFINITION_MESSAGE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DEFINITION_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "DEFINITION_STATE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "DEFINITION_TYPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_DEFINITIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ENTITIES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ENTITIES"
+                    },
+                    "name": "ENTITY_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ENTITY_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ENTITIES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_EXPORTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_EXPORTS"
+                    },
+                    "name": "EXPORT_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPORT_FINISHED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPORT_MESSAGE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "EXPORT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPORT_STARTED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPORT_STATUS",
+                    "type": "VARCHAR(50)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_EXPORTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_EXTENSIONS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_EXTENSIONS"
+                    },
+                    "name": "EXTENSION_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "EXTENSION_EXTENSIONPOINT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "EXTENSION_MODULE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXTENSION_ROLE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_EXTENSIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_EXTENSION_POINTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_EXTENSION_POINTS"
+                    },
+                    "name": "EXTENSIONPOINT_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_EXTENSION_POINTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_JAVA_FILES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_JAVA_FILES"
+                    },
+                    "name": "JAVAFILE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JAVAFILE_CLASS_FQN",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JAVAFILE_PROJECT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_JAVA_FILES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_JOBS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_JOBS"
+                    },
+                    "name": "JOB_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_CLASS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_ENABLED",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOB_ENGINE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOB_EXECUTED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_EXPRESSION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_GROUP",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOB_HANDLER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOB_MESSAGE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_SINGLETON",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOB_STATUS",
+                    "type": "VARCHAR(50)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_JOBS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_JOB_EMAILS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_JOB_EMAILS"
+                    },
+                    "name": "JOBEMAIL_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBEMAIL_EMAIL",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBEMAIL_JOB_NAME",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_JOB_EMAILS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_JOB_LOGS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_JOB_LOGS"
+                    },
+                    "name": "JOBLOG_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBLOG_FINISHED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBLOG_HANDLER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBLOG_JOB_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBLOG_MESSAGE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBLOG_STATUS",
+                    "type": "VARCHAR(50)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBLOG_TENANT_ID",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBLOG_TRIGGERED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBLOG_TRIGGERED_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_JOB_LOGS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_JOB_PARAMETERS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_JOB_PARAMETERS"
+                    },
+                    "name": "JOBPARAM_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBPARAM_CHOICES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBPARAM_DEFAULT_VALUE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBPARAM_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOBPARAM_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "JOBPARAM_VALUE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "JOB_ID",
+                    "type": "BIGINT"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_JOB_PARAMETERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_LISTENERS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_LISTENERS"
+                    },
+                    "name": "LISTENER_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "LISTENER_HANDLER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "LISTENER_KIND",
+                    "type": "CHAR(1)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_LISTENERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_MARKDOWN",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_MARKDOWN"
+                    },
+                    "name": "MARKDOWN_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "MARKDOWN_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_MARKDOWN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_NATIVE_APPS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_NATIVE_APPS"
+                    },
+                    "name": "NATIVE_APP_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "NATIVE_APP_BASE_PATH",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NATIVE_APP_CONFIG_JSON",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NATIVE_APP_DEFAULT_PORT",
+                    "type": "INT"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "NATIVE_APP_KIND",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NATIVE_APP_REMOTE_URL",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NATIVE_APP_START_MODE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_NATIVE_APPS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ODATA",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ODATA"
+                    },
+                    "name": "ODATA_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "HDB_CONTENT",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ODATA_NAMESPACE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ODATA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ODATA_CONTAINER",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ODATA_CONTAINER"
+                    },
+                    "name": "ODATAC_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ODATAC_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ODATA_CONTAINER"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ODATA_HANDLER",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ODATA_HANDLER"
+                    },
+                    "name": "ODATAH_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ODATAH_HANDLER",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ODATAH_KIND",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ODATAH_METHOD",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ODATAH_NAMESPACE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ODATA_HANDLER"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ODATA_MAPPING",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ODATA_MAPPING"
+                    },
+                    "name": "ODATAM_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ODATAM_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ODATA_MAPPING"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_ODATA_SCHEMA",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_ODATA_SCHEMA"
+                    },
+                    "name": "ODATAX_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ODATAX_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_ODATA_SCHEMA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_OPENAPI",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_OPENAPI"
+                    },
+                    "name": "OPENAPI_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "OPENAPI_CONTENT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_OPENAPI"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_PROBLEMS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_PROBLEMS"
+                    },
+                    "name": "PROBLEM_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_CATEGORY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_CAUSE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_COLUMN",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_EXPECTED",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_LINE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_MODULE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_PROGRAM",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_SOURCE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROBLEM_TYPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_PROBLEMS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_PROXY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_PROXY"
+                    },
+                    "name": "PROXY_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "PROXY_URL",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_PROXY"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_SECURITY_ACCESS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_SECURITY_ACCESS"
+                    },
+                    "name": "ACCESS_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ACCESS_METHOD",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ACCESS_PATH",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ACCESS_ROLE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ACCESS_SCOPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_SECURITY_ACCESS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_SECURITY_ROLES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_SECURITY_ROLES"
+                    },
+                    "name": "ROLE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_SECURITY_ROLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_SECURITY_SCOPES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_SECURITY_SCOPES"
+                    },
+                    "name": "SCOPE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "SCOPE_SCOPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_SECURITY_SCOPES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_SECURITY_SCOPE_ROLES",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "SCOPEROLE_SCOPE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SCOPEROLE_ROLE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_SECURITY_SCOPE_ROLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_TASK_STATE",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TASK_STATE"
+                    },
+                    "name": "TASKSTATE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_DEFINITION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_ENDED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TASKSTATE_EXECUTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_INSTANCE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TASKSTATE_STARTED",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TASKSTATE_STATUS",
+                    "type": "INT"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TASKSTATE_STEP",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_TENANT",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATE_THREAD",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TASKSTATE_TYPE",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_TASK_STATE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_TASK_STATE_INPUT",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TASK_STATE_INPUT"
+                    },
+                    "name": "TASKSTATEIN_TASKSTATE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATEIN_VALUE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TASK_STATE_INPUT"
+                    },
+                    "name": "TASKSTATEIN_NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_TASK_STATE_INPUT"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_TASK_STATE_OUTPUT",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TASK_STATE_OUTPUT"
+                    },
+                    "name": "TASKSTATEOUT_TASKSTATE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TASKSTATEOUT_VALUE",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TASK_STATE_OUTPUT"
+                    },
+                    "name": "TASKSTATEOUT_NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_TASK_STATE_OUTPUT"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_TENANTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_TENANTS"
+                    },
+                    "name": "TENANT_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TENANT_STATUS",
+                    "type": "VARCHAR(50)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "TENANT_SUBDOMAIN",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_TENANTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_USERS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_USERS"
+                    },
+                    "name": "USER_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "USER_PASSWORD",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "USER_USERNAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "USER_TENANT_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_USERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_USER_ROLE_ASSIGNMENTS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ROLE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "USER_ID",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_WEBSOCKETS",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_WEBSOCKETS"
+                    },
+                    "name": "WEBSOCKET_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "WEBSOCKET_ENDPOINT_NAME",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "WEBSOCKET_ENGINE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "WEBSOCKET_HANDLER",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_WEBSOCKETS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "create-DIRIGIBLE_WEB_EXPOSE",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "nullable": false,
+                      "primaryKey": true,
+                      "primaryKeyName": "PK_DIRIGIBLE_WEB_EXPOSE"
+                    },
+                    "name": "EXPOSE_ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "CREATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_AT",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "UPDATED_BY",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DEPENDENCIES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_DESCRIPTION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_ERROR",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_KEY",
+                    "type": "VARCHAR(2000)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_STATUS",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_LOCATION",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_NAME",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_PHASE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "ARTEFACT_RUNNING",
+                    "type": "BOOLEAN"
+                  }
+                },
+                {
+                  "column": {
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "ARTEFACT_TYPE",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPOSE_EXPOSES",
+                    "type": "CLOB"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "EXPOSE_PROJECT",
+                    "type": "CLOB"
+                  }
+                }
+              ],
+              "tableName": "DIRIGIBLE_WEB_EXPOSE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ODATA_CONTAINER_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ODATA_CONTAINER_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ODATA_CONTAINER"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLE_UNIQUES_CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "CONSTRAINTS_ID",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLE_UNIQUES_CONSTRAINTS_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_UNIQUES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_JAVA_FILES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_JAVA_FILES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_JAVA_FILES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_BPMN_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_BPMN_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_BPMN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_SOURCES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_DATA_SOURCES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_DATA_SOURCES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_PROXY_ARTEFACT_NAME",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_NAME",
+              "constraintName": "UK_DIRIGIBLE_PROXY_ARTEFACT_NAME",
+              "tableName": "DIRIGIBLE_PROXY"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_JOB_LOGS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_JOB_LOGS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_JOB_LOGS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLE_PRIMARYKEYS_CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "CONSTRAINTS_ID",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLE_PRIMARYKEYS_CONSTRAINTS_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_PRIMARYKEYS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_COMPONENTS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_COMPONENTS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_COMPONENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ODATA_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ODATA_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ODATA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLE_FOREIGNKEYS_CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "CONSTRAINTS_ID",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLE_FOREIGNKEYS_CONSTRAINTS_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_FOREIGNKEYS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ODATA_HANDLER_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ODATA_HANDLER_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ODATA_HANDLER"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_WEBSOCKETS_WEBSOCKET_ENDPOINT_NAME",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "WEBSOCKET_ENDPOINT_NAME",
+              "constraintName": "UK_DIRIGIBLE_WEBSOCKETS_WEBSOCKET_ENDPOINT_NAME",
+              "tableName": "DIRIGIBLE_WEBSOCKETS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_TENANTS_TENANT_SUBDOMAIN",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "TENANT_SUBDOMAIN",
+              "constraintName": "UK_DIRIGIBLE_TENANTS_TENANT_SUBDOMAIN",
+              "tableName": "DIRIGIBLE_TENANTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_JOBS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_JOBS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_JOBS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_TENANTS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_TENANTS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_TENANTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_MARKDOWN_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_MARKDOWN_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_MARKDOWN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_CONFLUENCE_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_CONFLUENCE_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_CONFLUENCE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_PROXY_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_PROXY_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_PROXY"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_WEB_EXPOSE_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_WEB_EXPOSE_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_WEB_EXPOSE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_EXTENSION_POINTS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_EXTENSION_POINTS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_EXTENSION_POINTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_CSVIM_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_CSVIM_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_CSVIM"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_CLIENT_REGISTRATIONS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_CLIENT_REGISTRATIONS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_CLIENT_REGISTRATIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_NATIVE_APPS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_NATIVE_APPS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_NATIVE_APPS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_CSV_FILE_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_CSV_FILE_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_CSV_FILE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_USER_ID_ROLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "USER_ID, ROLE_ID",
+              "constraintName": "UK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_USER_ID_ROLE_ID",
+              "tableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLE_CHECKS_CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "CONSTRAINTS_ID",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLE_CHECKS_CONSTRAINTS_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_CHECKS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_WEBSOCKETS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_WEBSOCKETS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_WEBSOCKETS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ODATA_SCHEMA_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ODATA_SCHEMA_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ODATA_SCHEMA"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_LISTENERS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_LISTENERS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_LISTENERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_DATA_TABLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_SCHEMAS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_DATA_SCHEMAS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_DATA_SCHEMAS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_JOB_EMAILS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_JOB_EMAILS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_JOB_EMAILS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ENTITIES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ENTITIES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ENTITIES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_EXTENSIONS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_EXTENSIONS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_EXTENSIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_CAMEL_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_CAMEL_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_CAMEL"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_SECURITY_ACCESS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_SECURITY_ACCESS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_SECURITY_ACCESS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_OPENAPI_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_OPENAPI_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_OPENAPI"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_TABLE_CONSTRAINTS_TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "TABLE_ID",
+              "constraintName": "UK_DIRIGIBLE_DATA_TABLE_CONSTRAINTS_TABLE_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_USERS_USER_TENANT_ID_USER_USERNAME",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "USER_TENANT_ID, USER_USERNAME",
+              "constraintName": "UK_DIRIGIBLE_USERS_USER_TENANT_ID_USER_USERNAME",
+              "tableName": "DIRIGIBLE_USERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DEFINITIONS_DEFINITION_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "DEFINITION_KEY",
+              "constraintName": "UK_DIRIGIBLE_DEFINITIONS_DEFINITION_KEY",
+              "tableName": "DIRIGIBLE_DEFINITIONS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_ODATA_MAPPING_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_ODATA_MAPPING_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_ODATA_MAPPING"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_DATA_VIEWS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_DATA_VIEWS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_DATA_VIEWS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_USERS_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_USERS_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_USERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_SECURITY_SCOPES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_SECURITY_SCOPES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_SECURITY_SCOPES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_SECURITY_ROLES_ARTEFACT_KEY",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_KEY",
+              "constraintName": "UK_DIRIGIBLE_SECURITY_ROLES_ARTEFACT_KEY",
+              "tableName": "DIRIGIBLE_SECURITY_ROLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_NATIVE_APPS_NATIVE_APP_BASE_PATH",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "NATIVE_APP_BASE_PATH",
+              "constraintName": "UK_DIRIGIBLE_NATIVE_APPS_NATIVE_APP_BASE_PATH",
+              "tableName": "DIRIGIBLE_NATIVE_APPS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "UK_DIRIGIBLE_NATIVE_APPS_ARTEFACT_NAME",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addUniqueConstraint": {
+              "columnNames": "ARTEFACT_NAME",
+              "constraintName": "UK_DIRIGIBLE_NATIVE_APPS_ARTEFACT_NAME",
+              "tableName": "DIRIGIBLE_NATIVE_APPS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_DATA_TABLE_INDEXES_TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "TABLE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_DATA_TABLE_INDEXES_TABLE_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_INDEXES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_DATA_TABLES_SCHEMA_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "SCHEMA_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_DATA_TABLES_SCHEMA_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_USERS_USER_TENANT_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "USER_TENANT_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_USERS_USER_TENANT_ID",
+              "tableName": "DIRIGIBLE_USERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_DATA_SOURCE_PROPERTIES_DS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "DS_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_DATA_SOURCE_PROPERTIES_DS_ID",
+              "tableName": "DIRIGIBLE_DATA_SOURCE_PROPERTIES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_TASK_STATE_INPUT_TASKSTATEIN_TASKSTATE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "TASKSTATEIN_TASKSTATE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_TASK_STATE_INPUT_TASKSTATEIN_TASKSTATE_ID",
+              "tableName": "DIRIGIBLE_TASK_STATE_INPUT"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_CSV_FILE_CSVIM_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "CSVIM_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_CSV_FILE_CSVIM_ID",
+              "tableName": "DIRIGIBLE_CSV_FILE"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_DATA_TABLE_COLUMNS_TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "TABLE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_DATA_TABLE_COLUMNS_TABLE_ID",
+              "tableName": "DIRIGIBLE_DATA_TABLE_COLUMNS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_USER_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "USER_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_USER_ID",
+              "tableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_DATA_VIEWS_SCHEMA_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "SCHEMA_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_DATA_VIEWS_SCHEMA_ID",
+              "tableName": "DIRIGIBLE_DATA_VIEWS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_TASK_STATE_OUTPUT_TASKSTATEOUT_TASKSTATE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "TASKSTATEOUT_TASKSTATE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_TASK_STATE_OUTPUT_TASKSTATEOUT_TASKSTATE_ID",
+              "tableName": "DIRIGIBLE_TASK_STATE_OUTPUT"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_JOB_PARAMETERS_JOB_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "JOB_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_JOB_PARAMETERS_JOB_ID",
+              "tableName": "DIRIGIBLE_JOB_PARAMETERS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_ROLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "ROLE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_USER_ROLE_ASSIGNMENTS_ROLE_ID",
+              "tableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "IX_DIRIGIBLE_SECURITY_SCOPE_ROLES_SCOPEROLE_SCOPE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "createIndex": {
+              "associatedWith": "",
+              "columns": [
+                {
+                  "column": {
+                    "name": "SCOPEROLE_SCOPE_ID"
+                  }
+                }
+              ],
+              "indexName": "IX_DIRIGIBLE_SECURITY_SCOPE_ROLES_SCOPEROLE_SCOPE_ID",
+              "tableName": "DIRIGIBLE_SECURITY_SCOPE_ROLES"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_INDEXES__TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "TABLE_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_INDEXES",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_INDEXES__TABLE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TABLE_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_CHECKS__CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "CONSTRAINTS_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_CHECKS",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_CHECKS__CONSTRAINTS_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "CONSTRAINTS_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_FOREIGNKEYS__CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "CONSTRAINTS_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_FOREIGNKEYS",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_FOREIGNKEYS__CONSTRAINTS_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "CONSTRAINTS_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLES__SCHEMA_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "SCHEMA_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLES",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLES__SCHEMA_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "SCHEMA_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_SCHEMAS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_USERS__USER_TENANT_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "USER_TENANT_ID",
+              "baseTableName": "DIRIGIBLE_USERS",
+              "constraintName": "FK_DIRIGIBLE_USERS__USER_TENANT_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TENANT_ID",
+              "referencedTableName": "DIRIGIBLE_TENANTS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_SOURCE_PROPERTIES__DS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "DS_ID",
+              "baseTableName": "DIRIGIBLE_DATA_SOURCE_PROPERTIES",
+              "constraintName": "FK_DIRIGIBLE_DATA_SOURCE_PROPERTIES__DS_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "DS_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_SOURCES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_TASK_STATE_INPUT__TASKSTATEIN_TASKSTATE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "TASKSTATEIN_TASKSTATE_ID",
+              "baseTableName": "DIRIGIBLE_TASK_STATE_INPUT",
+              "constraintName": "FK_DIRIGIBLE_TASK_STATE_INPUT__TASKSTATEIN_TASKSTATE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TASKSTATE_ID",
+              "referencedTableName": "DIRIGIBLE_TASK_STATE",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_CSV_FILE__CSVIM_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "CSVIM_ID",
+              "baseTableName": "DIRIGIBLE_CSV_FILE",
+              "constraintName": "FK_DIRIGIBLE_CSV_FILE__CSVIM_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "CSVIM_ID",
+              "referencedTableName": "DIRIGIBLE_CSVIM",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_COLUMNS__TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "TABLE_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_COLUMNS",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_COLUMNS__TABLE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TABLE_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_PRIMARYKEYS__CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "CONSTRAINTS_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_PRIMARYKEYS",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_PRIMARYKEYS__CONSTRAINTS_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "CONSTRAINTS_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS__USER_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "USER_ID",
+              "baseTableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS",
+              "constraintName": "FK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS__USER_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "USER_ID",
+              "referencedTableName": "DIRIGIBLE_USERS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_UNIQUES__CONSTRAINTS_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "CONSTRAINTS_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_UNIQUES",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_UNIQUES__CONSTRAINTS_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "CONSTRAINTS_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_VIEWS__SCHEMA_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "SCHEMA_ID",
+              "baseTableName": "DIRIGIBLE_DATA_VIEWS",
+              "constraintName": "FK_DIRIGIBLE_DATA_VIEWS__SCHEMA_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "SCHEMA_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_SCHEMAS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_TASK_STATE_OUTPUT__TASKSTATEOUT_TASKSTATE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "TASKSTATEOUT_TASKSTATE_ID",
+              "baseTableName": "DIRIGIBLE_TASK_STATE_OUTPUT",
+              "constraintName": "FK_DIRIGIBLE_TASK_STATE_OUTPUT__TASKSTATEOUT_TASKSTATE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TASKSTATE_ID",
+              "referencedTableName": "DIRIGIBLE_TASK_STATE",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_DATA_TABLE_CONSTRAINTS__TABLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "TABLE_ID",
+              "baseTableName": "DIRIGIBLE_DATA_TABLE_CONSTRAINTS",
+              "constraintName": "FK_DIRIGIBLE_DATA_TABLE_CONSTRAINTS__TABLE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "TABLE_ID",
+              "referencedTableName": "DIRIGIBLE_DATA_TABLES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_JOB_PARAMETERS__JOB_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "JOB_ID",
+              "baseTableName": "DIRIGIBLE_JOB_PARAMETERS",
+              "constraintName": "FK_DIRIGIBLE_JOB_PARAMETERS__JOB_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "JOB_ID",
+              "referencedTableName": "DIRIGIBLE_JOBS",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS__ROLE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "ROLE_ID",
+              "baseTableName": "DIRIGIBLE_USER_ROLE_ASSIGNMENTS",
+              "constraintName": "FK_DIRIGIBLE_USER_ROLE_ASSIGNMENTS__ROLE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "CASCADE",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "ROLE_ID",
+              "referencedTableName": "DIRIGIBLE_SECURITY_ROLES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "FK_DIRIGIBLE_SECURITY_SCOPE_ROLES__SCOPEROLE_SCOPE_ID",
+        "author": "dirigible",
+        "changes": [
+          {
+            "addForeignKeyConstraint": {
+              "baseColumnNames": "SCOPEROLE_SCOPE_ID",
+              "baseTableName": "DIRIGIBLE_SECURITY_SCOPE_ROLES",
+              "constraintName": "FK_DIRIGIBLE_SECURITY_SCOPE_ROLES__SCOPEROLE_SCOPE_ID",
+              "deferrable": false,
+              "initiallyDeferred": false,
+              "onDelete": "RESTRICT",
+              "onUpdate": "RESTRICT",
+              "referencedColumnNames": "SCOPE_ID",
+              "referencedTableName": "DIRIGIBLE_SECURITY_SCOPES",
+              "validate": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/components/group/group-core/pom.xml
+++ b/components/group/group-core/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-core-liquibase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-core-repository</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -30,6 +30,7 @@
         <module>core/core-tenants</module>
         <module>core/core-tracing</module>
         <module>core/core-java</module>
+        <module>core/core-liquibase</module>
 
         <!-- Security -->
         <module>security/security-basic</module>
@@ -530,6 +531,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-core-java</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-core-liquibase</artifactId>
                 <version>${project.version}</version>
             </dependency>
 


### PR DESCRIPTION
## Summary
- New `components/core/core-liquibase` module owns the DIRIGIBLE_* schema for SystemDB via a Liquibase JSON changelog (`db/changelog/dirigible-system.json`, 131 changesets, 52 tables).
- `DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO` default flipped from `update` → `none`. Hibernate on SystemDB now issues no DDL and no schema probes at boot, eliminating the H2 `SYS`-lock race that multiple Spring test contexts triggered during DDL planning.
- `DataSourceSystemConfig.entityManagerFactory` gains `@DependsOn("liquibaseSystemDB")` so the changelog runs before Hibernate wires up.
- `LegacyAwareSpringLiquibase` detects existing deployments (DIRIGIBLE_SECURITY_ACCESS exists, no `DATABASECHANGELOG`) and calls `changeLogSync()` so every changeset is marked applied without re-running DDL — zero data loss on upgrade.

## Scope
- SystemDB cutover only. Dynamic user entities (TypeScript `@Entity` via `data-store`, Java `@Entity` via `data-store-java`) are untouched and keep `hbm2ddl=update` — their schema is authored by user code, not by versioned changelogs.

## Source of the changelog
Baseline generated by running `liquibase generate-changelog` against a fresh hbm2ddl-built H2 SystemDB, then post-processed to:
- Replace H2-auto constraint names (`CONSTRAINT_18`, `CONSTRAINT_CB`, ...) with deterministic ones (`PK_<table>`, `UK_<table>_<col>`, `FK_<base>__<col>`, `IX_<table>_<col>`).
- Map `VARCHAR(1000000000)` (Hibernate's unbounded String) to:
  - `VARCHAR(2000)` for columns that participate in any PK/UK/FK/index (H2 can't index CLOB).
  - `CLOB` for non-indexed content columns (`BPMN_CONTENT`, `CAMEL_CONTENT`, etc.) — Liquibase translates `CLOB` to the right vendor type (H2 CLOB, Postgres TEXT, MSSQL NVARCHAR(MAX)).
- Map H2 `ENUM(...)` to `VARCHAR(50)` for portability across Postgres/MSSQL.
- Assign stable descriptive changeset ids (`create-DIRIGIBLE_<table>`, `UK_<table>_<col>`, ...) so future regeneration doesn't churn history.

## Test plan
- [x] Local: `mvn -pl tests/tests-integrations -P integration-tests -Dit.test=JavaEngineIT verify` → all 4 tests pass on a fresh H2 in 103s.
- [ ] CI: `integration-tests-h2`, `-postgresql`, `-mssql` on this PR — the multi-vendor matrix exercises Liquibase's type translation. Possible follow-ups if vendor-specific tweaks are needed.
- [ ] Manual verification of the legacy upgrade path: deploy on a SystemDB that has all DIRIGIBLE_* tables but no DATABASECHANGELOG, then start the app — `LegacyAwareSpringLiquibase.isLegacyDeployment()` should log `Legacy deployment detected — ... marking every changeset as applied via changelogSync()` and the existing rows survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)