### PR TITLE
Intent declarative glue: inbound webhooks (ingest JSON → entity)

### DIFF
--- a/components/engine/engine-intent/CLAUDE.md
+++ b/components/engine/engine-intent/CLAUDE.md
@@ -348,12 +348,12 @@ Every action below has a real SDK surface to generate against, so none of this n
 
 **Tier 2 — high value:**
 
-5. **Inbound integration / webhooks** — "another system tells us" → upsert an entity or start a process.
+5. **Inbound webhooks** — "another system tells us": a webhook that ingests a JSON payload into an entity. **(v1 implemented.)**
    ```yaml
    inbound:
-     - { name: returnBook, source: { webhook: "/returns" }, do: { upsert: Loan, match: { id: payload.loanId }, set: { status: "'RETURNED'" } } }
+     - { name: ingestOrder, path: /ingest, create: Order }
    ```
-   → `@Controller` + `@Post` (webhook), or `@Listener` / `Consumer` for a queue/topic source.
+   → `gen/events/<Name>Webhook.java`: a `@Controller` with a `@Post("<path>")` that deserializes the body (via the java.time-aware SDK `Json`) into the entity and `save`s it through the repository, returning the saved JSON. Served at `/services/java/<project>/gen/events/<Name>Webhook<path>`. **Gap:** v1 action is `create` (ingest); upsert/match-set and start-process, plus queue/topic sources (`@Listener`/`Consumer`), are later.
 6. **Status lifecycle (state machine) on an entity** — order/ticket/loan status; the highest "removes custom code" leverage of the set.
    ```yaml
    entities:

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
 import org.eclipse.dirigible.components.intent.generator.ProcessResolverSupport.Resolver;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.InboundIntent;
 import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
@@ -71,8 +72,10 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> notifications = buildNotifications(model, byName, compositionParents, settings);
         List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings);
         List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
+        List<Map<String, Object>> inbound = buildInbound(model, byName, compositionParents, settings);
 
-        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty() && integrations.isEmpty()) {
+        if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty() && integrations.isEmpty()
+                && inbound.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -83,9 +86,12 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("notifications", notifications);
         glue.put("schedules", schedules);
         glue.put("integrations", integrations);
+        glue.put("inbound", inbound);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
-        LOGGER.debug("Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s), [{}] schedule(s) and [{}] integration(s)",
-                triggers.size(), resolvers.size(), notifications.size(), schedules.size(), integrations.size());
+        LOGGER.debug(
+                "Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s), [{}] schedule(s), [{}] integration(s)"
+                        + " and [{}] inbound webhook(s)",
+                triggers.size(), resolvers.size(), notifications.size(), schedules.size(), integrations.size(), inbound.size());
     }
 
     private static List<Map<String, Object>> buildTriggers(IntentModel model, Map<String, EntityIntent> byName,
@@ -150,6 +156,33 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             notifications.add(entry);
         }
         return notifications;
+    }
+
+    private static List<Map<String, Object>> buildInbound(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents, IntentSettings settings) {
+        List<Map<String, Object>> inbound = new ArrayList<>();
+        for (InboundIntent webhook : model.getInbound()) {
+            if (webhook.getName() == null || webhook.getName()
+                                                    .isBlank()) {
+                continue;
+            }
+            String entity = webhook.getCreate();
+            if (entity == null || !byName.containsKey(entity)) {
+                continue;
+            }
+            if (!settings.shouldGenerate("inbound", webhook.getName())) {
+                LOGGER.info("Settings opt-out: keeping existing controller for inbound webhook [{}] (not generated)", webhook.getName());
+                continue;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("name", webhook.getName());
+            entry.put("className", IntentNaming.pascalCase(webhook.getName()));
+            entry.put("entity", entity);
+            entry.put("perspective", IntentEntities.resolvePerspective(entity, compositionParents));
+            entry.put("path", webhook.getPath());
+            inbound.add(entry);
+        }
+        return inbound;
     }
 
     private static List<Map<String, Object>> buildIntegrations(IntentModel model, Map<String, EntityIntent> byName,

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/InboundIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/InboundIntent.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+/**
+ * An inbound webhook: expose an HTTP endpoint that ingests a JSON payload into an entity. The
+ * "another system tells us" pattern of the declarative-glue catalog.
+ *
+ * <p>
+ * Generates a client-Java {@code @Controller} with a {@code @Post} that deserializes the request
+ * body into {@link #create} and saves it through the entity's repository. {@link #path} is the
+ * endpoint suffix. Upsert / start-process actions are later increments.
+ */
+public class InboundIntent {
+
+    private String name;
+    private String path;
+    private String create;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getCreate() {
+        return create;
+    }
+
+    public void setCreate(String create) {
+        this.create = create;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
@@ -37,6 +37,7 @@ public class IntentModel {
     private List<NotificationIntent> notifications = new ArrayList<>();
     private List<ScheduleIntent> schedules = new ArrayList<>();
     private List<IntegrationIntent> integrations = new ArrayList<>();
+    private List<InboundIntent> inbound = new ArrayList<>();
 
     public String getName() {
         return name;
@@ -132,5 +133,13 @@ public class IntentModel {
 
     public void setIntegrations(List<IntegrationIntent> integrations) {
         this.integrations = integrations == null ? new ArrayList<>() : integrations;
+    }
+
+    public List<InboundIntent> getInbound() {
+        return inbound;
+    }
+
+    public void setInbound(List<InboundIntent> inbound) {
+        this.inbound = inbound == null ? new ArrayList<>() : inbound;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -18,6 +18,7 @@ import java.util.Set;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.FormIntent;
+import org.eclipse.dirigible.components.intent.model.InboundIntent;
 import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
@@ -124,6 +125,7 @@ public final class IntentParser {
         validateNotifications(model, entityNames, issues);
         validateSchedules(model, entityNames, issues);
         validateIntegrations(model, entityNames, issues);
+        validateInbound(model, entityNames, issues);
         if (!issues.isEmpty()) {
             throw new IntentValidationException(issues);
         }
@@ -173,6 +175,31 @@ public final class IntentParser {
                                                   .count() >= 2) {
                     issues.add("schedule [" + name + "] notify recipient [" + to + "] uses a multi-hop path, which is not supported");
                 }
+            }
+        }
+    }
+
+    /**
+     * Each inbound webhook must have a unique name, a path, and a declared entity to create from the
+     * posted payload.
+     */
+    private static void validateInbound(IntentModel model, Set<String> entityNames, List<String> issues) {
+        Set<String> names = new HashSet<>();
+        for (InboundIntent inbound : model.getInbound()) {
+            String name = inbound.getName();
+            if (name == null || name.isBlank()) {
+                issues.add("inbound webhook has no name");
+                continue;
+            }
+            if (!names.add(name)) {
+                issues.add("duplicate inbound webhook [" + name + "]");
+            }
+            if (inbound.getPath() == null || inbound.getPath()
+                                                    .isBlank()) {
+                issues.add("inbound webhook [" + name + "] has no path");
+            }
+            if (inbound.getCreate() == null || !entityNames.contains(inbound.getCreate())) {
+                issues.add("inbound webhook [" + name + "] creates unknown entity [" + inbound.getCreate() + "]");
             }
         }
     }

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Webhook.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Webhook.java.template
@@ -1,0 +1,29 @@
+package gen.events;
+
+import org.eclipse.dirigible.sdk.http.Body;
+import org.eclipse.dirigible.sdk.http.Controller;
+import org.eclipse.dirigible.sdk.http.Post;
+import org.eclipse.dirigible.sdk.utils.Json;
+
+import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
+import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Repository;
+
+/**
+ * Inbound webhook ${name}: ingest a posted JSON payload as a ${entity}.
+ *
+ * Generated from the intent inbound block - do not edit; it is re-generated with the application.
+ * The endpoint is served under /services/java/<project>/gen/events/${className}Webhook${path}.
+ */
+@Controller
+public class ${className}Webhook {
+
+    @Post("${path}")
+    public String ingest(@Body String body) {
+        ${entity}Entity entity = Json.parse(body, ${entity}Entity.class);
+        if (entity == null) {
+            return "{\"error\": \"empty or invalid payload\"}";
+        }
+        ${entity}Entity saved = new ${entity}Repository().save(entity);
+        return Json.stringify(saved);
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -59,6 +59,13 @@ export function getTemplate(parameters) {
                 collection: "integrations"
             },
             {
+                location: "/template-application-events-java/events/Webhook.java.template",
+                action: "generate",
+                rename: "gen/events/{{className}}Webhook.java",
+                engine: "velocity",
+                collection: "inbound"
+            },
+            {
                 location: "/template-application-events-java/project.json.mjs",
                 action: "generate",
                 rename: "project.json",

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -415,6 +415,29 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "inbound":
+                    // Inbound webhooks (intent layer): one @Controller per webhook - ingest a posted JSON
+                    // payload as an entity. Not entity-shaped, own loop.
+                    if (model.inbound) {
+                        for (let w = 0; w < model.inbound.length; w++) {
+                            const inboundParameters = {
+                                ...parameters,
+                                name: model.inbound[w].name,
+                                className: model.inbound[w].className,
+                                entity: model.inbound[w].entity,
+                                perspective: model.inbound[w].perspective,
+                                javaPerspective: sanitizeJavaIdentifier(model.inbound[w].perspective),
+                                path: model.inbound[w].path
+                            };
+                            const cleanInboundParameters = cleanData(inboundParameters);
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, cleanInboundParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, cleanInboundParameters)
+                            });
+                        }
+                    }
+                    break;
                 default:
                     // No collection
                     parameters.models = model.entities;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -160,6 +160,11 @@ class IntentEngineIT extends IntegrationTest {
                 event: { onCreate: Order }
                 method: POST
                 url: "@config:WAREHOUSE_URL"
+
+            inbound:
+              - name: ingestOrder
+                path: /ingest
+                create: Order
             """;
 
     @Autowired
@@ -395,6 +400,16 @@ class IntentEngineIT extends IntegrationTest {
                 integration.contains("HttpClient.post(url, Json.stringify(options))")
                         && integration.contains("options.put(\"text\", message)"),
                 "a POST integration should forward the entity JSON as the request body");
+
+        // The inbound webhook is a @Controller that ingests a posted JSON payload as the entity.
+        String webhook = contentOf("gen/events/IngestOrderWebhook.java");
+        assertTrue(webhook.contains("@Controller") && webhook.contains("class IngestOrderWebhook"),
+                "the inbound webhook should be a @Controller");
+        assertTrue(webhook.contains("@Post(\"/ingest\")"), "the webhook should expose the declared path");
+        assertTrue(
+                webhook.contains("OrderEntity entity = Json.parse(body, OrderEntity.class)")
+                        && webhook.contains("new OrderRepository().save(entity)"),
+                "the webhook should deserialize the payload and save it through the repository");
     }
 
     @Test
@@ -609,6 +624,9 @@ class IntentEngineIT extends IntegrationTest {
                 && glue.contains("\"clientMethod\": \"post\""), "glue should carry the pushOrderToWarehouse integration as a POST");
         assertTrue(glue.contains("Configurations.get(\\\"WAREHOUSE_URL\\\")"),
                 "glue should carry the integration URL as a config lookup expression");
+        // Inbound: one per webhook, carrying the path + the entity to create.
+        assertTrue(glue.contains("\"inbound\"") && glue.contains("\"name\": \"ingestOrder\"") && glue.contains("\"path\": \"/ingest\""),
+                "glue should carry the ingestOrder inbound webhook with its path");
     }
 
     private void assertSettings() {


### PR DESCRIPTION
## What

Adds the **`inbound:`** block of the declarative-glue catalog — the "another system tells us" pattern, the inbound counterpart to outbound integrations. Exposes an HTTP endpoint that ingests a posted JSON payload into an entity, with **no hand-written code**:

```yaml
inbound:
  - name: ingestOrder
    path: /ingest
    create: Order
```

→ generates `gen/events/IngestOrderWebhook.java`: a client-Java `@Controller` with `@Post("/ingest")` that deserializes the body into an `OrderEntity` and `save`s it, returning the saved JSON. Served at `/services/java/<project>/gen/events/IngestOrderWebhook/ingest`.

## How

- `InboundIntent` model + parser validation (unique name, path, declared entity).
- `GlueIntentGenerator` emits an `inbound` collection into `<intent>.glue`; `Webhook.java.template` renders the `@Controller` (deserializing via the **java.time-aware SDK `Json`**, not Jackson, so date/timestamp fields don't choke); `generateUtils.js` gets the `inbound` collection case. Honors the `.settings` override.
- Introduces the `@Controller` generation surface — a new artefact shape alongside the `@Listener`/`@Scheduled` glue.

## Testing

`IntentEngineIT.glue_template_generates_…` extended: the generated `IngestOrderWebhook` is a `@Controller` with `@Post("/ingest")` that `Json.parse`s the body and `save`s through the repository — **green locally** (`Tests run: 1, Failures: 0`). CI runs the full suite on H2/PostgreSQL/MSSQL.

## Scope / gaps

v1 action is `create` (ingest). Upsert (match + set), start-process, and queue/topic sources (`@Listener`/`Consumer`) are later increments. The endpoint lives under the deterministic `gen/events/<Name>Webhook<path>` route; a cleaner custom base path is a possible refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)