### PR TITLE
Typed Criteria query API on JavaRepository (intent glue foundation)

### DIFF
--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/Criteria.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/Criteria.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.store.java.repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A small, typed, fluent query criteria for {@link JavaRepository#findAll(Criteria)}. It is the
+ * type-safe alternative to hand-writing HQL: each condition binds its value as a named parameter,
+ * so values can never be injected, and property names are validated to be plain identifiers.
+ *
+ * <p>
+ * Example (client / generated glue code):
+ * {@code repository.findAll(Criteria.create().lt("dueOn", today).eq("status", "ACTIVE").orderByDesc("dueOn"));}
+ *
+ * <p>
+ * Conditions are combined with {@code AND} in declaration order. The criteria renders to an HQL
+ * fragment ({@link #append(String)}) plus a parameter map ({@link #parameters()}); it holds no
+ * database state and is reusable.
+ */
+public final class Criteria {
+
+    /**
+     * Property names are plain identifiers, optionally dotted for a nested path (e.g.
+     * {@code member.name}).
+     */
+    private static final Pattern PROPERTY = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*");
+
+    private final List<String> conditions = new ArrayList<>();
+    private final List<String> orderings = new ArrayList<>();
+    private final Map<String, Object> parameters = new LinkedHashMap<>();
+    private int parameterIndex;
+
+    private Criteria() {}
+
+    /**
+     * @return a new, empty criteria
+     */
+    public static Criteria create() {
+        return new Criteria();
+    }
+
+    /**
+     * Equals ({@code property = value}).
+     *
+     * @param property the entity property name
+     * @param value the value to match
+     * @return this criteria
+     */
+    public Criteria eq(String property, Object value) {
+        return binary(property, "=", value);
+    }
+
+    /**
+     * Not equals ({@code property <> value}).
+     *
+     * @param property the entity property name
+     * @param value the value to exclude
+     * @return this criteria
+     */
+    public Criteria ne(String property, Object value) {
+        return binary(property, "<>", value);
+    }
+
+    /**
+     * Greater than ({@code property > value}).
+     *
+     * @param property the entity property name
+     * @param value the lower bound (exclusive)
+     * @return this criteria
+     */
+    public Criteria gt(String property, Object value) {
+        return binary(property, ">", value);
+    }
+
+    /**
+     * Greater than or equal ({@code property >= value}).
+     *
+     * @param property the entity property name
+     * @param value the lower bound (inclusive)
+     * @return this criteria
+     */
+    public Criteria ge(String property, Object value) {
+        return binary(property, ">=", value);
+    }
+
+    /**
+     * Less than ({@code property < value}).
+     *
+     * @param property the entity property name
+     * @param value the upper bound (exclusive)
+     * @return this criteria
+     */
+    public Criteria lt(String property, Object value) {
+        return binary(property, "<", value);
+    }
+
+    /**
+     * Less than or equal ({@code property <= value}).
+     *
+     * @param property the entity property name
+     * @param value the upper bound (inclusive)
+     * @return this criteria
+     */
+    public Criteria le(String property, Object value) {
+        return binary(property, "<=", value);
+    }
+
+    /**
+     * SQL {@code LIKE} ({@code property like pattern}); the pattern supplies its own wildcards.
+     *
+     * @param property the entity property name
+     * @param pattern the LIKE pattern (e.g. {@code "%foo%"})
+     * @return this criteria
+     */
+    public Criteria like(String property, String pattern) {
+        return binary(property, "like", pattern);
+    }
+
+    /**
+     * SQL {@code BETWEEN} ({@code property between lower and upper}), bounds inclusive.
+     *
+     * @param property the entity property name
+     * @param lower the lower bound
+     * @param upper the upper bound
+     * @return this criteria
+     */
+    public Criteria between(String property, Object lower, Object upper) {
+        validate(property);
+        String low = bind(lower);
+        String high = bind(upper);
+        conditions.add(property + " between :" + low + " and :" + high);
+        return this;
+    }
+
+    /**
+     * SQL {@code IN} ({@code property in (values)}).
+     *
+     * @param property the entity property name
+     * @param values the candidate values; an empty collection matches nothing
+     * @return this criteria
+     */
+    public Criteria in(String property, Collection<?> values) {
+        validate(property);
+        String name = bind(values);
+        conditions.add(property + " in (:" + name + ")");
+        return this;
+    }
+
+    /**
+     * {@code property is null}.
+     *
+     * @param property the entity property name
+     * @return this criteria
+     */
+    public Criteria isNull(String property) {
+        validate(property);
+        conditions.add(property + " is null");
+        return this;
+    }
+
+    /**
+     * {@code property is not null}.
+     *
+     * @param property the entity property name
+     * @return this criteria
+     */
+    public Criteria isNotNull(String property) {
+        validate(property);
+        conditions.add(property + " is not null");
+        return this;
+    }
+
+    /**
+     * Add an ascending {@code ORDER BY} on the property (applied in call order).
+     *
+     * @param property the entity property name
+     * @return this criteria
+     */
+    public Criteria orderByAsc(String property) {
+        validate(property);
+        orderings.add(property + " asc");
+        return this;
+    }
+
+    /**
+     * Add a descending {@code ORDER BY} on the property (applied in call order).
+     *
+     * @param property the entity property name
+     * @return this criteria
+     */
+    public Criteria orderByDesc(String property) {
+        validate(property);
+        orderings.add(property + " desc");
+        return this;
+    }
+
+    /**
+     * Append this criteria's {@code WHERE} and {@code ORDER BY} clauses to a {@code from ...} prefix.
+     *
+     * @param fromClause the HQL {@code from <entity>} prefix
+     * @return the full HQL query string
+     */
+    public String append(String fromClause) {
+        StringBuilder hql = new StringBuilder(fromClause);
+        if (!conditions.isEmpty()) {
+            hql.append(" where ")
+               .append(String.join(" and ", conditions));
+        }
+        if (!orderings.isEmpty()) {
+            hql.append(" order by ")
+               .append(String.join(", ", orderings));
+        }
+        return hql.toString();
+    }
+
+    /**
+     * @return the named-parameter bindings collected by the conditions, in insertion order
+     */
+    public Map<String, Object> parameters() {
+        return parameters;
+    }
+
+    private Criteria binary(String property, String operator, Object value) {
+        validate(property);
+        String name = bind(value);
+        conditions.add(property + " " + operator + " :" + name);
+        return this;
+    }
+
+    private String bind(Object value) {
+        String name = "p" + parameterIndex++;
+        parameters.put(name, value);
+        return name;
+    }
+
+    private static void validate(String property) {
+        if (property == null || !PROPERTY.matcher(property)
+                                         .matches()) {
+            throw new IllegalArgumentException("Invalid property name: [" + property + "]");
+        }
+    }
+}

--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/JavaRepository.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/repository/JavaRepository.java
@@ -115,6 +115,18 @@ public abstract class JavaRepository<T> {
     }
 
     /**
+     * Find every entity matching a typed {@link Criteria} — the type-safe alternative to
+     * {@link #query(String, Map)}. Conditions are combined with {@code AND}; values are bound as
+     * parameters.
+     *
+     * @param criteria the query criteria
+     * @return the matching entities
+     */
+    public List<T> findAll(Criteria criteria) {
+        return store().findAll(entityClass, criteria);
+    }
+
+    /**
      * Delete an entity instance.
      *
      * @param entity the entity to delete

--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/store/JavaEntityStore.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/store/JavaEntityStore.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.eclipse.dirigible.components.api.security.UserFacade;
 import org.eclipse.dirigible.components.data.store.java.manager.JavaEntityManager;
 import org.eclipse.dirigible.components.data.store.java.manager.RegisteredEntity;
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.hibernate.query.Query;
@@ -257,6 +258,25 @@ public class JavaEntityStore {
             }
             return mapRows(type, meta, q.getResultList());
         }
+    }
+
+    /**
+     * Find every entity of the given type matching a typed {@link Criteria}. Builds an HQL query from
+     * the criteria's conditions and ordering and runs it through the same map-projection path as
+     * {@link #query(Class, String, Map)} — values are bound as named parameters, never inlined.
+     *
+     * @param <T> the entity type
+     * @param type the entity class
+     * @param criteria the query criteria; {@code null} returns all rows
+     * @return the matching entities
+     */
+    public <T> List<T> findAll(Class<T> type, Criteria criteria) {
+        if (criteria == null) {
+            return findAll(type);
+        }
+        RegisteredEntity meta = resolve(type);
+        String hql = criteria.append("from " + meta.entityName());
+        return query(type, hql, criteria.parameters());
     }
 
     /**

--- a/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/repository/CriteriaTest.java
+++ b/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/repository/CriteriaTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.store.java.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class CriteriaTest {
+
+    @Test
+    void emptyCriteriaRendersBareFrom() {
+        Criteria criteria = Criteria.create();
+        assertEquals("from BookEntity", criteria.append("from BookEntity"));
+        assertTrue(criteria.parameters()
+                           .isEmpty());
+    }
+
+    @Test
+    void combinesConditionsWithAndAndBindsValues() {
+        Criteria criteria = Criteria.create()
+                                    .lt("dueOn", "2026-01-01")
+                                    .eq("status", "ACTIVE")
+                                    .orderByDesc("dueOn");
+
+        assertEquals("from LoanEntity where dueOn < :p0 and status = :p1 order by dueOn desc", criteria.append("from LoanEntity"));
+        assertEquals("2026-01-01", criteria.parameters()
+                                           .get("p0"));
+        assertEquals("ACTIVE", criteria.parameters()
+                                       .get("p1"));
+    }
+
+    @Test
+    void rendersBetweenInAndNullChecks() {
+        Criteria between = Criteria.create()
+                                   .between("price", 10, 20);
+        assertEquals("from BookEntity where price between :p0 and :p1", between.append("from BookEntity"));
+        assertEquals(20, between.parameters()
+                                .get("p1"));
+
+        Criteria in = Criteria.create()
+                              .in("status", List.of("ACTIVE", "OVERDUE"));
+        assertEquals("from LoanEntity where status in (:p0)", in.append("from LoanEntity"));
+        assertEquals(List.of("ACTIVE", "OVERDUE"), in.parameters()
+                                                     .get("p0"));
+
+        Criteria nulls = Criteria.create()
+                                 .isNull("returnedOn")
+                                 .isNotNull("member");
+        assertEquals("from LoanEntity where returnedOn is null and member is not null", nulls.append("from LoanEntity"));
+        assertTrue(nulls.parameters()
+                        .isEmpty());
+    }
+
+    @Test
+    void rejectsNonIdentifierPropertyNamesToPreventInjection() {
+        assertThrows(IllegalArgumentException.class, () -> Criteria.create()
+                                                                   .eq("status; drop table", "x"));
+        assertThrows(IllegalArgumentException.class, () -> Criteria.create()
+                                                                   .orderByAsc("1=1"));
+    }
+}


### PR DESCRIPTION
## What

Adds a typed, fluent `Criteria` query API to the client-Java `JavaRepository`, so glue and hand-written client code can filter rows type-safely instead of hand-writing HQL.

```java
repository.findAll(Criteria.create()
    .lt("dueOn", today)
    .eq("status", "ACTIVE")
    .orderByDesc("dueOn"));
```

This is the query surface the declarative-glue catalog needs — e.g. a scheduled "find overdue loans" activity (see `engine-intent/CLAUDE.md` → *"Planned: declarative glue"*, Tier 1 #3).

## How

- `Criteria` (in `data-store-java`'s `repository` package, next to `JavaRepository` — the package client code already imports from): `eq/ne/gt/ge/lt/le/like/between/in/isNull/isNotNull` + `orderByAsc/Desc`. Renders to an HQL fragment + a named-parameter map.
- **Safe by construction:** values are bound as named parameters (never inlined); property names are validated to plain (optionally dotted) identifiers, so `eq("status; drop table", …)` throws.
- `JavaRepository.findAll(Criteria)` → `JavaEntityStore.findAll(type, criteria)`, which builds `from <entityName> …` and reuses the existing map-projection `query(...)` path (returns typed `T`). No new Hibernate plumbing, no new module dependency.

## Testing

`CriteriaTest` (4 cases, unit-level, no DB) covers AND-combination + parameter binding, BETWEEN/IN/null checks, and the injection-rejection guard. Run green locally (`Tests run: 4, Failures: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)