### PR TITLE
Intent declarative glue: rollup counters

### DIFF
--- a/components/engine/engine-intent/CLAUDE.md
+++ b/components/engine/engine-intent/CLAUDE.md
@@ -375,7 +375,12 @@ Every action below has a real SDK surface to generate against, so none of this n
 **Tier 3 — denormalization & compliance (cheap once Tier 1 exists):**
 
 8. **Audit / history** — `audit: true` on an entity → shadow `<Entity>History` entity + a write-on-change `@Listener`.
-9. **Rollups / counters** — e.g. `Member.activeLoanCount: rollup(count Loan where status=='ACTIVE')`, maintained by reactions.
+9. **Rollups / counters** — maintain a denormalized count on a parent. **(v1 implemented.)**
+   ```yaml
+   rollups:
+     - { name: memberLoanCount, entity: Loan, via: member, field: loanCount }   # Member.loanCount = #Loans whose `member` FK = that Member
+   ```
+   → two `gen/events/<Name>RollupOn{Create,Delete}.java` `@Listener`s on the child's create/delete topics that recompute the affected parent's count via a typed `Criteria` (`findAll(Criteria.create().eq("<Fk>", entity.<Fk>)).size()`) and write it back. Recompute-on-event (self-healing); **eventually consistent, not transactionally exact** under heavy concurrency. **Gap:** no `where` filter (counts all children), and re-parenting on child update isn't tracked (only create/delete).
 10. **Dynamic user-task assignment** — `assignee: { fromPath: member.branch.manager }`, resolver-driven (extends the existing user-task glue).
 
 ### Guardrails (so this doesn't become the MDE expressiveness trap)

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -22,6 +22,8 @@ import org.eclipse.dirigible.components.intent.model.IntegrationIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
+import org.eclipse.dirigible.components.intent.model.RollupIntent;
 import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,9 +75,10 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings);
         List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
         List<Map<String, Object>> inbound = buildInbound(model, byName, compositionParents, settings);
+        List<Map<String, Object>> rollups = buildRollups(model, byName, compositionParents, settings);
 
         if (triggers.isEmpty() && resolvers.isEmpty() && notifications.isEmpty() && schedules.isEmpty() && integrations.isEmpty()
-                && inbound.isEmpty()) {
+                && inbound.isEmpty() && rollups.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -87,11 +90,13 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("schedules", schedules);
         glue.put("integrations", integrations);
         glue.put("inbound", inbound);
+        glue.put("rollups", rollups);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
         LOGGER.debug(
-                "Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s), [{}] schedule(s), [{}] integration(s)"
-                        + " and [{}] inbound webhook(s)",
-                triggers.size(), resolvers.size(), notifications.size(), schedules.size(), integrations.size(), inbound.size());
+                "Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] notification(s), [{}] schedule(s), [{}] integration(s),"
+                        + " [{}] inbound webhook(s) and [{}] rollup(s)",
+                triggers.size(), resolvers.size(), notifications.size(), schedules.size(), integrations.size(), inbound.size(),
+                rollups.size());
     }
 
     private static List<Map<String, Object>> buildTriggers(IntentModel model, Map<String, EntityIntent> byName,
@@ -158,6 +163,59 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             notifications.add(entry);
         }
         return notifications;
+    }
+
+    private static List<Map<String, Object>> buildRollups(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents, IntentSettings settings) {
+        List<Map<String, Object>> rollups = new ArrayList<>();
+        for (RollupIntent rollup : model.getRollups()) {
+            if (rollup.getName() == null || rollup.getName()
+                                                  .isBlank()) {
+                continue;
+            }
+            EntityIntent child = byName.get(rollup.getEntity());
+            RelationIntent via = child == null ? null : toOneRelation(child, rollup.getVia());
+            EntityIntent parent = via == null ? null : byName.get(via.getTo());
+            if (parent == null) {
+                continue; // parser already reported the bad reference
+            }
+            if (!settings.shouldGenerate("rollups", rollup.getName())) {
+                LOGGER.info("Settings opt-out: keeping existing listeners for rollup [{}] (not generated)", rollup.getName());
+                continue;
+            }
+            String fkProperty = IntentNaming.pascalCase(rollup.getVia());
+            Map<String, Object> base = new LinkedHashMap<>();
+            base.put("childEntity", rollup.getEntity());
+            base.put("childPerspective", IntentEntities.resolvePerspective(rollup.getEntity(), compositionParents));
+            base.put("parentEntity", via.getTo());
+            base.put("parentPerspective", IntentEntities.resolvePerspective(via.getTo(), compositionParents));
+            base.put("fkProperty", fkProperty);
+            base.put("countField", IntentNaming.pascalCase(rollup.getField()));
+            // Recompute the count for the affected parent from the store on each child event.
+            base.put("criteriaExpression", "Criteria.create().eq(\"" + fkProperty + "\", entity." + fkProperty + ")");
+            String className = IntentNaming.pascalCase(rollup.getName());
+            // Two listeners: recompute when a child is created and when one is deleted.
+            rollups.add(rollupEntry(base, className + "RollupOnCreate", ""));
+            rollups.add(rollupEntry(base, className + "RollupOnDelete", "-deleted"));
+        }
+        return rollups;
+    }
+
+    private static Map<String, Object> rollupEntry(Map<String, Object> base, String className, String topicSuffix) {
+        Map<String, Object> entry = new LinkedHashMap<>(base);
+        entry.put("className", className);
+        entry.put("topicSuffix", topicSuffix);
+        return entry;
+    }
+
+    private static RelationIntent toOneRelation(EntityIntent owner, String name) {
+        for (RelationIntent relation : owner.getRelations()) {
+            boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+            if (toOne && name != null && name.equals(relation.getName())) {
+                return relation;
+            }
+        }
+        return null;
     }
 
     private static List<Map<String, Object>> buildInbound(IntentModel model, Map<String, EntityIntent> byName,

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
@@ -38,6 +38,7 @@ public class IntentModel {
     private List<ScheduleIntent> schedules = new ArrayList<>();
     private List<IntegrationIntent> integrations = new ArrayList<>();
     private List<InboundIntent> inbound = new ArrayList<>();
+    private List<RollupIntent> rollups = new ArrayList<>();
 
     public String getName() {
         return name;
@@ -141,5 +142,13 @@ public class IntentModel {
 
     public void setInbound(List<InboundIntent> inbound) {
         this.inbound = inbound == null ? new ArrayList<>() : inbound;
+    }
+
+    public List<RollupIntent> getRollups() {
+        return rollups;
+    }
+
+    public void setRollups(List<RollupIntent> rollups) {
+        this.rollups = rollups == null ? new ArrayList<>() : rollups;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RollupIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RollupIntent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+/**
+ * A denormalized roll-up counter: maintain an integer {@link #field} on a parent entity equal to
+ * the number of {@link #entity} (child) rows pointing at it through the {@link #via} to-one
+ * relation.
+ *
+ * <p>
+ * The generator emits two client-Java {@code @Listener}s (on the child's create and delete events)
+ * that recompute the count for the affected parent and write it back. The count is recomputed from
+ * the store on each event (not blindly incremented), so it self-heals; under high write concurrency
+ * it is eventually consistent rather than transactionally exact.
+ */
+public class RollupIntent {
+
+    private String name;
+    private String entity;
+    private String via;
+    private String field;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public void setEntity(String entity) {
+        this.entity = entity;
+    }
+
+    public String getVia() {
+        return via;
+    }
+
+    public void setVia(String via) {
+        this.via = via;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -25,6 +25,7 @@ import org.eclipse.dirigible.components.intent.model.NotificationIntent;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.ReportIntent;
+import org.eclipse.dirigible.components.intent.model.RollupIntent;
 import org.eclipse.dirigible.components.intent.model.ScheduleConditionIntent;
 import org.eclipse.dirigible.components.intent.model.ScheduleIntent;
 import org.eclipse.dirigible.components.intent.model.SeedIntent;
@@ -126,6 +127,7 @@ public final class IntentParser {
         validateSchedules(model, entityNames, issues);
         validateIntegrations(model, entityNames, issues);
         validateInbound(model, entityNames, issues);
+        validateRollups(model, issues);
         if (!issues.isEmpty()) {
             throw new IntentValidationException(issues);
         }
@@ -177,6 +179,63 @@ public final class IntentParser {
                 }
             }
         }
+    }
+
+    /**
+     * Each roll-up must have a unique name, a child entity, a {@code via} to-one relation of that child
+     * pointing at a parent, and an integer {@code field} on the parent to maintain.
+     */
+    private static void validateRollups(IntentModel model, List<String> issues) {
+        java.util.Map<String, EntityIntent> byName = new java.util.HashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() != null) {
+                byName.put(entity.getName(), entity);
+            }
+        }
+        Set<String> names = new HashSet<>();
+        for (RollupIntent rollup : model.getRollups()) {
+            String name = rollup.getName();
+            if (name == null || name.isBlank()) {
+                issues.add("rollup has no name");
+                continue;
+            }
+            if (!names.add(name)) {
+                issues.add("duplicate rollup [" + name + "]");
+            }
+            EntityIntent child = byName.get(rollup.getEntity());
+            if (child == null) {
+                issues.add("rollup [" + name + "] counts unknown entity [" + rollup.getEntity() + "]");
+                continue;
+            }
+            RelationIntent via = null;
+            for (RelationIntent relation : child.getRelations()) {
+                boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+                if (toOne && relation.getName() != null && relation.getName()
+                                                                   .equals(rollup.getVia())) {
+                    via = relation;
+                }
+            }
+            if (via == null) {
+                issues.add("rollup [" + name + "] via [" + rollup.getVia() + "] is not a to-one relation of [" + rollup.getEntity() + "]");
+                continue;
+            }
+            EntityIntent parent = byName.get(via.getTo());
+            FieldIntent counter = parent == null ? null : fieldByName(parent, rollup.getField());
+            if (counter == null) {
+                issues.add("rollup [" + name + "] field [" + rollup.getField() + "] is not a field of parent [" + via.getTo() + "]");
+            } else if (!INTEGER_PK_TYPES.contains(counter.getType())) {
+                issues.add("rollup [" + name + "] field [" + rollup.getField() + "] must be an integer type to hold a count");
+            }
+        }
+    }
+
+    private static FieldIntent fieldByName(EntityIntent entity, String name) {
+        for (FieldIntent field : entity.getFields()) {
+            if (name != null && name.equals(field.getName())) {
+                return field;
+            }
+        }
+        return null;
     }
 
     /**

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
@@ -1,0 +1,39 @@
+package gen.events;
+
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
+import org.eclipse.dirigible.sdk.messaging.Listener;
+import org.eclipse.dirigible.sdk.messaging.ListenerKind;
+import org.eclipse.dirigible.sdk.messaging.MessageHandler;
+import org.eclipse.dirigible.sdk.utils.Json;
+
+import gen.${javaGenFolderName}.data.${javaChildPerspective}.${childEntity}Entity;
+import gen.${javaGenFolderName}.data.${javaChildPerspective}.${childEntity}Repository;
+import gen.${javaGenFolderName}.data.${javaParentPerspective}.${parentEntity}Entity;
+import gen.${javaGenFolderName}.data.${javaParentPerspective}.${parentEntity}Repository;
+
+/**
+ * Maintains the ${parentEntity}.${countField} roll-up count of ${childEntity} rows.
+ *
+ * Generated from the intent rollups block - do not edit; it is re-generated with the application.
+ * On each ${childEntity} event the count for the affected parent is recomputed from the store (so it
+ * self-heals); under heavy write concurrency it is eventually consistent, not transactionally exact.
+ */
+@Listener(name = "${projectName}-${childPerspective}-${childEntity}${topicSuffix}", kind = ListenerKind.TOPIC)
+public class ${className} implements MessageHandler {
+
+    @Override
+    public void onMessage(String message) {
+        ${childEntity}Entity entity = Json.parse(message, ${childEntity}Entity.class);
+        if (entity == null || entity.${fkProperty} == null) {
+            return;
+        }
+        ${parentEntity}Repository parents = new ${parentEntity}Repository();
+        ${parentEntity}Entity parent = parents.findById(entity.${fkProperty});
+        if (parent == null) {
+            return;
+        }
+        int count = new ${childEntity}Repository().findAll(${criteriaExpression}).size();
+        parent.${countField} = count;
+        parents.update(parent);
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -66,6 +66,13 @@ export function getTemplate(parameters) {
                 collection: "inbound"
             },
             {
+                location: "/template-application-events-java/events/Rollup.java.template",
+                action: "generate",
+                rename: "gen/events/{{className}}.java",
+                engine: "velocity",
+                collection: "rollups"
+            },
+            {
                 location: "/template-application-events-java/project.json.mjs",
                 action: "generate",
                 rename: "project.json",

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -440,6 +440,33 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "rollups":
+                    // Rollups (intent layer): per rollup, two @Listeners (child create/delete) that
+                    // recompute a parent counter. Not entity-shaped, own loop.
+                    if (model.rollups) {
+                        for (let r = 0; r < model.rollups.length; r++) {
+                            const rollupParameters = {
+                                ...parameters,
+                                className: model.rollups[r].className,
+                                childEntity: model.rollups[r].childEntity,
+                                childPerspective: model.rollups[r].childPerspective,
+                                javaChildPerspective: sanitizeJavaIdentifier(model.rollups[r].childPerspective),
+                                parentEntity: model.rollups[r].parentEntity,
+                                javaParentPerspective: sanitizeJavaIdentifier(model.rollups[r].parentPerspective),
+                                fkProperty: model.rollups[r].fkProperty,
+                                countField: model.rollups[r].countField,
+                                topicSuffix: model.rollups[r].topicSuffix,
+                                criteriaExpression: model.rollups[r].criteriaExpression
+                            };
+                            const cleanRollupParameters = cleanData(rollupParameters);
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, cleanRollupParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, cleanRollupParameters)
+                            });
+                        }
+                    }
+                    break;
                 default:
                     // No collection
                     parameters.models = model.entities;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -444,6 +444,49 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void rollup_generates_create_and_delete_listeners_that_recompute_the_parent_count() {
+        String yaml = """
+                name: library
+                entities:
+                  - name: Member
+                    fields:
+                      - { name: id,        type: integer, primaryKey: true, generated: true }
+                      - { name: loanCount, type: integer }
+                  - name: Loan
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: member, kind: manyToOne, to: Member }
+                rollups:
+                  - name: memberLoanCount
+                    entity: Loan
+                    via: member
+                    field: loanCount
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "library.glue");
+
+        String onCreate = contentOf("gen/events/MemberLoanCountRollupOnCreate.java");
+        assertTrue(onCreate.contains("class MemberLoanCountRollupOnCreate implements MessageHandler"),
+                "the create-side rollup listener should be generated");
+        assertTrue(onCreate.contains("@Listener(name = \"intent-test-Loan-Loan\""), "the create listener binds the child's base topic");
+        assertTrue(onCreate.contains("MemberEntity parent = parents.findById(entity.Member)"),
+                "it should load the parent via the child's FK");
+        assertTrue(
+                onCreate.contains("new LoanRepository().findAll(Criteria.create().eq(\"Member\", entity.Member)).size()")
+                        && onCreate.contains("parent.LoanCount = count"),
+                "it should recompute the count via a typed Criteria and write it to the parent counter");
+
+        String onDelete = contentOf("gen/events/MemberLoanCountRollupOnDelete.java");
+        assertTrue(onDelete.contains("@Listener(name = \"intent-test-Loan-Loan-deleted\""),
+                "the delete listener binds the child's -deleted topic");
+    }
+
+    @Test
     void service_task_handler_stub_is_scaffolded_under_custom_and_preserved() {
         writeIntent(INTENT_YAML);
         restAssuredExecutor.execute(() -> given().when()


### PR DESCRIPTION
## What

Adds the **`rollups:`** block of the declarative-glue catalog — maintain a denormalized count on a parent entity, **no hand-written code**:

```yaml
rollups:
  - name: memberLoanCount
    entity: Loan       # the child entity to count
    via: member        # the to-one relation on the child pointing at the parent (Member)
    field: loanCount   # the integer counter field on the parent to keep up to date
```

→ keeps `Member.loanCount` equal to the number of `Loan`s whose `member` FK points at that member.

## How

- `RollupIntent` model + parser validation (unique name; declared child entity; `via` is a to-one relation of the child to a declared parent; `field` is an **integer** field on that parent).
- `GlueIntentGenerator` emits **two** glue entries per rollup; `Rollup.java.template` renders an `@Listener` on the child's **create** and **delete** topics that recomputes the affected parent's count via the typed `Criteria` API — `new <Child>Repository().findAll(Criteria.create().eq("<Fk>", entity.<Fk>)).size()` — and writes it to the parent counter. `generateUtils.js` gets the `rollups` collection case. Honors the `.settings` override.

## Consistency note

The count is **recomputed from the store on each event** (not blindly incremented), so it self-heals. Under heavy write concurrency it is **eventually consistent, not transactionally exact** (concurrent recomputes can race) — documented in the model + template.

## Scope / gaps

v1 counts **all** children (no `where` filter) and tracks **create/delete** (re-parenting on a child update isn't tracked). Both are later refinements.

## Testing

`IntentEngineIT`: a `Loan → Member` rollup generates `MemberLoanCountRollupOnCreate`/`…OnDelete` listeners (bound to the child's base/`-deleted` topics) that load the parent and recompute `Member.loanCount` via `Criteria` — **green locally** (`Tests run: 2, Failures: 0`). CI runs the full suite on H2/PostgreSQL/MSSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)