### PR TITLE
release.yml: don't let a third-party PDF SaaS outage block the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,8 +441,14 @@ jobs:
       - name: Create dummy reports folder
         run: mkdir reports
 
+      # rsdmike/github-security-report-action calls out to a hosted PDF-generation
+      # service; that service has been timing out on every release attempt. Mark the
+      # step as continue-on-error so a third-party SaaS outage does not block the
+      # GitHub Release / Helm publish — the real security artefacts (CodeQL SARIFs,
+      # Docker Scout SARIF, ZAP HTML) are uploaded by their own jobs and are unaffected.
       - name: Generate GitHub Security Report
         uses: rsdmike/github-security-report-action@v3.0.4
+        continue-on-error: true
         with:
           template: summary
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -450,6 +456,7 @@ jobs:
           outputDir: "security-report"
 
       - name: Upload Generated GitHub Security Report as Artifact
+        if: ${{ hashFiles('security-report/**') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: security_report
@@ -520,15 +527,22 @@ jobs:
       - name: Copy report files due to naming collisions
         if: ${{ inputs.code-scans }}
         run: |
-          cp uploaded-artifacts/security_report/summary.pdf release_files/security-report.pdf
-          
+          # security-report.pdf is best-effort: the upstream PDF generator action
+          # (rsdmike/github-security-report-action) calls a hosted service that
+          # sometimes times out. Skip the copy rather than fail the release.
+          if [ -f uploaded-artifacts/security_report/summary.pdf ]; then
+            cp uploaded-artifacts/security_report/summary.pdf release_files/security-report.pdf
+          else
+            echo "::warning::security_report/summary.pdf not produced; skipping security-report.pdf from the release."
+          fi
+
           cp uploaded-artifacts/sast_codeql_sarif_java-kotlin/java.sarif release_files/sast_codeql_sarif_java-kotlin.sarif
           cp uploaded-artifacts/sast_codeql_sarif_javascript-typescript/javascript.sarif release_files/sast_codeql_sarif_javascript-typescript.sarif
-          
+
           cp uploaded-artifacts/sast_docker_scout_sarif.json/sast_docker_scout_sarif.json release_files/sast_docker_scout_sarif.json
-          
+
           cp uploaded-artifacts/dast_zap_report/report_html.html release_files/dast_zap_report.html
-          
+
           cp uploaded-artifacts/application-all/application-all.zip release_files/application-all.zip
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

`rsdmike/github-security-report-action@v3.0.4` calls out to a hosted PDF generation service. That service has been timing out on every release attempt — [run 27354926894](https://github.com/eclipse-dirigible/dirigible/actions/runs/27354926894/job/80870563641) failed three times across retries — failing the \`generate-git-security-report\` job. Because both \`github-release\` and \`helm-release\` chain off it, the GitHub Release page and the Helm chart publish were stuck **even though** Maven Central, the Docker images (amd64 + arm64), CodeQL, Docker Scout and ZAP all succeeded.

The PDF is a convenience artefact built from **empty input** — the job's "Create dummy reports folder" step creates an empty \`reports/\` dir and the action then attaches no SARIFs (\`SARIF files detected: []\` in the log). The real security artefacts already ship via the per-scanner jobs.

## Changes

1. **\`Generate GitHub Security Report\` step** gets \`continue-on-error: true\`. The action still tries the PDF; a SaaS timeout no longer transitions the job to failed.
2. **\`Upload Generated GitHub Security Report as Artifact\` step** gets \`if: \${{ hashFiles('security-report/**') != '' }}\` so it skips when the action produced nothing.
3. **\`Copy report files due to naming collisions\` step** in \`github-release\` guards \`cp summary.pdf\` with an existence check and emits a \`::warning::\` when the PDF is missing. The CodeQL / Docker Scout / ZAP / application-all copies are untouched.

## Net effect

The security-report PDF becomes an **optional release file**. If the upstream SaaS recovers, it lands as before. If it stays broken, the GitHub Release ships without that one PDF (the warning will surface in the workflow summary) and ops can ship a follow-up if needed. No other security artefact in the release is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)