### PR TITLE
Unify BPMN task ids and emit human-readable task/process names

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
@@ -92,4 +92,44 @@ public final class IntentNaming {
         }
         return out.toString();
     }
+
+    /**
+     * Lower-case the first letter to make a lowerCamelCase name, preserving the rest - the mirror of
+     * {@link #pascalCase(String)} ({@code ResolveBookPrice} -> {@code resolveBookPrice}). Used to
+     * normalise generated identifiers (e.g. a PascalCase handler) to the lower-camel form authored step
+     * names already use, so BPMN element ids are uniform.
+     *
+     * @param name the identifier to convert (may be null)
+     * @return the lowerCamelCase form, empty for null/empty input
+     */
+    public static String camelCase(String name) {
+        if (name == null || name.isEmpty()) {
+            return "";
+        }
+        return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+    }
+
+    /**
+     * Turn a camel-/Pascal-case identifier into a human-readable Title Case label by splitting on case
+     * boundaries ({@code librarianReview} -> {@code Librarian Review}, {@code LoanApproval} ->
+     * {@code Loan Approval}). Used for BPMN display names (process and task {@code name}) while the
+     * machine ids stay the compact identifier.
+     *
+     * @param name the identifier to humanize (may be null)
+     * @return the spaced Title Case label, empty for null/empty input
+     */
+    public static String humanize(String name) {
+        if (name == null || name.isEmpty()) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder(name.length() + 8);
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (i > 0 && Character.isUpperCase(c) && !Character.isUpperCase(name.charAt(i - 1))) {
+                out.append(' ');
+            }
+            out.append(i == 0 ? Character.toUpperCase(c) : c);
+        }
+        return out.toString();
+    }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/bpmn/BpmnIntentGenerator.java
@@ -230,7 +230,7 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         sb.append("  <process id=\"")
           .append(escapeXmlAttribute(processId))
           .append("\" name=\"")
-          .append(escapeXmlAttribute(processId))
+          .append(escapeXmlAttribute(IntentNaming.humanize(processId)))
           .append("\" isExecutable=\"true\">\n");
         sb.append("    <startEvent id=\"")
           .append(START_ID)
@@ -273,7 +273,9 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
                 }
             }
             for (Resolver resolver : stepResolvers) {
-                result.add(javaServiceTaskStep(resolver.handler(), "gen.events." + resolver.handler()));
+                // The task id is the lower-camel form of the handler so it matches the casing of the
+                // authored step ids; the delegate still resolves the PascalCase handler class.
+                result.add(javaServiceTaskStep(IntentNaming.camelCase(resolver.handler()), "gen.events." + resolver.handler()));
             }
             result.add(rewriteDecision(step, stepResolvers, ownFieldPascalCase));
         }
@@ -401,7 +403,7 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         sb.append("    <userTask id=\"")
           .append(escapeXmlAttribute(step.getName()))
           .append("\" name=\"")
-          .append(escapeXmlAttribute(step.getName()))
+          .append(escapeXmlAttribute(IntentNaming.humanize(step.getName())))
           .append("\"");
         if (assignee != null && !assignee.isBlank()) {
             String candidateGroups = resolveCandidateGroup(assignee, rolesByLowerName);
@@ -444,7 +446,7 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         sb.append("    <serviceTask id=\"")
           .append(escapeXmlAttribute(step.getName()))
           .append("\" name=\"")
-          .append(escapeXmlAttribute(step.getName()))
+          .append(escapeXmlAttribute(IntentNaming.humanize(step.getName())))
           .append("\" flowable:async=\"true\" flowable:delegateExpression=\"")
           .append(java ? "${JavaTask}" : "${JSTask}")
           .append("\">\n");
@@ -480,7 +482,7 @@ public class BpmnIntentGenerator implements IntentTargetGenerator {
         sb.append("    <exclusiveGateway id=\"")
           .append(escapeXmlAttribute(step.getName()))
           .append("\" name=\"")
-          .append(escapeXmlAttribute(step.getName()))
+          .append(escapeXmlAttribute(IntentNaming.humanize(step.getName())))
           .append("\" default=\"")
           .append(escapeXmlAttribute("flow_" + step.getName() + "_default"))
           .append("\"></exclusiveGateway>\n");

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -784,7 +784,11 @@ class IntentEngineIT extends IntegrationTest {
 
     private void assertBpmn() {
         String body = contentOf("OrderApproval.bpmn");
-        assertTrue(body.contains("<userTask id=\"managerReview\""), "BPMN should map managerReview to a userTask");
+        // The process keeps its compact id but gets a human-readable name; tasks likewise.
+        assertTrue(body.contains("<process id=\"OrderApproval\" name=\"Order Approval\""),
+                "the process should keep its id but carry a humanized name");
+        assertTrue(body.contains("<userTask id=\"managerReview\" name=\"Manager Review\""),
+                "BPMN should map managerReview to a userTask with a humanized name");
         // The assignee "manager" resolves to the declared role "Manager" (case-insensitive); the
         // settings' candidateGroupsExtra (ADMINISTRATOR by default) is appended so an admin can claim.
         assertTrue(body.contains("flowable:candidateGroups=\"Manager,ADMINISTRATOR\""),
@@ -794,9 +798,12 @@ class IntentEngineIT extends IntegrationTest {
         // (a bare name resolves relative to the inbox and 404s).
         assertTrue(body.contains("flowable:formKey=\"/services/web/intent-test/gen/ApproveOrder/forms/ApproveOrder/index.html\""),
                 "the userTask formKey must be the generated form page URL");
-        assertTrue(body.contains("<exclusiveGateway id=\"bigOrder\""), "BPMN should map the decision step to an exclusiveGateway");
+        assertTrue(body.contains("<exclusiveGateway id=\"bigOrder\" name=\"Big Order\""),
+                "BPMN should map the decision step to an exclusiveGateway with a humanized name");
         // A service task with no `call` binds to a generated Java handler under custom/.
-        assertTrue(body.contains("<serviceTask id=\"notifyCustomer\"") && body.contains("<![CDATA[custom.NotifyCustomer]]>"),
+        assertTrue(
+                body.contains("<serviceTask id=\"notifyCustomer\" name=\"Notify Customer\"")
+                        && body.contains("<![CDATA[custom.NotifyCustomer]]>"),
                 "a no-call service task should bind to ${JavaTask} -> custom.<Step>");
         assertTrue(body.contains("id=\"flow_bigOrder_then\" sourceRef=\"bigOrder\" targetRef=\"cfoReview\""),
                 "the conditioned flow should target the `then` step");
@@ -804,14 +811,17 @@ class IntentEngineIT extends IntegrationTest {
                 "the gateway default flow should target the `else` step so small orders skip CFO review");
         // The decision references customer.creditLimit, so a JavaTask resolver is inserted before the
         // gateway and the condition is rewritten to test the resolved variable.
+        // The resolver task id is the lower-camel form of the handler (unified with the authored step
+        // ids), with a humanized name; the delegate still resolves the PascalCase handler class.
         assertTrue(
-                body.contains("<serviceTask id=\"ResolveCustomerCreditLimit\"")
+                body.contains("<serviceTask id=\"resolveCustomerCreditLimit\" name=\"Resolve Customer Credit Limit\"")
                         && body.contains("flowable:delegateExpression=\"${JavaTask}\""),
-                "a JavaTask resolver service task should precede the decision");
-        assertTrue(body.contains("gen.events.ResolveCustomerCreditLimit"), "the resolver task should point at the generated handler FQN");
+                "a JavaTask resolver service task should precede the decision with a unified id and humanized name");
+        assertTrue(body.contains("gen.events.ResolveCustomerCreditLimit"),
+                "the resolver task should point at the generated PascalCase handler FQN");
         assertTrue(
-                body.contains("sourceRef=\"managerReview\" targetRef=\"ResolveCustomerCreditLimit\"")
-                        && body.contains("sourceRef=\"ResolveCustomerCreditLimit\" targetRef=\"bigOrder\""),
+                body.contains("sourceRef=\"managerReview\" targetRef=\"resolveCustomerCreditLimit\"")
+                        && body.contains("sourceRef=\"resolveCustomerCreditLimit\" targetRef=\"bigOrder\""),
                 "the resolver should sit on the linear flow right before the decision");
         assertTrue(body.contains("${customer_creditLimit > 10000}"),
                 "the decision condition should be rewritten to test the resolved variable");

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentEditorLoadsIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentEditorLoadsIT.java
@@ -113,7 +113,8 @@ public class IntentEditorLoadsIT extends UserInterfaceIntegrationTest {
         browser.assertElementExistByAttributePatternAndText(HtmlElementType.SPAN, HtmlAttribute.CLASS, "fd-icon-tab-bar__tag",
                 "LoanApproval.bpmn");
         browser.findElementInAllFrames(By.id("canvasSection"), Condition.visible);
-        Selenide.$(By.xpath("//*[contains(text(), 'librarianReview')]"))
+        // The canvas renders the task's human-readable name (the userTask `name`), not its id.
+        Selenide.$(By.xpath("//*[contains(text(), 'Librarian Review')]"))
                 .shouldBe(Condition.visible);
     }
 }


### PR DESCRIPTION
## Problem
Generated BPMN had two naming issues:
1. **Inconsistent task ids** — authored steps are lower camelCase (`librarianReview`, `notifyMember`), but the injected decision-**resolver** task used the PascalCase handler name (`ResolveBookPrice`).
2. **Machine-looking names** — every element's `name` was just its id, so the canvas read `librarianReview` instead of `Librarian Review`, and the process showed `LoanApproval`.

## Change
- **Unified task ids (lower camelCase):** the resolver task id is now the lower-camel form of its handler (`resolveBookPrice`), while the delegate still resolves the PascalCase class `gen.events.ResolveBookPrice`.
- **Human-readable task/gateway names:** `name` is humanized from the id — `librarianReview → "Librarian Review"`, `notifyMember → "Notify Member"`, decision `rareBook → "Rare Book"`, `resolveBookPrice → "Resolve Book Price"`.
- **Process Definition Name** humanized (`LoanApproval → "Loan Approval"`); the process **id** is unchanged.

Adds `IntentNaming.camelCase` + `IntentNaming.humanize`.

## Test
- `IntentEngineIT.assertBpmn`: process `id="OrderApproval" name="Order Approval"`, `<userTask id="managerReview" name="Manager Review">`, gateway/`serviceTask` humanized, and the resolver `id="resolveCustomerCreditLimit" name="Resolve Customer Credit Limit"` with the delegate FQN still `gen.events.ResolveCustomerCreditLimit`. Green.
- `IntentEditorLoadsIT`: the BPMN canvas renders `Librarian Review` (the humanized task name). Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)