### PR TITLE
Intent declarative glue: outbound integrations (event → HTTP)

### DIFF
--- a/components/engine/engine-intent/CLAUDE.md
+++ b/components/engine/engine-intent/CLAUDE.md
@@ -339,12 +339,12 @@ Every action below has a real SDK surface to generate against, so none of this n
        notify: { to: member.email, subject: "Overdue: {book.title}", body: "Your loan is overdue." }
    ```
    → `gen/events/<Name>Job.java`: a `@Scheduled(expression=cron)` `JobHandler` that runs `new <Entity>Repository().findAll(Criteria...)` (the typed `Criteria` query API) and performs the per-row `notify` (reusing `NotificationSupport.plan` against the row entity - same relation-load + interpolation as notifications). `ScheduleSupport.criteriaExpression` builds the `Criteria` chain (`where` -> typed conditions; field names PascalCased to the entity properties). Honors the `.settings` override. **Gap:** the action is `notify` only (other actions + `between`/`in` operators are later); process `trigger: { onSchedule: <cron> }` (timer start event) is still open.
-4. **Outbound calls** — "tell another system" on an event.
+4. **Outbound integrations** — "tell another system" on an event. **(v1 implemented.)**
    ```yaml
    integrations:
-     - { name: pushBookToCatalog, event: { onCreate: Book }, callHttp: { method: POST, url: "@config:CATALOG_URL", body: { isbn: id, title: title } } }
+     - { name: pushBookToCatalog, event: { onCreate: Book }, method: POST, url: "@config:CATALOG_URL" }
    ```
-   → `@Listener` using `sdk.http.HttpClient`; URL/secret via `Configurations`.
+   → `gen/events/<Name>Integration.java`: an `@Listener` that forwards the entity-event JSON to the URL via `sdk.http.HttpClient` (`IntegrationSupport` maps the method + the `@config:KEY` URL sugar to `Configurations.get`). The event-binding (`EventBinding`) + topic are shared with notifications. **Gap:** body forwards the whole entity (custom body mapping + headers/auth are later).
 
 **Tier 2 — high value:**
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/EventBinding.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/EventBinding.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.Map;
+
+/**
+ * Shared reading of an {@code event: { onCreate|onUpdate|onDelete: <Entity> }} binding map - the
+ * common entity-lifecycle hook used by notifications, integrations and other declarative glue. Maps
+ * the event kind to the per-operation topic suffix the Java DAO publishes to (create = unsuffixed
+ * base topic; update/delete = {@code -updated}/{@code -deleted}).
+ */
+public final class EventBinding {
+
+    private static final String[] KINDS = {"onCreate", "onUpdate", "onDelete"};
+
+    private EventBinding() {}
+
+    /**
+     * @param event the binding map (may be {@code null})
+     * @return the lifecycle event kind present, or {@code null}
+     */
+    public static String kind(Map<String, Object> event) {
+        if (event == null) {
+            return null;
+        }
+        for (String kind : KINDS) {
+            if (event.get(kind) != null) {
+                return kind;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param event the binding map (may be {@code null})
+     * @return the entity named by the bound event, or {@code null}
+     */
+    public static String entity(Map<String, Object> event) {
+        String kind = kind(event);
+        Object target = kind == null || event == null ? null : event.get(kind);
+        return target == null ? null : target.toString();
+    }
+
+    /**
+     * @param kind the lifecycle event kind
+     * @return the topic suffix ({@code ""} for create, {@code -updated}/{@code -deleted} otherwise)
+     */
+    public static String topicSuffix(String kind) {
+        if ("onUpdate".equals(kind)) {
+            return "-updated";
+        }
+        if ("onDelete".equals(kind)) {
+            return "-deleted";
+        }
+        return "";
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
 import org.eclipse.dirigible.components.intent.generator.ProcessResolverSupport.Resolver;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
@@ -69,8 +70,9 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> resolvers = buildResolvers(model, settings);
         List<Map<String, Object>> notifications = buildNotifications(model, byName, compositionParents, settings);
         List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings);
+        List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
 
-        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty()) {
+        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty() && integrations.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -80,9 +82,10 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("resolvers", resolvers);
         glue.put("notifications", notifications);
         glue.put("schedules", schedules);
+        glue.put("integrations", integrations);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
-        LOGGER.debug("Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s) and [{}] schedule(s)", triggers.size(),
-                resolvers.size(), notifications.size(), schedules.size());
+        LOGGER.debug("Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s), [{}] schedule(s) and [{}] integration(s)",
+                triggers.size(), resolvers.size(), notifications.size(), schedules.size(), integrations.size());
     }
 
     private static List<Map<String, Object>> buildTriggers(IntentModel model, Map<String, EntityIntent> byName,
@@ -147,6 +150,36 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             notifications.add(entry);
         }
         return notifications;
+    }
+
+    private static List<Map<String, Object>> buildIntegrations(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents, IntentSettings settings) {
+        List<Map<String, Object>> integrations = new ArrayList<>();
+        for (IntegrationIntent integration : model.getIntegrations()) {
+            if (integration.getName() == null || integration.getName()
+                                                            .isBlank()) {
+                continue;
+            }
+            String entity = EventBinding.entity(integration.getEvent());
+            if (entity == null || !byName.containsKey(entity)) {
+                continue;
+            }
+            if (!settings.shouldGenerate("integrations", integration.getName())) {
+                LOGGER.info("Settings opt-out: keeping existing listener for integration [{}] (not generated)", integration.getName());
+                continue;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("name", integration.getName());
+            entry.put("className", IntentNaming.pascalCase(integration.getName()));
+            entry.put("entity", entity);
+            entry.put("perspective", IntentEntities.resolvePerspective(entity, compositionParents));
+            entry.put("topicSuffix", EventBinding.topicSuffix(EventBinding.kind(integration.getEvent())));
+            entry.put("clientMethod", IntegrationSupport.clientMethod(integration.getMethod()));
+            entry.put("hasBody", IntegrationSupport.hasBody(integration.getMethod()));
+            entry.put("urlExpression", IntegrationSupport.urlExpression(integration.getUrl()));
+            integrations.add(entry);
+        }
+        return integrations;
     }
 
     private static List<Map<String, Object>> buildSchedules(IntentModel model, Map<String, EntityIntent> byName,

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntegrationSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntegrationSupport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Translates an {@code IntegrationIntent}'s {@code method}/{@code url} into the Java the generated
+ * {@code @Listener} pastes in. Pure (no Spring/IO) so the HTTP-method mapping and the
+ * {@code @config:} URL sugar are unit-tested directly.
+ */
+public final class IntegrationSupport {
+
+    /** HTTP method (author token, upper-case) -&gt; {@code sdk.http.HttpClient} method. */
+    static final Map<String, String> METHODS = Map.of("GET", "get", "POST", "post", "PUT", "put", "PATCH", "patch", "DELETE", "delete");
+
+    /** Methods that carry a request body (the forwarded entity JSON). */
+    static final Set<String> METHODS_WITH_BODY = Set.of("POST", "PUT", "PATCH");
+
+    private static final String CONFIG_PREFIX = "@config:";
+
+    private IntegrationSupport() {}
+
+    /**
+     * @param method the author-facing HTTP method (case-insensitive), may be {@code null} (defaults
+     *        POST)
+     * @return whether it maps to a supported {@code HttpClient} method
+     */
+    public static boolean isSupportedMethod(String method) {
+        return METHODS.containsKey(normalize(method));
+    }
+
+    /**
+     * @param method the author-facing HTTP method
+     * @return the {@code sdk.http.HttpClient} method name ({@code post}/{@code get}/...)
+     */
+    public static String clientMethod(String method) {
+        return METHODS.get(normalize(method));
+    }
+
+    /**
+     * @param method the author-facing HTTP method
+     * @return whether the request carries the forwarded entity JSON as its body
+     */
+    public static boolean hasBody(String method) {
+        return METHODS_WITH_BODY.contains(normalize(method));
+    }
+
+    /**
+     * The URL as a Java {@code String} expression: an {@code @config:KEY} reference becomes a
+     * {@code Configurations.get("KEY")} lookup (resolved server-side), otherwise a quoted literal.
+     *
+     * @param url the authored URL
+     * @return a Java {@code String} expression
+     */
+    public static String urlExpression(String url) {
+        if (url == null) {
+            return "null";
+        }
+        String trimmed = url.trim();
+        if (trimmed.startsWith(CONFIG_PREFIX)) {
+            return "Configurations.get(\"" + trimmed.substring(CONFIG_PREFIX.length())
+                                                    .trim()
+                    + "\")";
+        }
+        return "\"" + trimmed.replace("\\", "\\\\")
+                             .replace("\"", "\\\"")
+                + "\"";
+    }
+
+    private static String normalize(String method) {
+        return method == null ? "POST"
+                : method.trim()
+                        .toUpperCase();
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/NotificationSupport.java
@@ -35,7 +35,6 @@ import org.eclipse.dirigible.components.intent.model.RelationIntent;
  */
 public final class NotificationSupport {
 
-    private static final String[] EVENT_KINDS = {"onCreate", "onUpdate", "onDelete"};
     private static final Pattern PATH = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)?");
     private static final Pattern PLACEHOLDER = Pattern.compile("\\{([A-Za-z_][A-Za-z0-9_]*(?:\\.[A-Za-z_][A-Za-z0-9_]*)?)\\}");
     private static final Pattern SIMPLE_COMPARISON = Pattern.compile("\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*(==|!=)\\s*(.+?)\\s*");
@@ -56,13 +55,7 @@ public final class NotificationSupport {
      * @return the lifecycle event kind it binds to, or {@code null}
      */
     public static String eventKind(NotificationIntent notification) {
-        for (String kind : EVENT_KINDS) {
-            if (notification.getEvent()
-                            .get(kind) != null) {
-                return kind;
-            }
-        }
-        return null;
+        return EventBinding.kind(notification.getEvent());
     }
 
     /**
@@ -70,11 +63,7 @@ public final class NotificationSupport {
      * @return the entity named by the bound event, or {@code null}
      */
     public static String eventEntity(NotificationIntent notification) {
-        String kind = eventKind(notification);
-        Object target = kind == null ? null
-                : notification.getEvent()
-                              .get(kind);
-        return target == null ? null : target.toString();
+        return EventBinding.entity(notification.getEvent());
     }
 
     /**
@@ -85,13 +74,7 @@ public final class NotificationSupport {
      * @return the topic suffix, possibly empty
      */
     public static String topicSuffix(String eventKind) {
-        if ("onUpdate".equals(eventKind)) {
-            return "-updated";
-        }
-        if ("onDelete".equals(eventKind)) {
-            return "-deleted";
-        }
-        return "";
+        return EventBinding.topicSuffix(eventKind);
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntegrationIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntegrationIntent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An outbound integration: when an entity event fires, call an external HTTP endpoint. The "tell
+ * another system" pattern of the declarative-glue catalog.
+ *
+ * <p>
+ * {@link #event} is the same {@code onCreate}/{@code onUpdate}/{@code onDelete} binding the
+ * notifications use. The generated {@code @Listener} forwards the entity JSON (the event payload)
+ * to {@link #url} via {@link #method}. The URL is a literal or {@code @config:KEY} (read
+ * server-side from the configuration). Custom body mapping and headers are a later increment.
+ */
+public class IntegrationIntent {
+
+    private String name;
+    private Map<String, Object> event = new LinkedHashMap<>();
+    private String method = "POST";
+    private String url;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Map<String, Object> getEvent() {
+        return event;
+    }
+
+    public void setEvent(Map<String, Object> event) {
+        this.event = event == null ? new LinkedHashMap<>() : event;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
@@ -36,6 +36,7 @@ public class IntentModel {
     private List<SeedIntent> seeds = new ArrayList<>();
     private List<NotificationIntent> notifications = new ArrayList<>();
     private List<ScheduleIntent> schedules = new ArrayList<>();
+    private List<IntegrationIntent> integrations = new ArrayList<>();
 
     public String getName() {
         return name;
@@ -123,5 +124,13 @@ public class IntentModel {
 
     public void setSchedules(List<ScheduleIntent> schedules) {
         this.schedules = schedules == null ? new ArrayList<>() : schedules;
+    }
+
+    public List<IntegrationIntent> getIntegrations() {
+        return integrations;
+    }
+
+    public void setIntegrations(List<IntegrationIntent> integrations) {
+        this.integrations = integrations == null ? new ArrayList<>() : integrations;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.FormIntent;
+import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
@@ -68,6 +69,8 @@ public final class IntentParser {
     private static final Set<String> NOTIFICATION_CHANNELS = Set.of("email");
     /** Comparison operators a schedule's {@code where} condition may use. */
     private static final Set<String> SCHEDULE_OPERATORS = Set.of("eq", "ne", "gt", "ge", "lt", "le", "like");
+    /** HTTP methods an outbound integration may use. */
+    private static final Set<String> HTTP_METHODS = Set.of("GET", "POST", "PUT", "PATCH", "DELETE");
 
     /**
      * Plain Gson for the YAML-Map -> JSON -> POJO round-trip. The platform's {@code JsonHelper} /
@@ -120,6 +123,7 @@ public final class IntentParser {
         validateSeeds(model, entityNames, issues);
         validateNotifications(model, entityNames, issues);
         validateSchedules(model, entityNames, issues);
+        validateIntegrations(model, entityNames, issues);
         if (!issues.isEmpty()) {
             throw new IntentValidationException(issues);
         }
@@ -169,6 +173,47 @@ public final class IntentParser {
                                                   .count() >= 2) {
                     issues.add("schedule [" + name + "] notify recipient [" + to + "] uses a multi-hop path, which is not supported");
                 }
+            }
+        }
+    }
+
+    /**
+     * Each integration must have a unique name, bind to exactly one entity lifecycle event of a
+     * declared entity, use a supported HTTP method, and name a target URL.
+     */
+    private static void validateIntegrations(IntentModel model, Set<String> entityNames, List<String> issues) {
+        Set<String> names = new HashSet<>();
+        for (IntegrationIntent integration : model.getIntegrations()) {
+            String name = integration.getName();
+            if (name == null || name.isBlank()) {
+                issues.add("integration has no name");
+                continue;
+            }
+            if (!names.add(name)) {
+                issues.add("duplicate integration [" + name + "]");
+            }
+            int eventCount = 0;
+            for (String kind : EVENT_KINDS) {
+                Object target = integration.getEvent()
+                                           .get(kind);
+                if (target != null) {
+                    eventCount++;
+                    if (!entityNames.contains(target.toString())) {
+                        issues.add("integration [" + name + "] " + kind + " references unknown entity [" + target + "]");
+                    }
+                }
+            }
+            if (eventCount != 1) {
+                issues.add("integration [" + name + "] must declare exactly one of onCreate/onUpdate/onDelete");
+            }
+            String method = integration.getMethod();
+            if (method != null && !method.isBlank() && !HTTP_METHODS.contains(method.trim()
+                                                                                    .toUpperCase(Locale.ROOT))) {
+                issues.add("integration [" + name + "] has unsupported HTTP method [" + method + "]");
+            }
+            if (integration.getUrl() == null || integration.getUrl()
+                                                           .isBlank()) {
+                issues.add("integration [" + name + "] has no url");
             }
         }
     }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntegrationSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntegrationSupportTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class IntegrationSupportTest {
+
+    @Test
+    void mapsHttpMethodsCaseInsensitively() {
+        assertEquals("post", IntegrationSupport.clientMethod("POST"));
+        assertEquals("get", IntegrationSupport.clientMethod("get"));
+        assertEquals("post", IntegrationSupport.clientMethod(null), "method defaults to POST");
+        assertTrue(IntegrationSupport.isSupportedMethod("PATCH"));
+        assertFalse(IntegrationSupport.isSupportedMethod("FETCH"));
+    }
+
+    @Test
+    void onlyWriteMethodsCarryABody() {
+        assertTrue(IntegrationSupport.hasBody("POST"));
+        assertTrue(IntegrationSupport.hasBody("put"));
+        assertFalse(IntegrationSupport.hasBody("GET"));
+        assertFalse(IntegrationSupport.hasBody("DELETE"));
+    }
+
+    @Test
+    void urlIsAConfigLookupOrALiteral() {
+        assertEquals("Configurations.get(\"WAREHOUSE_URL\")", IntegrationSupport.urlExpression("@config:WAREHOUSE_URL"));
+        assertEquals("\"https://hooks.example.com/orders\"", IntegrationSupport.urlExpression("https://hooks.example.com/orders"));
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Integration.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Integration.java.template
@@ -1,0 +1,42 @@
+package gen.events;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.dirigible.sdk.core.Configurations;
+import org.eclipse.dirigible.sdk.http.HttpClient;
+import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.eclipse.dirigible.sdk.utils.Json;
+
+/**
+ * Forwards a ${entity} event to an external endpoint via ${clientMethod}.
+ *
+ * Generated from the intent integrations block - do not edit; it is re-generated with the
+ * application. The event payload (the entity JSON) is sent as the request body. The target URL comes
+ * from the intent (a literal or a configuration value).
+ */
+@Listener(name = "${projectName}-${perspective}-${entity}${topicSuffix}", kind = ListenerKind.TOPIC)
+public class ${className}Integration implements MessageHandler {
+
+    @Override
+    public void onMessage(String message) {
+        String url = ${urlExpression};
+        if (url == null || url.isBlank()) {
+            return;
+        }
+        try {
+#if($hasBody)
+            Map<String, Object> options = new HashMap<>();
+            options.put("text", message);
+            options.put("contentType", "application/json");
+            HttpClient.${clientMethod}(url, Json.stringify(options));
+#else
+            HttpClient.${clientMethod}(url, null);
+#end
+        } catch (Exception ex) {
+            throw new RuntimeException("Integration ${name} failed", ex);
+        }
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -52,6 +52,13 @@ export function getTemplate(parameters) {
                 collection: "schedules"
             },
             {
+                location: "/template-application-events-java/events/Integration.java.template",
+                action: "generate",
+                rename: "gen/events/{{className}}Integration.java",
+                engine: "velocity",
+                collection: "integrations"
+            },
+            {
                 location: "/template-application-events-java/project.json.mjs",
                 action: "generate",
                 rename: "project.json",

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -390,6 +390,31 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "integrations":
+                    // Integrations (intent layer): one @Listener per outbound integration - forward the
+                    // entity event to an external HTTP endpoint. Not entity-shaped, own loop.
+                    if (model.integrations) {
+                        for (let i = 0; i < model.integrations.length; i++) {
+                            const integrationParameters = {
+                                ...parameters,
+                                name: model.integrations[i].name,
+                                className: model.integrations[i].className,
+                                entity: model.integrations[i].entity,
+                                perspective: model.integrations[i].perspective,
+                                topicSuffix: model.integrations[i].topicSuffix,
+                                clientMethod: model.integrations[i].clientMethod,
+                                hasBody: model.integrations[i].hasBody,
+                                urlExpression: model.integrations[i].urlExpression
+                            };
+                            const cleanIntegrationParameters = cleanData(integrationParameters);
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, cleanIntegrationParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, cleanIntegrationParameters)
+                            });
+                        }
+                    }
+                    break;
                 default:
                     // No collection
                     parameters.models = model.entities;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -154,6 +154,12 @@ class IntentEngineIT extends IntegrationTest {
                   to: ops@example.com
                   subject: "Stale order {id} for {customer.name}"
                   body: "This order is stale."
+
+            integrations:
+              - name: pushOrderToWarehouse
+                event: { onCreate: Order }
+                method: POST
+                url: "@config:WAREHOUSE_URL"
             """;
 
     @Autowired
@@ -376,6 +382,19 @@ class IntentEngineIT extends IntegrationTest {
                         "CustomerEntity customer = entity.Customer == null ? null : new CustomerRepository().findById(entity.Customer)"),
                 "the per-row notify should load the one-hop related entity");
         assertTrue(job.contains("Mail.send("), "the job should notify per row via the SDK Mail API");
+
+        // The integration is an @Listener that forwards the entity JSON to an external endpoint.
+        String integration = contentOf("gen/events/PushOrderToWarehouseIntegration.java");
+        assertTrue(integration.contains("class PushOrderToWarehouseIntegration implements MessageHandler"),
+                "the integration should be a message-handling listener");
+        assertTrue(integration.contains("@Listener(name = \"intent-test-Order-Order\""),
+                "an onCreate integration should bind to the entity's base (create) topic");
+        assertTrue(integration.contains("String url = Configurations.get(\"WAREHOUSE_URL\")"),
+                "an @config: URL should resolve through the configuration at run time");
+        assertTrue(
+                integration.contains("HttpClient.post(url, Json.stringify(options))")
+                        && integration.contains("options.put(\"text\", message)"),
+                "a POST integration should forward the entity JSON as the request body");
     }
 
     @Test
@@ -585,6 +604,11 @@ class IntentEngineIT extends IntegrationTest {
                 "glue should carry the staleOrders schedule with its cron");
         assertTrue(glue.contains("Criteria.create().lt(\\\"OrderDate\\\", java.time.LocalDate.now())"),
                 "glue should carry the schedule's typed Criteria expression");
+        // Integrations: one per outbound integration, carrying the HTTP method + URL expression.
+        assertTrue(glue.contains("\"integrations\"") && glue.contains("\"name\": \"pushOrderToWarehouse\"")
+                && glue.contains("\"clientMethod\": \"post\""), "glue should carry the pushOrderToWarehouse integration as a POST");
+        assertTrue(glue.contains("Configurations.get(\\\"WAREHOUSE_URL\\\")"),
+                "glue should carry the integration URL as a config lookup expression");
     }
 
     private void assertSettings() {


### PR DESCRIPTION
## What

Adds the **`integrations:`** block of the declarative-glue catalog — the "tell another system" pattern. On an entity event, forward the event payload to an external HTTP endpoint, with **no hand-written code**:

```yaml
integrations:
  - name: pushOrderToWarehouse
    event: { onCreate: Order }     # onCreate | onUpdate | onDelete
    method: POST                   # GET/POST/PUT/PATCH/DELETE
    url: "@config:WAREHOUSE_URL"   # literal, or @config:KEY resolved server-side
```

→ generates `gen/events/PushOrderToWarehouseIntegration.java`: an `@Listener` that `HttpClient.post`s the entity JSON to the resolved URL.

## How

- `IntegrationIntent` model + parser validation (unique name, exactly one event of a declared entity, supported method, url present).
- `IntegrationSupport` (pure, unit-tested) maps the HTTP method to the `sdk.http.HttpClient` call and the `@config:KEY` URL sugar to `Configurations.get` (literal otherwise).
- Extracted **`EventBinding`** — the `onCreate/onUpdate/onDelete` + topic-suffix logic now shared by notifications and integrations (`NotificationSupport` delegates to it; no behaviour change).
- `GlueIntentGenerator` emits an `integrations` collection into `<intent>.glue`; `Integration.java.template` renders the `@Listener`; `generateUtils.js` gets the `integrations` collection case. Honors the `.settings` override.

## Testing

- `IntegrationSupportTest` — method mapping, body-method set, `@config:`/literal URL — green.
- `IntentEngineIT.glue_template_generates_…` extended: the generated `PushOrderToWarehouseIntegration` binds the create topic, resolves `Configurations.get("WAREHOUSE_URL")`, and POSTs the entity JSON — **green locally** (`Tests run: 1, Failures: 0`). CI runs the full suite on H2/PostgreSQL/MSSQL.

## Scope / gaps

v1 forwards the whole entity JSON as the body; custom body mapping, request headers/auth, and other DBs' operators are later increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)