### PR TITLE
Fix Java LSP completion for git-backed projects (follow symlinks)

### DIFF
--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -248,9 +249,16 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
     /**
      * Returns {@code true} if the given directory contains at least one {@code .java} file within the
      * first five levels of nesting.
+     *
+     * <p>
+     * {@link FileVisitOption#FOLLOW_LINKS} is required because git-backed workspace projects are
+     * symlinks into the repository's {@code .git} store. Without it, {@link Files#walk} treats the
+     * symlinked project directory as a non-traversable file, finds no {@code .java}, and the project is
+     * silently skipped — so {@code .project}/{@code .classpath} are never generated and JDT.LS falls
+     * back to a JRE-only default project (SDK and project types do not resolve).
      */
     private boolean containsJavaFile(Path dir) {
-        try (Stream<Path> walk = Files.walk(dir, 5)) {
+        try (Stream<Path> walk = Files.walk(dir, 5, FileVisitOption.FOLLOW_LINKS)) {
             return walk.anyMatch(p -> !Files.isDirectory(p) && p.getFileName()
                                                                 .toString()
                                                                 .endsWith(".java"));


### PR DESCRIPTION
## Problem

In the Monaco editor, Java code completion resolves only standard JRE packages (`java.util.*`, etc.) but **not** `org.eclipse.dirigible.sdk.*` nor the project's own Java types. Root cause: the JDT.LS `.project`/`.classpath` descriptors are never generated for the project, so JDT.LS falls back to a **JRE-only default project**.

## Root cause

git-backed workspace projects are **symlinks** into the repository's `.git` store, e.g.:

```
users/<user>/workspace/<project>  ->  repository/.git/<user>/workspace/<project>/<project>
```

`JdtLsManager.containsJavaFile()` walked the project directory with `Files.walk(dir, 5)` **without** `FileVisitOption.FOLLOW_LINKS`. When the start path is a symlink, `Files.walk` treats it as a non-traversable file, descends into nothing, and finds zero `.java`. The project is therefore filtered out of `ensureEclipseProjectFilesForWorkspace()`, the descriptors are never written, and JDT.LS gives JRE-only completion.

This affects **every git-cloned / git-backed Java project** (the common case — e.g. the `dirigiblelabs/sample-intent-model` clone used by `IntentEditorLoadsIT`). It is unrelated to the recent Monaco upgrade (#6025), which only touched the in-browser TS/JS/HTML language services.

## Fix

Pass `FileVisitOption.FOLLOW_LINKS` to `Files.walk` in `containsJavaFile()` so the symlinked project directory is traversed.

## Verification

- Module compiles: `mvn -o -pl components/ide/ide-java-lsp compile`.
- On the `sample-intent-model` workspace project (a git clone), the directory walk finds **0** `.java` files before the change and **17** after — so the project is now recognized and its `.project`/`.classpath` are generated.

## Follow-up (not in this PR)

Worth validating that JDT.LS resolves the symlinked project cleanly on import; if Eclipse balks at the symlink, a further step would be to generate/import descriptors against the resolved real path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)