### PR TITLE
Harmonia: full-width inline FK lookup + embedded-dialog chrome & cancel-to-close (follow-up to #6092)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -43,9 +43,12 @@
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.aggregate != "true")
 #set($readonly = ($property.isCalculatedProperty == "true" || $property.isReadOnlyProperty == "true" || ($property.auditType && $property.auditType != "NONE")))
+## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
+#set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))
 #if($property.widgetLabel)#set($label = $property.widgetLabel)#else#set($label = $property.name)#end
 #if($property.widgetSize)#set($span = $property.widgetSize)#else#set($span = "6")#end
 #if($property.widgetType == "TEXTAREA" || $property.widgetType == "CHECKBOX")#set($span = "12")#end
+#if($lookup)#set($span = "12")#end
       <div x-h-field#if($span == "12") class="col-span-full"#else style="grid-column: span ${span};"#end :data-invalid="!!errors.${property.name}">
 #if($property.widgetType == "CHECKBOX")
         <div class="hbox items-center gap-3">
@@ -55,6 +58,23 @@
 #else
         <label x-h-label for="f_${property.name}">${label}#if($property.isRequiredProperty == "true") <span class="text-negative">*</span>#end</label>
 #if($property.widgetType == "DROPDOWN")
+#if($lookup)
+        <!-- Non-setting association: combobox + Add new (opens the target's own create page in an iframe
+             dialog) + Refresh, all on one full-width row. -->
+        <div class="hbox gap-1 items-center">
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" placeholder="Select ${label}..." />
+            <div x-h-select-content>
+              <div x-h-select-search></div>
+              <template x-for="opt in options${property.name}" :key="opt.value">
+                <div x-h-select-option="opt.text" :data-value="String(opt.value)"></div>
+              </template>
+            </div>
+          </div>
+          <button type="button" x-h-button data-variant="outline" class="shrink-0" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> New ${property.relationshipEntityName}</button>
+          <button type="button" x-h-button data-variant="transparent" class="shrink-0" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
+        </div>
+#else
         <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#end>
           <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" placeholder="Select ${label}..." />
           <div x-h-select-content>
@@ -63,12 +83,6 @@
               <div x-h-select-option="opt.text" :data-value="String(opt.value)"></div>
             </template>
           </div>
-        </div>
-#if(!$readonly && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")
-        <!-- Non-setting association: Add new (opens the target's create page in a dialog) + Refresh. -->
-        <div class="hbox gap-1 mt-1">
-          <button type="button" x-h-button data-variant="transparent" data-size="sm" aria-label="Add ${property.relationshipEntityName}" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i></button>
-          <button type="button" x-h-button data-variant="transparent" data-size="sm" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #end
 #elseif($property.widgetType == "NUMBER")
@@ -188,8 +202,8 @@
                   </div>
                   <!-- Non-setting association: Add new (opens the target's create page in a dialog) + Refresh. -->
                   <div class="hbox gap-1 mt-1" x-show="col.lookup && col.lookup.creatable && !col.readonly">
-                    <button type="button" x-h-button data-variant="transparent" data-size="sm" @click="addRelatedItem(col)"><i data-lucide="plus" class="size-4"></i></button>
-                    <button type="button" x-h-button data-variant="transparent" data-size="sm" @click="refreshItemOptions(col)"><i data-lucide="refresh-cw" class="size-4"></i></button>
+                    <button type="button" x-h-button data-variant="outline" @click="addRelatedItem(col)"><i data-lucide="plus" class="size-4"></i> <span x-text="'New ' + (col.lookup && col.lookup.entity)"></span></button>
+                    <button type="button" x-h-button data-variant="transparent" aria-label="Refresh" @click="refreshItemOptions(col)"><i data-lucide="refresh-cw" class="size-4"></i></button>
                   </div>
                 </div>
               </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -241,6 +241,12 @@ document.addEventListener('alpine:init', () => {
     },
 
     cancel() {
+      // Opened as an FK "Add" iframe dialog: ask the parent to close the dialog instead of navigating
+      // this iframe to a list.
+      if (this.isEmbedded) {
+        this.emitClose();
+        return;
+      }
       this.navigateBack('/${name}');
     },
   }));

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -5,7 +5,9 @@
 -->
 <div x-data="${name}FormPage" class="vbox size-full">
 
-  <div x-h-toolbar data-variant="transparent">
+  <!-- Hidden when this form is hosted inside an FK "Add" iframe dialog (?embedded) - the dialog's own
+       header titles it; the form-page exposes isEmbedded. -->
+  <div x-h-toolbar data-variant="transparent" x-show="!isEmbedded">
     <span x-h-toolbar-title class="shrink-0" x-text="isEdit ? 'Edit ${name}' : 'New ${name}'"></span>
   </div>
 
@@ -48,9 +50,12 @@
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement)
 #set($readonly = ($property.isCalculatedProperty == "true" || $property.isReadOnlyProperty == "true" || ($property.auditType && $property.auditType != "NONE")))
+## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
+#set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))
 #if($property.widgetLabel)#set($label = $property.widgetLabel)#else#set($label = $property.name)#end
 #if($property.widgetSize)#set($span = $property.widgetSize)#else#set($span = "6")#end
 #if($property.widgetType == "TEXTAREA" || $property.widgetType == "CHECKBOX")#set($span = "12")#end
+#if($lookup)#set($span = "12")#end
       <!-- ${property.name} (${property.widgetType}) -->
       <div x-h-field#if($span == "12") class="col-span-full"#else style="grid-column: span ${span};"#end :data-invalid="!!errors.${property.name}">
 #if($property.widgetType == "CHECKBOX")
@@ -66,7 +71,24 @@
         <!-- Combobox per the Harmonia select contract (see codbex-athena-app forms): x-model on the
              x-h-select-input holds the VALUE (the option data-value), a string; the input shows the
              matched option's label. data-filter enables type-to-search; x-h-select-search adds the
-             in-dropdown search box for longer option lists. -->
+             in-dropdown search box for longer option lists. A non-setting association ($lookup) is laid
+             out on one row with an "Add new" button (opens the target's own create page in an iframe
+             dialog) and a Refresh button. -->
+#if($lookup)
+        <div class="hbox gap-1 items-center">
+          <div x-h-select data-filter="contains" class="grow">
+            <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}" :aria-invalid="!!errors.${property.name}" placeholder="Select ${label}..." />
+            <div x-h-select-content>
+              <div x-h-select-search></div>
+              <template x-for="opt in options${property.name}" :key="opt.value">
+                <div x-h-select-option="opt.text" :data-value="String(opt.value)"></div>
+              </template>
+            </div>
+          </div>
+          <button type="button" x-h-button data-variant="outline" class="shrink-0" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> New ${property.relationshipEntityName}</button>
+          <button type="button" x-h-button data-variant="transparent" class="shrink-0" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
+        </div>
+#else
         <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#end>
           <input x-h-select-input id="f_${property.name}" x-model="form.${property.name}"
                  :aria-invalid="!!errors.${property.name}"
@@ -77,12 +99,6 @@
               <div x-h-select-option="opt.text" :data-value="String(opt.value)"></div>
             </template>
           </div>
-        </div>
-#if(!$readonly && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")
-        <!-- Non-setting association: Add new (opens the target's create page in a dialog) + Refresh. -->
-        <div class="hbox gap-1 mt-1">
-          <button type="button" x-h-button data-variant="transparent" data-size="sm" aria-label="Add ${property.relationshipEntityName}" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i></button>
-          <button type="button" x-h-button data-variant="transparent" data-size="sm" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #end
 #elseif($property.widgetType == "NUMBER")

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -148,7 +148,9 @@
       <!-- Main panel -->
       <div x-h-split-panel>
         <div class="vbox size-full">
-          <div x-h-toolbar data-variant="transparent" x-cloak>
+          <!-- Top bar (breadcrumb + notifications + theme + user) - hidden in embedded mode so an FK
+               "Add" iframe dialog shows just the form, no shell chrome. -->
+          <div x-h-toolbar data-variant="transparent" x-cloak x-show="!embedded">
             <button x-show="hiddenPanels.left && !embedded" x-h-button data-variant="transparent"
                     aria-label="Navigation" @click="openSideNav()" data-size="icon">
               <i role="img" data-lucide="menu"></i>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/js/components/pages/baseFormPage.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/js/components/pages/baseFormPage.js.template
@@ -133,5 +133,14 @@ function baseFormPage() {
         }
       } catch (e) { /* cross-origin / standalone: nothing to notify */ }
     },
+
+    // Ask the hosting dialog to close (embedded Cancel) instead of navigating this iframe to a list.
+    emitClose() {
+      try {
+        if (window.parent && window.parent !== window) {
+          window.parent.postMessage({ type: 'harmonia.dialog.cancel' }, '*');
+        }
+      } catch (e) { /* standalone: nothing to close */ }
+    },
   };
 }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/js/stores/related.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/js/stores/related.js.template
@@ -40,12 +40,15 @@ document.addEventListener('alpine:init', () => {
   });
 });
 
-// The embedded create page posts { type: 'harmonia.entity.created', id } to its parent on save.
+// The embedded create page posts a message to its parent: 'harmonia.entity.created' (with id) on
+// save, or 'harmonia.dialog.cancel' when the user cancels. Route both to the related store.
 window.addEventListener('message', (event) => {
   const data = event && event.data;
-  if (!data || data.type !== 'harmonia.entity.created') return;
+  if (!data) return;
   try {
     const store = window.Alpine && Alpine.store('related');
-    if (store && store.open) store.handleCreated(data.id);
+    if (!store || !store.open) return;
+    if (data.type === 'harmonia.entity.created') store.handleCreated(data.id);
+    else if (data.type === 'harmonia.dialog.cancel') store.close();
   } catch (e) { /* Alpine not ready / no store */ }
 });


### PR DESCRIPTION
Follow-up polish on the FK "Add new" lookup and the embedded create dialog from #6092 (which merged just before these refinements were pushed). One commit, templates only.

- **Full-width inline FK field**: a non-setting association combobox spans the full row (`col-span-full`) with the combobox + a labeled **New ‹Entity›** (outline) + **Refresh** button on one line. Applies to the manage `form-view`, the document header, and the document item dialog (labeled, no `data-size`). Gated by a single `#set($lookup = … relationshipEntityPerspectiveName != "Settings" && !$readonly)`; setting dropdowns and read-only FKs keep the normal single-column layout.
- **Embedded dialog is chrome-free**: in `?embedded` mode (the FK "Add" iframe dialog) the shell's top bar (breadcrumb/theme/notifications/user) and the form's own top toolbar are hidden, so the dialog shows just the create form.
- **Embedded Cancel closes the dialog**: the embedded form posts `harmonia.dialog.cancel` and the `related` store closes the dialog instead of navigating the iframe to a list (`baseFormPage` gains `emitClose()`).

Verified on the served generated copies. Templates/JS/HTML only — no engine change (engine unit tests unaffected); runtime verification is via regenerating the `sample-intent-multi-model` projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)