### PR TITLE
Let a process trigger flag the BPM business key field (+ optional timestamp)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -120,6 +120,17 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             trigger.put("entity", entity);
             trigger.put("perspective", IntentEntities.resolvePerspective(entity, compositionParents));
             trigger.put("keyProperty", IntentEntities.keyFieldName(byName.get(entity)));
+            // The BPM business key: the flagged trigger field's property, or the primary key when none
+            // is flagged (preserving the historical default). keyProperty stays the PK - the listener
+            // still loads the entity by id via findById; only the business key may differ.
+            String businessKey = TriggerSupport.triggerBusinessKey(process);
+            boolean hasBusinessKey = businessKey != null && !businessKey.isBlank();
+            trigger.put("businessKeyProperty",
+                    hasBusinessKey ? IntentNaming.pascalCase(businessKey) : IntentEntities.keyFieldName(byName.get(entity)));
+            // When a businessKeyStrategy is set, the listener mints the value into the flagged field if
+            // it is blank (today: a yyyyMMddHHmmss timestamp) and persists it via the existing update.
+            boolean generateBusinessKey = hasBusinessKey && "timestamp".equals(TriggerSupport.triggerBusinessKeyStrategy(process));
+            trigger.put("generateBusinessKey", String.valueOf(generateBusinessKey));
             trigger.put("topicSuffix", EventBinding.topicSuffix(TriggerSupport.triggerKind(process)));
             trigger.put("guardExpression", NotificationSupport.guard(TriggerSupport.triggerWhen(process)));
             triggers.add(trigger);

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TriggerSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/TriggerSupport.java
@@ -48,6 +48,28 @@ public final class TriggerSupport {
     }
 
     /**
+     * The optional {@code businessKey} field flagged on the trigger - the trigger entity field whose
+     * value becomes the started process instance's BPM business key. Null when omitted, in which case
+     * the generator defaults the business key to the entity's primary key.
+     */
+    public static String triggerBusinessKey(ProcessIntent process) {
+        Object value = process.getTrigger()
+                              .get("businessKey");
+        return value == null ? null : value.toString();
+    }
+
+    /**
+     * The optional {@code businessKeyStrategy} on the trigger - how the {@code businessKey} field is
+     * populated when blank. Today the only strategy is {@code timestamp} (a {@code yyyyMMddHHmmss}
+     * value minted by the listener). Null when the field is used as-is.
+     */
+    public static String triggerBusinessKeyStrategy(ProcessIntent process) {
+        Object value = process.getTrigger()
+                              .get("businessKeyStrategy");
+        return value == null ? null : value.toString();
+    }
+
+    /**
      * Entity names that some process triggers on - they get the {@code ProcessId} back-reference,
      * regardless of which lifecycle event starts the process.
      */

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -428,6 +428,12 @@ public final class IntentParser {
 
     private static void validateProcesses(IntentModel model, Set<String> entityNames, List<String> issues) {
         Set<String> processNames = new HashSet<>();
+        java.util.Map<String, EntityIntent> byName = new java.util.HashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() != null) {
+                byName.put(entity.getName(), entity);
+            }
+        }
         for (ProcessIntent process : model.getProcesses()) {
             if (process.getName() == null || process.getName()
                                                     .isBlank()) {
@@ -438,11 +444,13 @@ public final class IntentParser {
                 issues.add("duplicate process [" + process.getName() + "]");
             }
             int triggerEvents = 0;
+            String triggerEntity = null;
             for (String kind : EVENT_KINDS) {
                 Object target = process.getTrigger()
                                        .get(kind);
                 if (target != null) {
                     triggerEvents++;
+                    triggerEntity = target.toString();
                     if (!entityNames.contains(target.toString())) {
                         issues.add("process [" + process.getName() + "] trigger " + kind + " references unknown entity [" + target + "]");
                     }
@@ -450,6 +458,40 @@ public final class IntentParser {
             }
             if (triggerEvents > 1) {
                 issues.add("process [" + process.getName() + "] trigger must declare at most one of onCreate/onUpdate/onDelete");
+            }
+            // An optional businessKey flags which trigger-entity field becomes the started process
+            // instance's BPM business key; it must be a field of the triggered entity.
+            Object businessKey = process.getTrigger()
+                                        .get("businessKey");
+            FieldIntent businessKeyField = null;
+            if (businessKey != null) {
+                if (triggerEntity == null) {
+                    issues.add("process [" + process.getName()
+                            + "] trigger declares businessKey but no onCreate/onUpdate/onDelete event to start on");
+                } else {
+                    EntityIntent triggered = byName.get(triggerEntity);
+                    businessKeyField = triggered == null ? null : fieldByName(triggered, businessKey.toString());
+                    if (triggered != null && businessKeyField == null) {
+                        issues.add("process [" + process.getName() + "] trigger businessKey [" + businessKey + "] is not a field of ["
+                                + triggerEntity + "]");
+                    }
+                }
+            }
+            // An optional businessKeyStrategy mints the businessKey field's value when blank. Only
+            // "timestamp" (a yyyyMMddHHmmss string) is supported today, and it needs a string field.
+            Object strategy = process.getTrigger()
+                                     .get("businessKeyStrategy");
+            if (strategy != null) {
+                if (!"timestamp".equals(strategy.toString())) {
+                    issues.add("process [" + process.getName() + "] trigger businessKeyStrategy [" + strategy
+                            + "] is not supported (supported: timestamp)");
+                } else if (businessKey == null) {
+                    issues.add("process [" + process.getName() + "] trigger businessKeyStrategy needs a businessKey field to populate");
+                } else if (businessKeyField != null && businessKeyField.getType() != null && !"string".equals(businessKeyField.getType())
+                        && !"text".equals(businessKeyField.getType())) {
+                    issues.add("process [" + process.getName() + "] trigger businessKey field [" + businessKey
+                            + "] must be a string/text field to hold a generated timestamp");
+                }
             }
             Set<String> stepNames = new HashSet<>();
             for (StepIntent step : process.getSteps()) {

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Trigger.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Trigger.java.template
@@ -36,7 +36,12 @@ public class ${process}Trigger implements MessageHandler {
             return;
         }
 #end
-        String businessKey = String.valueOf(entity.${keyProperty});
+#if(${generateBusinessKey} == "true")
+        if (entity.${businessKeyProperty} == null || entity.${businessKeyProperty}.isBlank()) {
+            entity.${businessKeyProperty} = java.time.LocalDateTime.now().format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        }
+#end
+        String businessKey = String.valueOf(entity.${businessKeyProperty});
         String processId = Process.start("${process}", businessKey, message);
         entity.ProcessId = processId;
         repository.update(entity);

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -287,6 +287,8 @@ export function generateFiles(model, parameters, templateSources) {
                                 // topic the DAO publishes to (${projectName}-${perspectiveName}-${name}).
                                 javaPerspective: sanitizeJavaIdentifier(model.triggers[t].perspective),
                                 keyProperty: model.triggers[t].keyProperty,
+                                businessKeyProperty: model.triggers[t].businessKeyProperty,
+                                generateBusinessKey: model.triggers[t].generateBusinessKey,
                                 topicSuffix: model.triggers[t].topicSuffix,
                                 guardExpression: model.triggers[t].guardExpression
                             };

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -284,6 +284,30 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void parse_rejects_a_trigger_business_key_that_is_not_a_field() {
+        String yaml = """
+                name: orders
+                entities:
+                  - name: SalesOrder
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                processes:
+                  - name: Approve
+                    trigger: { onCreate: SalesOrder, businessKey: nope }
+                    steps:
+                      - { name: done, kind: end }
+                """;
+        restAssuredExecutor.execute(() -> given().contentType("text/plain")
+                                                 .body(yaml)
+                                                 .when()
+                                                 .post(PARSE_URL)
+                                                 .then()
+                                                 .statusCode(422)
+                                                 .body("issues", hasItem(
+                                                         "process [Approve] trigger businessKey [nope] is not a field of [SalesOrder]")));
+    }
+
+    @Test
     void generate_writes_all_model_files_into_the_workspace_project() {
         writeIntent(INTENT_YAML);
 
@@ -505,6 +529,76 @@ class IntentEngineIT extends IntegrationTest {
         String onDelete = contentOf("gen/events/MemberLoanCountRollupOnDelete.java");
         assertTrue(onDelete.contains("@Listener(name = \"intent-test-Loan-Loan-deleted\""),
                 "the delete listener binds the child's -deleted topic");
+    }
+
+    @Test
+    void process_trigger_business_key_uses_the_flagged_field_not_the_primary_key() {
+        // The trigger flags `orderNumber` as the business key; the listener must still LOAD the entity
+        // by its primary key (findById), but start the process with the flagged field as the BPM
+        // business key - so it is correlatable by the domain identifier, not the surrogate id.
+        String yaml = """
+                name: orders
+                entities:
+                  - name: SalesOrder
+                    fields:
+                      - { name: id,          type: integer, primaryKey: true, generated: true }
+                      - { name: orderNumber, type: string }
+                processes:
+                  - name: Approve
+                    trigger: { onCreate: SalesOrder, businessKey: orderNumber }
+                    steps:
+                      - { name: review, kind: serviceTask }
+                      - { name: done,   kind: end }
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "orders.glue");
+
+        String trigger = contentOf("gen/events/ApproveTrigger.java");
+        assertTrue(trigger.contains("repository.findById(created.Id)"), "the listener must still load the entity by its primary key");
+        assertTrue(trigger.contains("String businessKey = String.valueOf(entity.OrderNumber);"),
+                "the BPM business key must be the flagged field (OrderNumber), not the primary key");
+        assertTrue(trigger.contains("Process.start(\"Approve\", businessKey, message)"),
+                "the started process should receive the resolved business key");
+    }
+
+    @Test
+    void process_trigger_business_key_strategy_timestamp_mints_and_persists_the_field() {
+        // businessKeyStrategy: timestamp -> the listener mints a yyyyMMddHHmmss value into the (blank)
+        // number field, persists it via the existing update, and uses it as the business key.
+        String yaml = """
+                name: orders
+                entities:
+                  - name: SalesOrder
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                processes:
+                  - name: Approve
+                    trigger: { onCreate: SalesOrder, businessKey: number, businessKeyStrategy: timestamp }
+                    steps:
+                      - { name: review, kind: serviceTask }
+                      - { name: done,   kind: end }
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "orders.glue");
+
+        String trigger = contentOf("gen/events/ApproveTrigger.java");
+        assertTrue(trigger.contains("repository.findById(created.Id)"), "the listener must still load the entity by its primary key");
+        assertTrue(
+                trigger.contains("if (entity.Number == null || entity.Number.isBlank())")
+                        && trigger.contains("DateTimeFormatter.ofPattern(\"yyyyMMddHHmmss\")"),
+                "a timestamp strategy should mint a yyyyMMddHHmmss value into the flagged field when blank");
+        assertTrue(trigger.contains("String businessKey = String.valueOf(entity.Number);"),
+                "the business key must be the minted number field");
+        assertTrue(trigger.contains("repository.update(entity)"), "the minted number must be persisted via the existing update");
     }
 
     @Test


### PR DESCRIPTION
## What
A process-trigger listener already starts its process with a BPM **business key**, but it was hardcoded to the trigger entity's **primary key**. This adds an optional `businessKey` on the trigger naming which field becomes the started instance's business key — so the process is correlatable by a domain identifier instead of the surrogate id:

```yaml
trigger: { onCreate: Loan, businessKey: number }
```

`keyProperty` stays the PK (the listener still loads the entity via `findById`); only the business key may differ (a separate `businessKeyProperty`).

### Simple value generation (for now)
Also adds an explicit, minimal `businessKeyStrategy: timestamp` that mints a `yyyyMMddHHmmss` value into the (blank) `businessKey` field in the listener and persists it via the listener's existing `update`:

```yaml
trigger: { onCreate: Loan, businessKey: number, businessKeyStrategy: timestamp }
```

This is intentionally simple. It's the **extension point** for richer, pluggable number generators later (sequential, zero-padded, config-prefixed invoice numbers as external functions) — a new strategy value plugs in here without reworking the trigger wiring.

## Validation
- `businessKey` must be a field of the trigger entity.
- `businessKeyStrategy` must be supported (`timestamp`), needs a `businessKey` to populate, and that field must be `string`/`text` to hold the generated value.

## Test
`IntentEngineIT` covers: the flagged field becoming the business key (PK still used for `findById`), the `timestamp` strategy minting + persisting the field, and the parse rejection for a non-field `businessKey`. All green locally (`Tests run: 3, Failures: 0`).

> Note: the assistant guide (`intent-assistant-guide.md`, PR #6062) should gain a one-line mention of `businessKey`/`businessKeyStrategy` once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)