### PR TITLE
feat(harmonia): app-shell Settings + notifications/user, perspective kind, humanized labels

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.intent.generator;
 
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Naming conventions shared by every intent generator. The physical table name in particular is
@@ -20,6 +21,19 @@ import java.util.Locale;
 public final class IntentNaming {
 
     private IntentNaming() {}
+
+    /**
+     * Identifiers whose human-readable singular form cannot be produced by case-boundary splitting -
+     * acronyms and mixed-case domain terms (keyed lower-case). {@code UoM} -> {@code Unit of Measure}.
+     */
+    private static final Map<String, String> HUMANIZE_OVERRIDES = Map.of("uom", "Unit of Measure");
+
+    /**
+     * Plural overrides for (humanized) labels whose last word must not be naively pluralized (keyed
+     * lower-case). Both the humanized singular and the raw identifier map to the same plural.
+     */
+    private static final Map<String, String> PLURALIZE_OVERRIDES =
+            Map.of("unit of measure", "Units of Measure", "uom", "Units of Measure");
 
     /**
      * The intent's base name used for single-file outputs ({@code <base>.edm}, {@code <base>.roles})
@@ -141,6 +155,10 @@ public final class IntentNaming {
         if (name == null || name.isEmpty()) {
             return "";
         }
+        String override = HUMANIZE_OVERRIDES.get(name.toLowerCase(Locale.ROOT));
+        if (override != null) {
+            return override;
+        }
         StringBuilder out = new StringBuilder(name.length() + 8);
         for (int i = 0; i < name.length(); i++) {
             char c = name.charAt(i);
@@ -164,6 +182,10 @@ public final class IntentNaming {
     public static String pluralize(String label) {
         if (label == null || label.isEmpty()) {
             return "";
+        }
+        String override = PLURALIZE_OVERRIDES.get(label.toLowerCase(Locale.ROOT));
+        if (override != null) {
+            return override;
         }
         int sp = label.lastIndexOf(' ');
         String head = sp >= 0 ? label.substring(0, sp + 1) : "";

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -421,6 +421,8 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         // Navigation label: humanized + pluralized so the menu reads naturally
         // (SalesInvoice -> "Sales Invoices", Book -> "Books").
         entity.put("menuLabel", IntentNaming.pluralize(IntentNaming.humanize(name)));
+        // Singular humanized label for in-page UI text (titles, "New X", "Delete X", "X #id").
+        entity.put("entityLabel", IntentNaming.humanize(name));
         entity.put("menuIndex", "100");
         entity.put("layoutType", dependent ? "MANAGE_DETAILS" : "MANAGE_MASTER");
         entity.put("perspectiveName", perspective);

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -47,7 +47,8 @@
       <div x-h-sheet data-align="left" x-ref="overlay"></div>
     </div>
 
-    <div x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+    <!-- x-cloak hides the shell until Alpine + Harmonia upgrade the markup (no raw-chrome flash). -->
+    <div x-cloak x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
 
       <!-- Sidebar -->
       <div x-h-split-panel :data-hidden="hiddenPanels.left" data-max="280" data-min="220"

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -110,9 +110,14 @@
             </template>
           </div>
 
-          <!-- Reports (native Harmonia, reused) pinned to the footer. -->
+          <!-- Settings + Reports pinned to the footer. Settings aggregates every app's SETTING entities. -->
           <div x-h-sidebar-footer>
             <ul x-h-sidebar-menu>
+              <li x-h-sidebar-menu-item x-show="settingsItems.length > 0">
+                <button x-h-sidebar-menu-button :data-active="settingsMode" @click="openSettings()">
+                  <i role="img" data-lucide="settings"></i><span>Settings</span>
+                </button>
+              </li>
               <li x-h-sidebar-menu-item>
                 <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/reports')" @click="navigate('/reports')">
                   <i role="img" data-lucide="bar-chart-3"></i><span>Reports</span>
@@ -138,20 +143,132 @@
               <i x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></i>
               <i x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></i>
             </button>
+
+            <!-- Notifications: the bell shows the unread count; the popover lists them. -->
+            <button x-h-button x-h-popover-trigger data-variant="transparent" data-size="icon-sm" aria-label="Notifications" class="relative">
+              <i role="img" data-lucide="bell"></i>
+              <span x-show="$store.notifications.unreadCount > 0" class="absolute" x-text="$store.notifications.unreadCount"
+                    style="right:-2px; bottom:-2px; min-width:15px; height:15px; padding:0 3px; border-radius:9999px; background:#e01b24; color:#fff; font-size:9px; line-height:15px; text-align:center; font-weight:700;"></span>
+            </button>
+            <div class="w-80" x-h-popover data-innerclicks="true">
+              <div x-h-toolbar data-size="sm">
+                <span x-h-toolbar-title class="shrink-0" x-text="'Notifications (' + $store.notifications.unreadCount + ')'"></span>
+                <div x-h-toolbar-spacer></div>
+                <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.notifications.markAllRead()"
+                        title="Mark all as read" aria-label="Mark all as read"><i role="img" data-lucide="check-check"></i></button>
+              </div>
+              <div x-show="$store.notifications.items.length === 0" x-h-text.muted class="p-3 text-sm">You're all caught up.</div>
+              <ol x-show="$store.notifications.items.length" x-h-notification-list>
+                <template x-for="n in $store.notifications.items" :key="n.id">
+                  <li x-h-notification class="hbox" :data-unread="n.unread ? 'true' : 'false'"
+                      :class="n.task ? 'cursor-pointer' : ''" @click="openNotification(n)">
+                    <div x-h-notification-media><svg x-h-icon.circle-info class="size-5" role="img" aria-label="info"></svg></div>
+                    <div class="vbox flex-1">
+                      <h1 x-h-notification-title x-text="n.title"></h1>
+                      <p x-h-notification-description x-text="n.description"></p>
+                    </div>
+                  </li>
+                </template>
+              </ol>
+            </div>
+
+            <!-- Logged-in user: avatar; the dropdown shows the user name and Log out. -->
+            <button x-h-button x-h-menu-trigger.dropdown data-variant="transparent" data-size="icon-sm"
+                    :aria-label="$store.currentUser.name || 'Account'">
+              <i role="img" data-lucide="circle-user"></i>
+            </button>
+            <ul x-h-menu aria-label="User menu" data-align="bottom-end">
+              <div x-h-tile class="mb-1">
+                <div x-h-tile-media><i role="img" data-lucide="circle-user" class="size-6"></i></div>
+                <div x-h-tile-content>
+                  <div x-h-tile-title x-text="$store.currentUser.name || 'User'"></div>
+                </div>
+              </div>
+              <div x-h-menu-separator></div>
+              <li x-h-menu-item data-variant="negative" @click="$store.currentUser.logout()">
+                <i role="img" data-lucide="log-out"></i> Log out
+              </li>
+            </ul>
           </div>
 
           <!-- Built-in pages render here (Pinecone); a hosted domain app shows in the iframe instead. -->
-          <div id="app" x-show="!hostedUrl" class="size-full overflow-auto flex-1">
+          <div id="app" x-show="!hostedUrl && !settingsMode" class="size-full overflow-auto flex-1">
             <!-- Pinecone Router renders the matched built-in view fragment here. -->
           </div>
-          <div x-show="hostedUrl" class="flex-1 size-full" style="position: relative;">
+          <div x-show="hostedUrl && !settingsMode" class="flex-1 size-full" style="position: relative;">
             <iframe :src="hostedUrl" title="Application" @load="onIframeLoad($event)"
                     style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
+          </div>
+
+          <!-- Settings: master-detail. Left lists every app's SETTING entities; selecting one hosts that
+               app at the entity's route in the detail iframe (cross-app, so it is hosted, not inlined). -->
+          <div x-show="settingsMode" class="flex-1 size-full">
+            <div x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+              <div x-h-split-panel data-size="22%" data-min="200">
+                <div class="vbox gap-2 p-3">
+                  <span x-h-text.muted class="text-sm">Configuration &amp; nomenclature across all applications.</span>
+                  <template x-for="item in settingsItems" :key="item.id">
+                    <button x-h-button data-variant="outline" class="justify-start"
+                            :data-state="isSettingActive(item) ? 'selected' : ''" @click="selectSetting(item)">
+                      <i role="img" data-lucide="settings"></i>
+                      <span x-text="item.label"></span>
+                    </button>
+                  </template>
+                </div>
+              </div>
+              <div x-h-split-panel data-size="78%" style="position: relative;">
+                <div x-show="!settingsUrl" x-h-info-page class="p-4">
+                  <div x-h-info-page-header>
+                    <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>
+                    <div x-h-info-page-title>Select a setting</div>
+                    <div x-h-info-page-description>Choose a configuration entity on the left to manage it here.</div>
+                  </div>
+                </div>
+                <iframe x-show="settingsUrl" :src="settingsUrl" title="Settings"
+                        style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
+              </div>
+            </div>
           </div>
         </div>
       </div>
 
     </div>
+
+    <!-- App-wide BPM task form dialog (driven by the processTasks store). Opened from a task
+         notification in the bell popover; the store re-fetches on close so badges update. -->
+    <div x-h-dialog-overlay :data-open="$store.processTasks.formOpen">
+      <div x-h-dialog style="width: 92vw; max-width: 1100px;">
+        <div x-h-dialog-header>
+          <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+        </div>
+        <div x-h-dialog-content>
+          <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
+                  title="Task form" style="width:100%; height:70vh; border:0;"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- App-wide transient toasts (raised through Harmonia's notifications magic with this template). -->
+    <section x-h-notification-overlay>
+      <template id="toast">
+        <li x-h-notification.floating data-variant="toast" class="hbox items-center gap-3 min-w-3xs max-w-md">
+          <div x-h-notification-media>
+            <span x-h-avatar class="rounded-full" :data-variant="variant">
+              <template x-if="variant === 'positive'"><svg x-h-icon.circle-success role="img" aria-label="success"></svg></template>
+              <template x-if="variant === 'negative'"><svg x-h-icon.circle-error role="img" aria-label="error"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon.circle-info role="img" aria-label="info"></svg></template>
+            </span>
+          </div>
+          <span x-h-notification-title class="flex-1" x-text="message"></span>
+          <div x-h-notification-actions data-orientation="vertical">
+            <button x-h-button x-h-notification-close class="rounded-full" data-variant="transparent" data-size="icon-md" aria-label="Dismiss">
+              <svg x-h-icon.close role="img" aria-label="close"></svg>
+            </button>
+          </div>
+        </li>
+      </template>
+    </section>
 
     <!-- Built-in routes. Dashboard is local (generic landing); the rest reuse the shared runtime. -->
     <template x-route="/" x-template.target.app="./views/_dashboard.html"></template>
@@ -159,6 +276,10 @@
     <template x-route="/inbox" x-template.target.app="/services/web/application-core/shell/views/_inbox.html"></template>
     <template x-route="/documents" x-template.target.app="/services/web/application-core/shell/views/_documents.html"></template>
     <template x-route="/reports" x-template.target.app="/services/web/application-core/shell/views/_reports.html"></template>
+    <!-- Settings: list (/settings) or a selected entity (/settings/<perspective-id>). No template - the
+         settings master-detail layout above renders it (driven by settingsMode). -->
+    <template x-route="/settings"></template>
+    <template x-route="/settings/:id"></template>
     <!-- Hosted domain apps: /app/<perspective-id>[/<inner-route>]. No template - the iframe renders them;
          the optional inner segment mirrors the embedded app's own hash route (deep-linkable). -->
     <template x-route="/app/:id/:inner*"></template>
@@ -177,6 +298,7 @@
     <script src="/services/web/application-core/shell/js/stores/processTasks.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/reports.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/theme.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/currentUser.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/pages/inboxPage.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/pages/documentsPage.js" defer></script>
     <script src="./js/appShell.js" defer></script>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -96,11 +96,17 @@ document.addEventListener('alpine:init', () => {
       this.closeSideNav();
     },
 
-    /** Host a domain app (a perspective) in the iframe via its /app/<id> route; applyRoute sets the iframe. */
+    /** Host a domain app (a perspective) in the iframe. Swap the iframe synchronously on click (do not
+     *  wait for the router's pinecone:end - for a template-less route it can fire before the context is
+     *  ready, leaving the pane stale), then update the URL. applyRoute then no-ops (hostedId already set). */
     openApp(item) {
       // Re-clicking the already-hosted app is a no-op: leave its inner route (and the URL) untouched.
       if (this.hostedId !== item.id) {
+        this.hostedId = item.id;
+        this.hostedUrl = this.appUrl(item, '');
+        this.currentPath = '/app/' + encodeURIComponent(item.id);
         window.PineconeRouter.navigate('/app/' + encodeURIComponent(item.id));
+        this.refreshIcons();
       }
       this.closeSideNav();
     },

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -27,6 +27,12 @@ document.addEventListener('alpine:init', () => {
     // The currently hosted domain app (a perspective). When set, the iframe is shown instead of #app.
     hostedUrl: '',
     hostedId: '',
+    // Settings: the SETTING entities from every app (the 'settings' perspective group), surfaced as a
+    // single footer entry + master-detail page (list left, the selected setting hosted in an iframe).
+    settingsItems: [],
+    settingsMode: false,
+    settingsSelected: '',
+    settingsUrl: '',
 
     async init() {
       try {
@@ -35,8 +41,31 @@ document.addEventListener('alpine:init', () => {
           const data = await res.json();
           // Domain apps live in named groups; skip the platform's 'undefined-group' and utilities
           // (those are the legacy AngularJS perspectives, which do not belong in the Harmonia shell).
-          this.groups = (Array.isArray(data.perspectives) ? data.perspectives : [])
-            .filter(g => g.id !== 'undefined-group' && Array.isArray(g.items) && g.items.length);
+          // Every app's SETTING entities are shown under the dedicated Settings footer entry, never in
+          // the sidebar - whether they were declared inside a nav group or with no group at all. A
+          // perspective is a setting when its kind is SETTING (from the generator); the legacy 'settings'
+          // group id is a fallback for apps generated before the kind tag existed.
+          const all = Array.isArray(data.perspectives) ? data.perspectives : [];
+          const settings = [];
+          const appGroups = [];
+          all.forEach(g => {
+            if (Array.isArray(g.items)) {
+              // A navigation group: pull its SETTING entities into Settings, keep the rest in the sidebar.
+              const isSetting = (it) => it.kind === 'SETTING' || g.id === 'settings';
+              settings.push(...g.items.filter(isSetting));
+              const keep = g.items.filter(it => !isSetting(it));
+              if (g.id !== 'undefined-group' && keep.length) {
+                appGroups.push(Object.assign({}, g, { items: keep }));
+              }
+            } else if (g.path && g.kind === 'SETTING') {
+              // A standalone setting perspective declared with no navigation group.
+              settings.push(g);
+            }
+          });
+          // Settings entities are listed alphabetically by label.
+          settings.sort((a, b) => (a.label || '').toLowerCase().localeCompare((b.label || '').toLowerCase()));
+          this.groups = appGroups;
+          this.settingsItems = settings;
         }
       } catch (e) {
         console.error('Failed to load application perspectives', e);
@@ -55,19 +84,32 @@ document.addEventListener('alpine:init', () => {
         let p = (h.charAt(0) === '#' ? h.slice(1) : h) || '/';
         if (p === '/') p = '/dashboard';
         this.currentPath = p;
-        const match = p.match(/^\/app\/([^/]+)(?:\/(.*))?$/);
-        if (match) {
-          const id = decodeURIComponent(match[1]);
-          const inner = match[2] ? '/' + match[2] : '';
-          // Only (re)point the iframe when the app changes - while the same app is hosted the iframe
-          // owns its inner route, so we must not reset its src (that would reload it and lose state).
-          if (this.hostedId !== id) {
-            const item = this.findItem(id);
-            if (item) { this.hostedId = id; this.hostedUrl = this.appUrl(item, inner); }
-          }
-        } else {
+        if (p === '/settings' || p.indexOf('/settings/') === 0) {
+          // Settings master-detail: /settings (list only) or /settings/<perspective-id> (one selected).
+          this.settingsMode = true;
           this.hostedId = '';
           this.hostedUrl = '';
+          const rest = p.indexOf('/settings/') === 0 ? p.slice('/settings/'.length) : '';
+          if (rest) {
+            const item = this.findSettingItem(decodeURIComponent(rest));
+            if (item) { this.settingsSelected = item.id; this.settingsUrl = item.path || ''; }
+          }
+        } else {
+          this.settingsMode = false;
+          const match = p.match(/^\/app\/([^/]+)(?:\/(.*))?$/);
+          if (match) {
+            const id = decodeURIComponent(match[1]);
+            const inner = match[2] ? '/' + match[2] : '';
+            // Only (re)point the iframe when the app changes - while the same app is hosted the iframe
+            // owns its inner route, so we must not reset its src (that would reload it and lose state).
+            if (this.hostedId !== id) {
+              const item = this.findItem(id);
+              if (item) { this.hostedId = id; this.hostedUrl = this.appUrl(item, inner); }
+            }
+          } else {
+            this.hostedId = '';
+            this.hostedUrl = '';
+          }
         }
         this.refreshIcons();
       };
@@ -92,6 +134,7 @@ document.addEventListener('alpine:init', () => {
 
     /** Navigate to a built-in page (Pinecone route into #app); applyRoute clears any hosted app. */
     navigate(route) {
+      this.settingsMode = false;
       window.PineconeRouter.navigate(route);
       this.closeSideNav();
     },
@@ -101,7 +144,8 @@ document.addEventListener('alpine:init', () => {
      *  ready, leaving the pane stale), then update the URL. applyRoute then no-ops (hostedId already set). */
     openApp(item) {
       // Re-clicking the already-hosted app is a no-op: leave its inner route (and the URL) untouched.
-      if (this.hostedId !== item.id) {
+      if (this.hostedId !== item.id || this.settingsMode) {
+        this.settingsMode = false;
         this.hostedId = item.id;
         this.hostedUrl = this.appUrl(item, '');
         this.currentPath = '/app/' + encodeURIComponent(item.id);
@@ -150,6 +194,41 @@ document.addEventListener('alpine:init', () => {
         // replaceState updates the address bar without re-triggering the shell router (no reload loop).
         history.replaceState(history.state, '', newHash);
         this.currentPath = top;
+      }
+    },
+
+    /** Open the Settings master-detail (the aggregated SETTING entities from every app). */
+    openSettings() {
+      this.settingsMode = true;
+      this.hostedId = '';
+      this.hostedUrl = '';
+      this.currentPath = '/settings';
+      window.PineconeRouter.navigate('/settings');
+      this.refreshIcons();
+      this.closeSideNav();
+    },
+
+    /** Select a setting entity: host its app at that entity's route in the settings detail iframe. */
+    selectSetting(item) {
+      if (this.settingsSelected !== item.id) {
+        this.settingsSelected = item.id;
+        this.settingsUrl = item.path || '';
+        this.currentPath = '/settings/' + encodeURIComponent(item.id);
+        window.PineconeRouter.navigate('/settings/' + encodeURIComponent(item.id));
+        this.refreshIcons();
+      }
+    },
+
+    isSettingActive(item) { return this.settingsMode && this.settingsSelected === item.id; },
+
+    /** Find a setting entity (perspective) by id. */
+    findSettingItem(id) { return (this.settingsItems || []).find(i => i.id === id) || null; },
+
+    /** Open the task behind a (task-derived) notification, and mark it read. */
+    openNotification(n) {
+      if (n && n.task) {
+        this.$store.processTasks.openTask(n.task);
+        n.unread = false;
       }
     },
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -6,10 +6,10 @@
 <div x-data="${name}ManageListPage" class="vbox size-full">
 
   <div x-h-toolbar data-variant="transparent">
-    <span x-h-toolbar-title class="shrink-0">${name}</span>
+    <span x-h-toolbar-title class="shrink-0">${menuLabel}</span>
     <div x-h-toolbar-spacer></div>
     <div x-h-input-group data-size="sm">
-      <input x-h-input.group type="text" placeholder="Search ${name}..."
+      <input x-h-input.group type="text" placeholder="Search ${menuLabel}..."
              x-model="searchTerm" @input="onSearchChange()" />
       <div x-h-input-group-addon data-align="inline-start">
         <svg x-h-icon.search class="size-4" role="img" aria-label="search"></svg>
@@ -40,11 +40,11 @@
   <div x-show="displayState === 'empty'" x-h-info-page class="p-4">
     <div x-h-info-page-header>
       <div x-h-info-page-media.icon><i role="img" data-lucide="inbox"></i></div>
-      <div x-h-info-page-title>No ${name} yet</div>
+      <div x-h-info-page-title>No ${menuLabel} yet</div>
       <div x-h-info-page-description>Get started by creating the first record.</div>
     </div>
     <div x-h-info-page-content>
-      <button x-h-button data-variant="primary" @click="newEntity()">New ${name}</button>
+      <button x-h-button data-variant="primary" @click="newEntity()">New ${entityLabel}</button>
     </div>
   </div>
 
@@ -77,7 +77,7 @@
             </thead>
             <tbody x-h-table-body>
               <tr x-show="displayState === 'no-results'" x-h-table-row>
-                <td x-h-table-cell>No matching ${name}.</td>
+                <td x-h-table-cell>No matching ${menuLabel}.</td>
               </tr>
               <template x-for="row in paginatedItems" :key="row.${primaryKeysString}">
                 <tr x-h-table-row data-hoverable="true" :data-state="isSelected(row) ? 'selected' : ''" @click="selectRow(row)" style="cursor:pointer;">
@@ -122,14 +122,14 @@
       <div x-show="!selected" x-h-info-page class="p-4">
         <div x-h-info-page-header>
           <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>
-          <div x-h-info-page-title>Select a ${name}</div>
+          <div x-h-info-page-title>Select a ${entityLabel}</div>
           <div x-h-info-page-description>Choose a row to see all its details#if($hasProcess) and pending tasks#end.</div>
         </div>
       </div>
 
       <div x-show="selected" class="vbox size-full overflow-auto">
         <div x-h-toolbar data-variant="transparent" data-size="sm">
-          <span x-h-toolbar-title class="shrink-0" x-text="'${name} #' + selectedId"></span>
+          <span x-h-toolbar-title class="shrink-0" x-text="'${entityLabel} #' + selectedId"></span>
           <div x-h-toolbar-spacer></div>
           <button x-h-button data-variant="outline" data-size="sm" @click="editEntity(selected)"><i role="img" data-lucide="pencil"></i><span>Edit</span></button>
           <button x-h-button data-variant="transparent" data-size="sm" @click="askDelete(selected)" aria-label="Delete"><i role="img" data-lucide="trash-2"></i></button>
@@ -171,7 +171,7 @@
   <div x-h-dialog-overlay :data-open="deleteOpen">
     <div x-h-dialog>
       <div x-h-dialog-header>
-        <h2 x-h-dialog-title>Delete ${name}</h2>
+        <h2 x-h-dialog-title>Delete ${entityLabel}</h2>
         <p x-h-dialog-description>This action cannot be undone.</p>
         <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
       </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/perspective.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/perspective.js.template
@@ -12,6 +12,7 @@ const perspectiveData = {
 	id: '${projectName}-${name}',
 	label: '${menuLabel}',
 	path: '/services/web/${projectName}/gen/${genFolderName}/index.html?embedded=true#/${name}',
+	kind: '${type}',
 #if($perspectiveNavId)
 	groupId: '${perspectiveNavId}',
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -44,7 +44,9 @@
       <div x-h-sheet data-align="left" x-ref="overlay"></div>
     </div>
 
-    <div x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+    <!-- x-cloak hides the shell until Alpine + Harmonia upgrade the markup, so the host iframe never
+         flashes the raw, un-styled chrome (sidebar/components) before init. -->
+    <div x-cloak x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
 
       <!-- Sidebar panel -->
       <div x-h-split-panel :data-hidden="hiddenPanels.left" data-max="256" data-min="200"


### PR DESCRIPTION
## Application shell (`resources-application`)
- **Sidebar app-switch fix**: swap the hosted iframe synchronously on click (router `pinecone:end` for a template-less route can fire before the context is ready).
- **Top bar**: notifications bell (popover) + logged-in user menu (loads the shared `currentUser` store), plus the BPM task dialog and toast overlay.
- **Settings**: a footer entry + master-detail page that aggregates every app's SETTING entities and hosts the selected one in an iframe. Settings are collected by perspective **kind** (regardless of nav group; grouped or standalone), listed **alphabetically** with a uniform icon.

## Generator (`template-application-ui-harmonia-java` + `engine-intent`)
- Tag each generated perspective with the entity **kind** (`${type}`) so the shell can route SETTING entities to Settings.
- Manage-list view uses **humanized labels** - plural `${menuLabel}` for list/empty/search, new singular `${entityLabel}` for New/Select/Delete/#id (was the raw entity name).
- `IntentNaming`: hardcode **UoM -> "Unit of Measure" / "Units of Measure"** so acronym labels read properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)