### PR TITLE
Intent declarative glue: scheduled activities (cron → query → notify)

### DIFF
--- a/components/engine/engine-intent/CLAUDE.md
+++ b/components/engine/engine-intent/CLAUDE.md
@@ -327,12 +327,18 @@ Every action below has a real SDK surface to generate against, so none of this n
      - { name: orderUpdated, event: { onUpdate: Order }, channel: email, to: ops@example.com, subject: "Order {id} updated, total {total}", body: "The order changed." }
    ```
    → `gen/events/<Name>Notification.java` (`@Listener`) using `sdk.mail.Mail`, bound to the entity's create / `-updated` / `-deleted` topic; sender from `DIRIGIBLE_MAIL_SENDER`. The author-facing fields are translated to Java by `NotificationSupport` (unit-tested) and emitted into `.glue` (`GlueIntentGenerator`), rendered by `Notification.java.template` via the `notifications` collection case in `generateUtils.js`. **Scope:** `to`/`{placeholder}` resolve a literal, a **direct field**, or a **one-hop `relation.field`** of a to-one relation — the listener loads the related entity once by FK id (same one-hop mechanism as the decision resolvers; `NotificationSupport.plan` emits the `relationLoads` the template renders). `when:` supports a single `field ==|!= literal` on a direct field. **Multi-hop** paths (`a.b.c`) and relation-path `when:` are the remaining gap; the parser rejects multi-hop `to` with a clear message.
-3. **Scheduled activities + `onSchedule` process triggers** — reminders / cleanups; a per-row activity over a query.
+3. **Scheduled activities** — cron reminders / cleanups; query an entity and act per matching row. **(v1 implemented.)**
    ```yaml
    schedules:
-     - { name: overdueReminders, cron: "0 0 9 * * ?", forEach: "Loan where dueOn < CURRENT_DATE and status == 'ACTIVE'", do: { notify: { channel: email, to: member.email, body: overdue } } }
+     - name: overdueLoans
+       cron: "0 0 9 * * ?"
+       entity: Loan
+       where:
+         - { field: dueOn,  op: lt, value: CURRENT_DATE }   # eq/ne/gt/ge/lt/le/like; CURRENT_DATE/CURRENT_TIMESTAMP -> now()
+         - { field: status, op: eq, value: "ACTIVE" }
+       notify: { to: member.email, subject: "Overdue: {book.title}", body: "Your loan is overdue." }
    ```
-   → `@Scheduled(expression="...")` + `JobHandler`. Also wires process `trigger: { onSchedule: <cron> }`.
+   → `gen/events/<Name>Job.java`: a `@Scheduled(expression=cron)` `JobHandler` that runs `new <Entity>Repository().findAll(Criteria...)` (the typed `Criteria` query API) and performs the per-row `notify` (reusing `NotificationSupport.plan` against the row entity - same relation-load + interpolation as notifications). `ScheduleSupport.criteriaExpression` builds the `Criteria` chain (`where` -> typed conditions; field names PascalCased to the entity properties). Honors the `.settings` override. **Gap:** the action is `notify` only (other actions + `between`/`in` operators are later); process `trigger: { onSchedule: <cron> }` (timer start event) is still open.
 4. **Outbound calls** — "tell another system" on an event.
    ```yaml
    integrations:

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
+import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
@@ -67,8 +68,9 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> triggers = buildTriggers(model, byName, compositionParents, settings);
         List<Map<String, Object>> resolvers = buildResolvers(model, settings);
         List<Map<String, Object>> notifications = buildNotifications(model, byName, compositionParents, settings);
+        List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings);
 
-        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty()) {
+        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -77,9 +79,10 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("triggers", triggers);
         glue.put("resolvers", resolvers);
         glue.put("notifications", notifications);
+        glue.put("schedules", schedules);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
-        LOGGER.debug("Wrote glue with [{}] trigger(s), [{}] resolver(s) and [{}] notification(s)", triggers.size(), resolvers.size(),
-                notifications.size());
+        LOGGER.debug("Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s) and [{}] schedule(s)", triggers.size(),
+                resolvers.size(), notifications.size(), schedules.size());
     }
 
     private static List<Map<String, Object>> buildTriggers(IntentModel model, Map<String, EntityIntent> byName,
@@ -144,6 +147,47 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             notifications.add(entry);
         }
         return notifications;
+    }
+
+    private static List<Map<String, Object>> buildSchedules(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents, IntentSettings settings) {
+        List<Map<String, Object>> schedules = new ArrayList<>();
+        for (ScheduleIntent schedule : model.getSchedules()) {
+            if (schedule.getName() == null || schedule.getName()
+                                                      .isBlank()) {
+                continue;
+            }
+            String entity = schedule.getEntity();
+            if (entity == null || !byName.containsKey(entity) || schedule.getNotify() == null) {
+                continue;
+            }
+            if (!settings.shouldGenerate("schedules", schedule.getName())) {
+                LOGGER.info("Settings opt-out: keeping existing job for schedule [{}] (not generated)", schedule.getName());
+                continue;
+            }
+            // The per-row action reuses the notification machinery against the queried row entity.
+            NotificationSupport.Plan plan = NotificationSupport.plan(schedule.getNotify(), byName.get(entity), byName, compositionParents);
+            if (plan == null) {
+                LOGGER.warn("Schedule [{}] notify recipient [{}] is not a resolvable field or relation.field of [{}] - skipping",
+                        schedule.getName(), schedule.getNotify()
+                                                    .getTo(),
+                        entity);
+                continue;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("name", schedule.getName());
+            entry.put("className", IntentNaming.pascalCase(schedule.getName()));
+            entry.put("cron", schedule.getCron());
+            entry.put("entity", entity);
+            entry.put("perspective", IntentEntities.resolvePerspective(entity, compositionParents));
+            entry.put("criteriaExpression", ScheduleSupport.criteriaExpression(schedule));
+            entry.put("relationLoads", relationLoads(plan));
+            entry.put("toExpression", plan.toExpression());
+            entry.put("subjectExpression", plan.subjectExpression());
+            entry.put("bodyExpression", plan.bodyExpression());
+            schedules.add(entry);
+        }
+        return schedules;
     }
 
     private static List<Map<String, Object>> relationLoads(NotificationSupport.Plan plan) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ScheduleSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/ScheduleSupport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.ScheduleConditionIntent;
+import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
+
+/**
+ * Translates a {@link ScheduleIntent}'s {@code where} filter into the typed {@code Criteria}
+ * builder call the generated {@code @Scheduled} job runs against the entity repository. Pure (no
+ * Spring/IO) so the operator mapping and date-token handling are unit-tested directly.
+ */
+public final class ScheduleSupport {
+
+    /** Author operator -&gt; {@code Criteria} method. */
+    static final Map<String, String> OPERATORS =
+            Map.of("eq", "eq", "ne", "ne", "gt", "gt", "ge", "ge", "lt", "lt", "le", "le", "like", "like");
+
+    private ScheduleSupport() {}
+
+    /**
+     * @param op the author-facing operator token
+     * @return whether it maps to a supported {@code Criteria} comparison
+     */
+    public static boolean isSupportedOperator(String op) {
+        return op != null && OPERATORS.containsKey(op);
+    }
+
+    /**
+     * Build the Java {@code Criteria} expression for a schedule's {@code where} (field names are the
+     * PascalCase entity property names; values are bound, with {@code CURRENT_DATE}/
+     * {@code CURRENT_TIMESTAMP} evaluated to "now").
+     *
+     * @param schedule the schedule
+     * @return e.g.
+     *         {@code Criteria.create().lt("DueOn", java.time.LocalDate.now()).eq("Status", "ACTIVE")}
+     */
+    public static String criteriaExpression(ScheduleIntent schedule) {
+        StringBuilder expr = new StringBuilder("Criteria.create()");
+        for (ScheduleConditionIntent condition : schedule.getWhere()) {
+            String method = OPERATORS.get(condition.getOp());
+            if (method == null) {
+                continue; // validated at parse time; defensively skip an unknown operator
+            }
+            expr.append('.')
+                .append(method)
+                .append("(\"")
+                .append(IntentNaming.pascalCase(condition.getField()))
+                .append("\", ")
+                .append(valueToJava(condition.getValue()))
+                .append(')');
+        }
+        return expr.toString();
+    }
+
+    /** A condition value as a Java expression: a now-token, a number/boolean, or a quoted string. */
+    private static String valueToJava(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            return value.toString();
+        }
+        String text = value.toString();
+        if ("CURRENT_DATE".equals(text)) {
+            return "java.time.LocalDate.now()";
+        }
+        if ("CURRENT_TIMESTAMP".equals(text) || "NOW".equals(text)) {
+            return "java.time.LocalDateTime.now()";
+        }
+        return "\"" + text.replace("\\", "\\\\")
+                          .replace("\"", "\\\"")
+                + "\"";
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
@@ -35,6 +35,7 @@ public class IntentModel {
     private List<PermissionIntent> permissions = new ArrayList<>();
     private List<SeedIntent> seeds = new ArrayList<>();
     private List<NotificationIntent> notifications = new ArrayList<>();
+    private List<ScheduleIntent> schedules = new ArrayList<>();
 
     public String getName() {
         return name;
@@ -114,5 +115,13 @@ public class IntentModel {
 
     public void setNotifications(List<NotificationIntent> notifications) {
         this.notifications = notifications == null ? new ArrayList<>() : notifications;
+    }
+
+    public List<ScheduleIntent> getSchedules() {
+        return schedules;
+    }
+
+    public void setSchedules(List<ScheduleIntent> schedules) {
+        this.schedules = schedules == null ? new ArrayList<>() : schedules;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleConditionIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleConditionIntent.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+/**
+ * One condition of a {@link ScheduleIntent}'s {@code where} filter: a field, a comparison operator
+ * ({@code eq}/{@code ne}/{@code gt}/{@code ge}/{@code lt}/{@code le}/{@code like}) and a value. The
+ * value is a literal, or the token {@code CURRENT_DATE} / {@code CURRENT_TIMESTAMP} which the
+ * generated job evaluates to "now". Maps to a typed {@code Criteria} condition.
+ */
+public class ScheduleConditionIntent {
+
+    private String field;
+    private String op;
+    private Object value;
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getOp() {
+        return op;
+    }
+
+    public void setOp(String op) {
+        this.op = op;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleIntent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A time-driven activity: on a cron schedule, query an entity and run an action per matching row.
+ * The "overdue reminders" pattern of the declarative-glue catalog.
+ *
+ * <p>
+ * Generates a client-Java {@code @Scheduled} {@code JobHandler} that queries {@link #entity} with a
+ * typed {@code Criteria} built from {@link #where} and, for each row, performs {@link #notify}
+ * (reusing the notification machinery against the row entity). The notify's {@code event}/
+ * {@code channel} are unused here - the cron + {@code where} are the trigger and filter.
+ */
+public class ScheduleIntent {
+
+    private String name;
+    private String cron;
+    private String entity;
+    private List<ScheduleConditionIntent> where = new ArrayList<>();
+    private NotificationIntent notify;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCron() {
+        return cron;
+    }
+
+    public void setCron(String cron) {
+        this.cron = cron;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public void setEntity(String entity) {
+        this.entity = entity;
+    }
+
+    public List<ScheduleConditionIntent> getWhere() {
+        return where;
+    }
+
+    public void setWhere(List<ScheduleConditionIntent> where) {
+        this.where = where == null ? new ArrayList<>() : where;
+    }
+
+    public NotificationIntent getNotify() {
+        return notify;
+    }
+
+    public void setNotify(NotificationIntent notify) {
+        this.notify = notify;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -23,6 +23,8 @@ import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.ReportIntent;
+import org.eclipse.dirigible.components.intent.model.ScheduleConditionIntent;
+import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
 import org.eclipse.dirigible.components.intent.model.SeedIntent;
 import org.eclipse.dirigible.components.intent.model.StepIntent;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -64,6 +66,8 @@ public final class IntentParser {
     private static final Set<String> EVENT_KINDS = Set.of("onCreate", "onUpdate", "onDelete");
     /** Notification delivery channels supported today. */
     private static final Set<String> NOTIFICATION_CHANNELS = Set.of("email");
+    /** Comparison operators a schedule's {@code where} condition may use. */
+    private static final Set<String> SCHEDULE_OPERATORS = Set.of("eq", "ne", "gt", "ge", "lt", "le", "like");
 
     /**
      * Plain Gson for the YAML-Map -> JSON -> POJO round-trip. The platform's {@code JsonHelper} /
@@ -115,8 +119,57 @@ public final class IntentParser {
         validateReports(model, entityNames, issues);
         validateSeeds(model, entityNames, issues);
         validateNotifications(model, entityNames, issues);
+        validateSchedules(model, entityNames, issues);
         if (!issues.isEmpty()) {
             throw new IntentValidationException(issues);
+        }
+    }
+
+    /**
+     * Each schedule must have a unique name, a cron expression, an entity to query, supported
+     * {@code where} operators, and a notify action with a valid recipient.
+     */
+    private static void validateSchedules(IntentModel model, Set<String> entityNames, List<String> issues) {
+        Set<String> names = new HashSet<>();
+        for (ScheduleIntent schedule : model.getSchedules()) {
+            String name = schedule.getName();
+            if (name == null || name.isBlank()) {
+                issues.add("schedule has no name");
+                continue;
+            }
+            if (!names.add(name)) {
+                issues.add("duplicate schedule [" + name + "]");
+            }
+            if (schedule.getCron() == null || schedule.getCron()
+                                                      .isBlank()) {
+                issues.add("schedule [" + name + "] has no cron expression");
+            }
+            if (schedule.getEntity() == null || !entityNames.contains(schedule.getEntity())) {
+                issues.add("schedule [" + name + "] queries unknown entity [" + schedule.getEntity() + "]");
+            }
+            for (ScheduleConditionIntent condition : schedule.getWhere()) {
+                if (condition.getField() == null || condition.getField()
+                                                             .isBlank()) {
+                    issues.add("schedule [" + name + "] has a where-condition with no field");
+                }
+                if (!SCHEDULE_OPERATORS.contains(condition.getOp())) {
+                    issues.add("schedule [" + name + "] where-condition uses unsupported operator [" + condition.getOp()
+                            + "] (supported: eq/ne/gt/ge/lt/le/like)");
+                }
+            }
+            if (schedule.getNotify() == null) {
+                issues.add("schedule [" + name + "] has no notify action");
+            } else {
+                String to = schedule.getNotify()
+                                    .getTo();
+                if (to == null || to.isBlank()) {
+                    issues.add("schedule [" + name + "] notify has no recipient (to)");
+                } else if (!to.contains("@") && to.chars()
+                                                  .filter(c -> c == '.')
+                                                  .count() >= 2) {
+                    issues.add("schedule [" + name + "] notify recipient [" + to + "] uses a multi-hop path, which is not supported");
+                }
+            }
         }
     }
 

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/ScheduleSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/ScheduleSupportTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.eclipse.dirigible.components.intent.model.ScheduleConditionIntent;
+import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
+import org.junit.jupiter.api.Test;
+
+class ScheduleSupportTest {
+
+    private static ScheduleConditionIntent cond(String field, String op, Object value) {
+        ScheduleConditionIntent c = new ScheduleConditionIntent();
+        c.setField(field);
+        c.setOp(op);
+        c.setValue(value);
+        return c;
+    }
+
+    private static ScheduleIntent schedule(List<ScheduleConditionIntent> where) {
+        ScheduleIntent s = new ScheduleIntent();
+        s.setName("overdue");
+        s.setWhere(where);
+        return s;
+    }
+
+    @Test
+    void emptyWhereIsAnUnfilteredCriteria() {
+        assertEquals("Criteria.create()", ScheduleSupport.criteriaExpression(schedule(List.of())));
+    }
+
+    @Test
+    void buildsTypedCriteriaWithPascalFieldsDateTokensAndLiterals() {
+        ScheduleIntent s = schedule(List.of(cond("dueOn", "lt", "CURRENT_DATE"), cond("status", "eq", "ACTIVE")));
+        assertEquals("Criteria.create().lt(\"DueOn\", java.time.LocalDate.now()).eq(\"Status\", \"ACTIVE\")",
+                ScheduleSupport.criteriaExpression(s));
+    }
+
+    @Test
+    void numbersAndTimestampTokensRenderWithoutQuotes() {
+        ScheduleIntent s = schedule(List.of(cond("quantity", "gt", 1), cond("changedAt", "ge", "CURRENT_TIMESTAMP")));
+        assertEquals("Criteria.create().gt(\"Quantity\", 1).ge(\"ChangedAt\", java.time.LocalDateTime.now())",
+                ScheduleSupport.criteriaExpression(s));
+    }
+
+    @Test
+    void operatorSupport() {
+        assertTrue(ScheduleSupport.isSupportedOperator("between") == false && ScheduleSupport.isSupportedOperator("lt"));
+        assertFalse(ScheduleSupport.isSupportedOperator("xx"));
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
@@ -1,0 +1,54 @@
+package gen.events;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
+import org.eclipse.dirigible.sdk.core.Configurations;
+import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.eclipse.dirigible.sdk.job.Scheduled;
+import org.eclipse.dirigible.sdk.mail.Mail;
+
+import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
+import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Repository;
+#foreach($load in $relationLoads)
+import gen.${javaGenFolderName}.data.${load.javaTargetPerspective}.${load.targetEntity}Entity;
+import gen.${javaGenFolderName}.data.${load.javaTargetPerspective}.${load.targetEntity}Repository;
+#end
+
+/**
+ * Runs the ${name} schedule: on each cron tick, query ${entity} and notify per matching row.
+ *
+ * Generated from the intent schedules block - do not edit; it is re-generated with the application.
+ * The sender address comes from the DIRIGIBLE_MAIL_SENDER configuration.
+ */
+@Scheduled(expression = "${cron}")
+public class ${className}Job implements JobHandler {
+
+    @Override
+    public void run() {
+        List<${entity}Entity> rows = new ${entity}Repository().findAll(${criteriaExpression});
+        for (${entity}Entity entity : rows) {
+#foreach($load in $relationLoads)
+            ${load.targetEntity}Entity ${load.local} = entity.${load.fkProperty} == null ? null : new ${load.targetEntity}Repository().findById(entity.${load.fkProperty});
+#end
+            String to = ${toExpression};
+            if (to == null || to.isBlank()) {
+                continue;
+            }
+            String subject = ${subjectExpression};
+            String body = ${bodyExpression};
+            Map part = new HashMap();
+            part.put("type", "text");
+            part.put("contentType", "text/plain");
+            part.put("text", body);
+            String from = Configurations.get("DIRIGIBLE_MAIL_SENDER", "noreply@dirigible.io");
+            try {
+                Mail.send(from, new String[] {to}, new String[0], new String[0], subject, List.of(part));
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to send schedule ${name}", ex);
+            }
+        }
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -45,6 +45,13 @@ export function getTemplate(parameters) {
                 collection: "notifications"
             },
             {
+                location: "/template-application-events-java/events/Job.java.template",
+                action: "generate",
+                rename: "gen/events/{{className}}Job.java",
+                engine: "velocity",
+                collection: "schedules"
+            },
+            {
                 location: "/template-application-events-java/project.json.mjs",
                 action: "generate",
                 rename: "project.json",

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -359,6 +359,37 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "schedules":
+                    // Schedules (intent layer): one @Scheduled JobHandler per schedule - query the entity
+                    // via a typed Criteria and notify per matching row. Not entity-shaped, own loop.
+                    if (model.schedules) {
+                        for (let s = 0; s < model.schedules.length; s++) {
+                            const scheduleParameters = {
+                                ...parameters,
+                                name: model.schedules[s].name,
+                                className: model.schedules[s].className,
+                                cron: model.schedules[s].cron,
+                                entity: model.schedules[s].entity,
+                                perspective: model.schedules[s].perspective,
+                                javaPerspective: sanitizeJavaIdentifier(model.schedules[s].perspective),
+                                criteriaExpression: model.schedules[s].criteriaExpression,
+                                relationLoads: (model.schedules[s].relationLoads || []).map(load => ({
+                                    ...load,
+                                    javaTargetPerspective: sanitizeJavaIdentifier(load.targetPerspective)
+                                })),
+                                toExpression: model.schedules[s].toExpression,
+                                subjectExpression: model.schedules[s].subjectExpression,
+                                bodyExpression: model.schedules[s].bodyExpression
+                            };
+                            const cleanScheduleParameters = cleanData(scheduleParameters);
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, cleanScheduleParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, cleanScheduleParameters)
+                            });
+                        }
+                    }
+                    break;
                 default:
                     // No collection
                     parameters.models = model.entities;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -143,6 +143,17 @@ class IntentEngineIT extends IntegrationTest {
                 to: ops@example.com
                 subject: "Order {id} for {customer.name}, total {total}"
                 body: "The order changed."
+
+            schedules:
+              - name: staleOrders
+                cron: "0 0 9 * * ?"
+                entity: Order
+                where:
+                  - { field: orderDate, op: lt, value: CURRENT_DATE }
+                notify:
+                  to: ops@example.com
+                  subject: "Stale order {id} for {customer.name}"
+                  body: "This order is stale."
             """;
 
     @Autowired
@@ -352,6 +363,19 @@ class IntentEngineIT extends IntegrationTest {
                 "the listener should load the one-hop related entity by FK id");
         assertTrue(notification.contains("\"Order \" + entity.Id + \" for \" + (customer == null ? null : customer.Name)"),
                 "the subject should interpolate the relation.field against the loaded related entity");
+
+        // The schedule is a @Scheduled JobHandler that queries via a typed Criteria and notifies per row.
+        String job = contentOf("gen/events/StaleOrdersJob.java");
+        assertTrue(job.contains("@Scheduled(expression = \"0 0 9 * * ?\")") && job.contains("class StaleOrdersJob implements JobHandler"),
+                "the schedule should generate a @Scheduled JobHandler");
+        assertTrue(job.contains("new OrderRepository().findAll(Criteria.create().lt(\"OrderDate\", java.time.LocalDate.now()))"),
+                "the job should query the entity with a typed Criteria built from the where clause");
+        assertTrue(job.contains("for (OrderEntity entity : rows)"), "the job should iterate the matching rows");
+        assertTrue(
+                job.contains(
+                        "CustomerEntity customer = entity.Customer == null ? null : new CustomerRepository().findById(entity.Customer)"),
+                "the per-row notify should load the one-hop related entity");
+        assertTrue(job.contains("Mail.send("), "the job should notify per row via the SDK Mail API");
     }
 
     @Test
@@ -555,6 +579,12 @@ class IntentEngineIT extends IntegrationTest {
                 "glue should carry the orderUpdated notification bound to the -updated topic");
         assertTrue(glue.contains("\"toExpression\": \"\\\"ops@example.com\\\"\""),
                 "glue should carry the notification recipient as a Java string expression");
+        // Schedules: one per declarative schedule, carrying the cron + the typed Criteria expression.
+        assertTrue(
+                glue.contains("\"schedules\"") && glue.contains("\"name\": \"staleOrders\"") && glue.contains("\"cron\": \"0 0 9 * * ?\""),
+                "glue should carry the staleOrders schedule with its cron");
+        assertTrue(glue.contains("Criteria.create().lt(\\\"OrderDate\\\", java.time.LocalDate.now())"),
+                "glue should carry the schedule's typed Criteria expression");
     }
 
     private void assertSettings() {


### PR DESCRIPTION
## What

Adds the **`schedules:`** block of the declarative-glue catalog — the "overdue reminders" pattern. On a cron tick, query an entity and notify per matching row, with **no hand-written code**:

```yaml
schedules:
  - name: overdueLoans
    cron: "0 0 9 * * ?"
    entity: Loan
    where:
      - { field: dueOn,  op: lt, value: CURRENT_DATE }   # eq/ne/gt/ge/lt/le/like; CURRENT_DATE/CURRENT_TIMESTAMP → now()
      - { field: status, op: eq, value: "ACTIVE" }
    notify: { to: member.email, subject: "Overdue: {book.title}", body: "Your loan is overdue." }
```

→ generates `gen/events/OverdueLoansJob.java`: a `@Scheduled` `JobHandler` that runs `new LoanRepository().findAll(Criteria…)` and notifies per row.

## How (heavy reuse of the just-merged foundation)

- `ScheduleSupport.criteriaExpression` (pure, unit-tested) builds the **typed `Criteria`** chain from `where` (the query API from #6050) — field names PascalCased to the entity properties; `CURRENT_DATE`/`CURRENT_TIMESTAMP` → `now()`.
- The per-row `notify` reuses **`NotificationSupport.plan`** (from #6052) against the row entity — same relation-load + `{field}`/`{relation.field}` interpolation as notifications.
- `GlueIntentGenerator` emits a `schedules` collection into `<intent>.glue`; `Job.java.template` renders the `@Scheduled JobHandler`; `generateUtils.js` gets the `schedules` collection case. Parser validates name/cron/entity/operators/notify; honors the `.settings` override.

## Testing

- `ScheduleSupportTest` — `Criteria` building (operators, PascalCase fields, date tokens, numbers) — green.
- `IntentEngineIT.glue_template_generates_…` extended: asserts the generated `StaleOrdersJob` is `@Scheduled`, queries via `Criteria.create().lt("OrderDate", java.time.LocalDate.now())`, loads the related `Customer`, and `Mail.send`s per row — **green locally** (`Tests run: 1, Failures: 0`). CI runs the full suite on H2/PostgreSQL/MSSQL.

## Scope / gaps

Action is `notify` only; `between`/`in` operators and process `trigger: { onSchedule: <cron> }` (timer start event) are later increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)