### PR TITLE
fix(java-lsp): track rolling JDT-LS snapshot to stop 404 build failures

### DIFF
--- a/components/ide/ide-java-lsp/pom.xml
+++ b/components/ide/ide-java-lsp/pom.xml
@@ -54,7 +54,6 @@
                             <url>${jdtls.download.url}</url>
                             <outputDirectory>${project.build.directory}/jdtls-download</outputDirectory>
                             <outputFileName>jdtls.tar.gz</outputFileName>
-                            <sha256>${jdtls.sha256}</sha256>
                             <cacheDirectory>${settings.localRepository}/jdtls-cache</cacheDirectory>
                             <readTimeOut>300000</readTimeOut>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,11 @@
         <maven-git-commit-id-plugin.version>4.9.10</maven-git-commit-id-plugin.version>
         <maven-download-plugin.version>1.13.0</maven-download-plugin.version>
 
-        <!-- JDT Language Server bundled at build time -->
-        <jdtls.version>1.47.0</jdtls.version>
-        <jdtls.build.timestamp>202505151856</jdtls.build.timestamp>
-        <jdtls.download.url>https://download.eclipse.org/jdtls/milestones/${jdtls.version}/jdt-language-server-${jdtls.version}-${jdtls.build.timestamp}.tar.gz</jdtls.download.url>
-        <jdtls.sha256>354242694936016cd48635967cb28cd4b0735779dafe963077139d2823ccda3a</jdtls.sha256>
+        <!-- JDT Language Server bundled at build time.
+             Pinned milestone tarballs on download.eclipse.org get pruned (causes 404 build failures),
+             so we track the rolling 'latest' snapshot, which is never removed. The contents change over
+             time, so the download is intentionally not sha256-pinned. -->
+        <jdtls.download.url>https://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz</jdtls.download.url>
         <jdtls.download.skip>false</jdtls.download.skip>
         <!-- com.microsoft.java.debug plugin bundled alongside JDT.LS (EPL-1.0, on Maven Central) -->
         <java.debug.plugin.version>0.53.1</java.debug.plugin.version>


### PR DESCRIPTION
## Problem

The build fails at the `download-jdtls` goal of `dirigible-components-ide-java-lsp`:

```
[ERROR] download-maven-plugin:1.13.0:wget (download-jdtls) ... Download failed with code 404: Not Found
```

The pinned milestone tarball `jdt-language-server-1.47.0-202505151856.tar.gz` was pruned from `download.eclipse.org`. Both `milestones/` and `snapshots/` dated builds are pruned over time, so any pinned URL there eventually 404s.

(Failing run: https://github.com/eclipse-dirigible/dirigible/actions/runs/28200122114/job/83597824499)

## Fix

- Point `jdtls.download.url` at the rolling `jdt-language-server-latest.tar.gz` snapshot, which is never pruned.
- Drop the `sha256` pin (removed the `<sha256>` element + the now-unused `jdtls.version`, `jdtls.build.timestamp`, `jdtls.sha256` properties) since the snapshot contents change.

The snapshot is still the **full product** tarball (Equinox launcher + `plugins/` + `config_<platform>/config.ini`) that `JdtLsManager` extracts and runs at runtime — verified locally.

## Trade-offs

- Builds are no longer reproducible (JDT-LS version drifts as snapshots roll).
- No checksum verification on the download.
- `download-maven-plugin` caches by URL in `jdtls-cache`; the URL is now constant, so a local cache won't refresh until cleared. CI uses a fresh cache per run, so it always pulls the current latest.

## Verification

`mvn -pl components/ide/ide-java-lsp generate-resources` now succeeds; the downloaded tarball contains `plugins/org.eclipse.equinox.launcher_*.jar` and `config_{linux,mac,win}/config.ini`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)