### PR TITLE
Report a wrong-typed intent scalar as a validation issue, not a 500

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -36,6 +36,7 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.ToNumberPolicy;
 
 /**
@@ -104,12 +105,34 @@ public final class IntentParser {
             return new IntentModel();
         }
         String json = GSON.toJson(tree);
-        IntentModel model = GSON.fromJson(json, IntentModel.class);
+        IntentModel model;
+        try {
+            model = GSON.fromJson(json, IntentModel.class);
+        } catch (JsonSyntaxException ex) {
+            // A scalar with the wrong shape (commonly a {..} YAML flow-mapping where a string is
+            // expected - e.g. an unquoted brace recipient like `to: {member.email}`) fails the typed
+            // mapping here, before validate() runs. Surface it as a normal validation issue so the
+            // editor shows a helpful message in its problem list instead of a raw 500.
+            throw new IntentValidationException(List.of("intent has a value of the wrong type: " + rootMessage(ex)
+                    + " - note that brace interpolation ({...}) is only valid inside quoted subject/body strings;"
+                    + " a recipient/path field must be a plain scalar (e.g. `to: member.email`, not `to: {member.email}`)"));
+        }
         if (model == null) {
             return new IntentModel();
         }
         validate(model);
         return model;
+    }
+
+    /**
+     * The deepest cause message - Gson wraps the informative "Expected ... path $...." in its cause.
+     */
+    private static String rootMessage(Throwable ex) {
+        Throwable cause = ex;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() == null ? ex.toString() : cause.getMessage();
     }
 
     /**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.junit.jupiter.api.Test;
+
+class IntentParserTest {
+
+    private static final String HEAD = """
+            name: lib
+            entities:
+              - name: Member
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: email, type: string }
+              - name: Loan
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                relations:
+                  - { name: member, kind: manyToOne, to: Member }
+            notifications:
+              - name: loanUpdated
+                event: { onUpdate: Loan }
+                subject: "x"
+            """;
+
+    @Test
+    void braceRecipientReportsACleanIssueInsteadOfA500() {
+        // `to: {member.email}` is YAML flow-mapping (an object), not a string. The typed mapping used
+        // to throw a raw Gson JsonSyntaxException (-> 500); it must now be a clean validation issue.
+        String yaml = HEAD.stripTrailing() + "\n    to: {member.email}\n";
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("wrong type")),
+                "a wrong-typed scalar should be reported as a validation issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void bareOneHopRelationFieldRecipientParses() {
+        // `to: member.email` (bare, no braces) is the supported one-hop relation.field recipient.
+        String yaml = HEAD.stripTrailing() + "\n    to: member.email\n";
+        IntentModel model = IntentParser.parse(yaml);
+        assertEquals("member.email", model.getNotifications()
+                                          .get(0)
+                                          .getTo());
+    }
+}


### PR DESCRIPTION
## Problem
`IntentParser.parse()` maps the YAML through `GSON.fromJson(json, IntentModel.class)`. A scalar with the **wrong shape** — most commonly a `{..}` YAML *flow-mapping* where a string is expected, e.g. an unquoted brace recipient:

```yaml
notifications:
  - name: loanUpdated
    event: { onUpdate: Loan }
    to: {member.email}      # <-- YAML parses this as an OBJECT, not a string
```

threw a raw `com.google.gson.JsonSyntaxException` **before** `validate()` ran. It escaped the endpoint's `IntentValidationException` catch and surfaced as a **500** — the editor showed "Unable to parse" with no problem-list entry and no obvious way back.

## Fix
Catch `JsonSyntaxException` in `parse()` and rethrow it as an `IntentValidationException` with a helpful message (it includes the offending JSON path from Gson's cause, and reminds that brace interpolation `{...}` is only valid inside quoted `subject`/`body` strings, while a recipient/path field must be a plain scalar). The editor already renders `IntentValidationException` issues in its problem list, so the author now sees exactly what to fix.

`to: member.email` (a bare one-hop relation.field recipient) is and remains fully supported — only the *braced* form was the problem.

## Test
`IntentParserTest` (new): asserts the braced recipient now yields a clean validation issue (not an exception type leak), and that the bare `to: member.email` form parses. Both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)