### PR TITLE
Publish entity update/delete events from the Java DAO (intent glue foundation)

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -30,20 +30,39 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #end
 #end
         ${name}Entity saved = super.save(entity);
-        // Publish the create event so listeners (e.g. intent process triggers under gen/events) can react.
+        // Publish the create event so listeners (e.g. intent process triggers / reactions under gen/events) can react.
         Producer.sendToTopic("${projectName}-${perspectiveName}-${name}", Json.stringify(saved));
         return saved;
     }
-#if($haveCalculatedPropertyOnUpdate)
 
     @Override
     public ${name}Entity update(${name}Entity entity) {
+#if($haveCalculatedPropertyOnUpdate)
 #foreach ($property in $properties)
 #if($property.isCalculatedProperty && $property.calculatedPropertyExpressionUpdate)
         entity.${property.name} = ${property.calculatedPropertyExpressionUpdate};
 #end
 #end
-        return super.update(entity);
-    }
 #end
+        ${name}Entity updated = super.update(entity);
+        // Publish the update event (suffixed topic) so intent reactions under gen/events can react.
+        Producer.sendToTopic("${projectName}-${perspectiveName}-${name}-updated", Json.stringify(updated));
+        return updated;
+    }
+
+    @Override
+    public void delete(${name}Entity entity) {
+        super.delete(entity);
+        // Publish the delete event (suffixed topic) so intent reactions under gen/events can react.
+        Producer.sendToTopic("${projectName}-${perspectiveName}-${name}-deleted", Json.stringify(entity));
+    }
+
+    @Override
+    public void deleteById(Object id) {
+        ${name}Entity entity = findById(id);
+        super.deleteById(id);
+        if (entity != null) {
+            Producer.sendToTopic("${projectName}-${perspectiveName}-${name}-deleted", Json.stringify(entity));
+        }
+    }
 }


### PR DESCRIPTION
## What

The generated `<Entity>Repository` (Java DAO) already publishes the **create** event via `Producer.sendToTopic(...)`. This adds the **update** and **delete** events the same way, so the planned intent "reactions" glue (`onUpdate` / `onDelete` → notify / call / …) has events to bind to.

This is the one hard prerequisite for Tier 1 of the declarative-glue catalog (see `components/engine/engine-intent/CLAUDE.md` → *"Planned: declarative glue"*).

## How (additive, mirrors the proven create pattern)

- `update()` is now **always** overridden: persist (including any calculated-on-update properties, as before) then publish the full entity JSON to `"<project>-<perspective>-<name>-updated"`.
- `delete(entity)` and `deleteById(id)` publish the full entity to `"...-deleted"` (`deleteById` loads the row first so the payload is complete).

**Topic convention:** create stays on the **unsuffixed base topic** (unchanged), update/delete use `-updated` / `-deleted` suffixes. So existing process-trigger listeners and `IntentEngineIT` are **unaffected** — the change is purely additive. (The create asymmetry is intentional for back-compat; we can normalise later if desired.)

## Testing / caveat

Template-only change, mirroring the already-working create publication line-for-line. It is exercised at runtime only by a full "Generate from EDM → compile → run" cycle, which I could not boot cleanly in this environment; **CI builds + runs the suite on H2/PostgreSQL/MSSQL**. No consumer of the new topics exists yet (unconsumed topics simply drop messages), so this is safe to land ahead of the reaction generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)