### PR TITLE
Use non-modal notifications in generated task forms

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
@@ -145,21 +145,22 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                 """
                         const __taskParams = new URLSearchParams(window.location.search);
                         const __taskId = __taskParams.get('taskId');
+                        const __notifications = new NotificationHub();
 
                         function __completeTask(action) {
                             if (!__taskId) {
-                                Dialogs.showAlert({ title: 'Cannot submit', message: 'This form was not opened from a task (no taskId).', type: AlertTypes.Error });
+                                __notifications.show({ type: 'negative', title: 'Cannot submit', description: 'This form was not opened from a task (no taskId).' });
                                 return;
                             }
                             $http.post('/services/bpm/bpm-processes/tasks/' + __taskId, {
                                 action: 'COMPLETE',
                                 data: Object.assign({ action: action }, $scope.model || {})
                             }).then(() => {
-                                Dialogs.showAlert({ title: 'Task submitted', message: 'The task was completed (' + action + ').', type: AlertTypes.Success });
+                                __notifications.show({ type: 'positive', title: 'Task submitted', description: 'The task was completed (' + action + ').' });
                                 window.close();
                             }).catch((error) => {
                                 const message = error && error.data && error.data.message ? error.data.message : 'Unknown error';
-                                Dialogs.showAlert({ title: 'Submit failed', message: message, type: AlertTypes.Error });
+                                __notifications.show({ type: 'negative', title: 'Submit failed', description: message });
                             });
                         }
 


### PR DESCRIPTION
## What

Generated BPM task forms (from `FormIntentGenerator`) reported submit results with a modal `Dialogs.showAlert` on completion. This switches all three feedback paths to non-modal `NotificationHub` notifications:

- success ("Task submitted") -> `positive`
- no `taskId` ("Cannot submit") -> `negative`
- submit error ("Submit failed") -> `negative`

This matches the non-modal notification style used by the redesigned Process Inbox (#6064) and the sibling BPM tasks view.

## Notes

- `NotificationHub` is available in the generated form under the `ng-view` `platform-links` category (same as `view-preview`), so `new NotificationHub()` resolves without extra script includes.
- No behavioral change to task completion itself - still posts `COMPLETE` to `/services/bpm/bpm-processes/tasks/{id}` with the action + form model.
- `IntentEngineIT.assertForm()` assertions are unaffected (`__completeTask(`, the BPM task API call, `COMPLETE`, `onApproveClicked`, no TODO stubs all still hold).

## Context

This is a follow-up that was intended to ride along with #6064 but missed its squash merge; re-applied on top of current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)