### PR TITLE
test: drive the redesigned Process Inbox in the BPM ITs

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMLeaveRequestTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BPMLeaveRequestTestProject.java
@@ -141,12 +141,11 @@ abstract class BPMLeaveRequestTestProject extends BaseTestProject {
         managerIDE.openInbox();
 
         Browser browser = managerIDE.getBrowser();
-        browser.clickOnElementContainingText(HtmlElementType.TR, "Process request");
+        // The redesigned inbox is an Outlook-style master-detail list: tasks are bk-list links (not
+        // table rows), and claiming embeds the task's form in the detail pane (no "Open Form" tab).
+        browser.clickOnElementContainingText(HtmlElementType.ANCHOR, "Process request");
 
         browser.clickOnElementContainingText(HtmlElementType.BUTTON, "Claim");
-
-        browser.clickOnElementContainingText(HtmlElementType.BUTTON, "Open Form");
-        browser.switchToLatestTab();
     }
 
     private void assertLeaveRequestEmail() throws MessagingException {

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BpmnMultitenancyTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/BpmnMultitenancyTestProject.java
@@ -109,12 +109,11 @@ class BpmnMultitenancyTestProject extends BaseMultitenantTestProject {
         ide.openInbox();
 
         Browser browser = ide.getBrowser();
-        browser.clickOnElementContainingText(HtmlElementType.TR, "Process request");
+        // The redesigned inbox is an Outlook-style master-detail list: tasks are bk-list links (not
+        // table rows), and claiming embeds the task's form in the detail pane (no "Open Form" tab).
+        browser.clickOnElementContainingText(HtmlElementType.ANCHOR, "Process request");
 
         browser.clickOnElementContainingText(HtmlElementType.BUTTON, "Claim");
-
-        browser.clickOnElementContainingText(HtmlElementType.BUTTON, "Open Form");
-        browser.switchToLatestTab();
 
         browser.clickOnElementContainingText(HtmlElementType.BUTTON, "Approve");
 


### PR DESCRIPTION
## Problem
Master's integration-tests are red: `ApproveLeaveRequestBpmIT`, `DeclineLeaveRequestBpmIT`, `BpmnMultitenancyIT` all fail with `[By.tagName: tr] … "Process request" … cannot be found in any iframe`.

The Outlook-style Process Inbox redesign (#6064, + #6066 non-modal notifications, #6068 splitter) changed the inbox UI but the BPM test projects weren't updated to match:
- the task **table** became a `bk-list` — tasks are now `<a>` `bk-list-link`s, not `<tr>` rows;
- claiming a task **embeds its form in the detail pane** — there's no "Open Form" button / new tab.

## Fix
In `BPMLeaveRequestTestProject` and `BpmnMultitenancyTestProject`:
- select the task via `HtmlElementType.ANCHOR, "Process request"` (the list link);
- drop the `"Open Form"` click + `switchToLatestTab()`; the Approve/Decline click + `assertAlertWithMessage` now run against the embedded form iframe.

The fixture `process-leave-request.form` still uses a native `alert(...)` (untouched), which fires browser-level from the embedded iframe — so `assertAlertWithMessage` still holds. (#6066's non-modal change is to *intent-generated* forms, not this fixture.)

## Test
`ApproveLeaveRequestBpmIT` + `BpmnMultitenancyIT` green locally; `DeclineLeaveRequestBpmIT` shares the Approve project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)