### PR TITLE
Upgraded Monaco editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,68 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Provides behavioral guidelines to reduce common LLM coding mistakes and guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Project
 

--- a/components/engine/engine-web/src/main/resources/platform-links.json
+++ b/components/engine/engine-web/src/main/resources/platform-links.json
@@ -204,10 +204,6 @@
     },
     {
       "type": "SCRIPT",
-      "path": "/webjars/monaco-editor/min/vs/editor/editor.main.nls.js"
-    },
-    {
-      "type": "SCRIPT",
       "path": "/webjars/monaco-editor/min/vs/editor/editor.main.js"
     },
     {

--- a/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/diff-view.html
+++ b/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/diff-view.html
@@ -181,16 +181,18 @@
                                     containerEl.removeChild(containerEl.children.item(i));
                             }
                             let editor = monaco.editor.createDiffEditor(containerEl, {
+                                renderSideBySide: true,
+                                diffAlgorithm: "advanced",
+                                renderIndicators: true,
+                                renderOverviewRuler: true,
+                                originalEditable: false,
                                 automaticLayout: true,
                                 readOnly: true,
                                 scrollBeyondLastLine: false,
                                 enableSplitViewResizing: false,
+                                ignoreTrimWhitespace: false,
                             });
 
-                            monaco.editor.createDiffNavigator(editor, {
-                                followsCaret: true,
-                                ignoreCharChanges: true,
-                            });
                             resolve(editor);
                             window.onresize = function () {
                                 diffEditor.layout();

--- a/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/editor.js
+++ b/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/editor.js
@@ -826,7 +826,7 @@ class DirigibleEditor {
     configureMonaco() {
         const fileObject = this.fileObject;
 
-        this.monaco.languages.typescript.javascriptDefaults.setDiagnosticsOptions({
+        this.monaco.typescript.javascriptDefaults.setDiagnosticsOptions({
             noSemanticValidation: false,
             noSyntaxValidation: false,
             noSuggestionDiagnostics: false,
@@ -844,7 +844,7 @@ class DirigibleEditor {
             ]
         });
 
-        this.monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+        this.monaco.typescript.typescriptDefaults.setDiagnosticsOptions({
             noSemanticValidation: false,
             noSyntaxValidation: false,
             noSuggestionDiagnostics: false,
@@ -854,8 +854,8 @@ class DirigibleEditor {
             ]
         });
 
-        this.monaco.languages.typescript.javascriptDefaults.setCompilerOptions({
-            target: this.monaco.languages.typescript.ScriptTarget.ESNext,
+        this.monaco.typescript.javascriptDefaults.setCompilerOptions({
+            target: this.monaco.typescript.ScriptTarget.ESNext,
             strict: true,
             strictNullChecks: true,
             strictPropertyInitialization: true,
@@ -867,14 +867,14 @@ class DirigibleEditor {
             noUnusedLocals: true,
             checkJs: true,
             noFallthroughCasesInSwitch: true,
-            module: (this.fileName?.endsWith(".mjs") === true) ? this.monaco.languages.typescript.ModuleKind.ESNext : this.monaco.languages.typescript.ModuleKind.CommonJS,
-            moduleResolution: this.monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+            module: (this.fileName?.endsWith(".mjs") === true) ? this.monaco.typescript.ModuleKind.ESNext : this.monaco.typescript.ModuleKind.CommonJS,
+            moduleResolution: this.monaco.typescript.ModuleResolutionKind.NodeJs,
             resolveJsonModule: true,
             jsx: (this.fileName?.endsWith(".jsx") === true) ? "react" : undefined
         });
 
-        this.monaco.languages.typescript.typescriptDefaults.setCompilerOptions({
-            target: this.monaco.languages.typescript.ScriptTarget.ESNext,
+        this.monaco.typescript.typescriptDefaults.setCompilerOptions({
+            target: this.monaco.typescript.ScriptTarget.ESNext,
             strict: true,
             strictNullChecks: true,
             strictPropertyInitialization: true,
@@ -886,18 +886,18 @@ class DirigibleEditor {
             noUnusedLocals: true,
             checkJs: true,
             noFallthroughCasesInSwitch: true,
-            module: this.monaco.languages.typescript.ModuleKind.ESNext,
-            moduleResolution: this.monaco.languages.typescript.ModuleResolutionKind.NodeJs,
+            module: this.monaco.typescript.ModuleKind.ESNext,
+            moduleResolution: this.monaco.typescript.ModuleResolutionKind.NodeJs,
             esModuleInterop: true,
             resolveJsonModule: true,
             jsx: (this.fileName?.endsWith(".tsx") === true) ? "react" : undefined
         });
 
-        this.monaco.languages.typescript.javascriptDefaults.addExtraLib('/** $. XSJS API */ var $: any;', 'ts:$.js');
+        this.monaco.typescript.javascriptDefaults.addExtraLib('/** $. XSJS API */ var $: any;', 'ts:$.js');
 
-        this.monaco.languages.html.registerHTMLLanguageService('xml', {}, { documentFormattingEdits: true });
+        this.monaco.html.registerHTMLLanguageService('xml', {}, { documentFormattingEdits: true });
 
-        this.monaco.languages.html.htmlDefaults.setOptions({
+        this.monaco.html.htmlDefaults.setOptions({
             format: {
                 tabSize: 2,
                 insertSpaces: true,
@@ -1286,7 +1286,7 @@ class TypeScriptUtils {
                 const importedFileMetadata = await fileIO.loadText(importedFilePath);
                 let uriPath = importedFileMetadata.filePath;
                 if (TypeScriptUtils.isGlobalImport(importedFile)) {
-                    monaco.languages.typescript.typescriptDefaults.addExtraLib(
+                    monaco.typescript.typescriptDefaults.addExtraLib(
                         importedFileMetadata.sourceCode,
                         `file:///node_modules/@types/${importedFile.substring(0, importedFile.indexOf('.ts'))}.d.ts`
                     );
@@ -1316,14 +1316,14 @@ class TypeScriptUtils {
         const res = await fetch('/services/js/all-dts');
         const allDts = await res.json();
         for (const dts of allDts) {
-            monaco.languages.typescript.javascriptDefaults.addExtraLib(dts.content, dts.filePath);
-            monaco.languages.typescript.typescriptDefaults.addExtraLib(dts.content, dts.filePath);
+            monaco.typescript.javascriptDefaults.addExtraLib(dts.content, dts.filePath);
+            monaco.typescript.typescriptDefaults.addExtraLib(dts.content, dts.filePath);
         }
 
         const cachedDts = window.sessionStorage.getItem('dtsContent');
         if (cachedDts) {
-            monaco.languages.typescript.javascriptDefaults.addExtraLib(cachedDts, "");
-            monaco.languages.typescript.typescriptDefaults.addExtraLib(cachedDts, "");
+            monaco.typescript.javascriptDefaults.addExtraLib(cachedDts, "");
+            monaco.typescript.typescriptDefaults.addExtraLib(cachedDts, "");
         } else {
             const xhrModules = new XMLHttpRequest();
             xhrModules.open('GET', '/services/js/editor-monaco-extensions/api/dts.js');
@@ -1331,8 +1331,8 @@ class TypeScriptUtils {
             xhrModules.onload = function (xhrModules) {
                 // @ts-ignore
                 const dtsContent = xhrModules.target.responseText;
-                monaco.languages.typescript.javascriptDefaults.addExtraLib(dtsContent, "");
-                monaco.languages.typescript.typescriptDefaults.addExtraLib(dtsContent, "");
+                monaco.typescript.javascriptDefaults.addExtraLib(dtsContent, "");
+                monaco.typescript.typescriptDefaults.addExtraLib(dtsContent, "");
                 window.sessionStorage.setItem('dtsContent', dtsContent);
             };
             xhrModules.onerror = function (error) {

--- a/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/lsp/package.json
+++ b/components/ui/editor-monaco/src/main/resources/META-INF/dirigible/editor-monaco/js/lsp/package.json
@@ -8,7 +8,7 @@
     "devDependencies": {
         "esbuild": "^0.24.0",
         "typescript": "^5.7.0",
-        "monaco-editor": "^0.40.0",
+        "monaco-editor": "^0.55.1",
         "vscode-languageserver-types": "^3.17.0"
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <logcaptor.version>2.12.6</logcaptor.version>
 
         <!-- UI -->
-        <blimpkit.version>2.3.0</blimpkit.version>
+        <blimpkit.version>2.3.1</blimpkit.version>
         <sap-theming__theming-base-content.version>11.18.2</sap-theming__theming-base-content.version>
         <chart.js.version>4.4.3</chart.js.version>
         <sortablejs.version>1.15.7</sortablejs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
         <angular-aria.version>1.8.2</angular-aria.version>
         <split.js.version>1.6.5</split.js.version>
         <diff.version>5.1.0</diff.version>
-        <monaco-editor.version>0.40.0</monaco-editor.version>
+        <monaco-editor.version>0.55.1</monaco-editor.version>
         <requirejs.version>2.3.6</requirejs.version>
         <stompjs.version>7.2.1</stompjs.version>
         <jstree.version>3.3.12</jstree.version>


### PR DESCRIPTION
### What does this PR do?

Upgrade the bundled Monaco editor from 0.40.0 to 0.55.1 (~2.5 years of upstream fixes, security patches, and the new default diff editor).

1. Namespace change
Monaco moved the language namespaces outside the `language` object, so we had to do a lot of changes like this - `monaco.languages.typescript.*` -> `monaco.typescript.*`.
2. Removed `createDiffNavigator` as it was removed upstream.
3. Modernized the `createDiffEditor` options.
Took advantage of the more advanced diff algorithm in the newer version. Also enabled whitespace changes as previously they were not being rendered.
4. The `editor.main.nls.js` link is removed.
The English-NLS module got removed as Monaco inlined the default English strings directly into `editor.main.js`. Might want to look into locale support in the future if we introduce a second language for the IDE part of Dirigible.

### What issues does this PR fix or reference?

#6024 