### PR TITLE
feat(harmonia): number formatting + right-aligned numerics, master select-URL, condensed detail pane

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
@@ -67,6 +67,7 @@ function detailPanel(def, masterId) {
         const t = m ? m[v] : undefined;
         if (t !== undefined && t !== null && t !== '') return t;
       }
+      if (col.float) return this.formatNumber(v, col.pattern);
       return this.displayValue(v, col.date);
     },
 

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -29,5 +29,23 @@ function basePage() {
         }
       });
     },
+
+    /**
+     * Format a floating-point value for display using a DecimalFormat-style pattern. The number of
+     * fraction digits is taken from the pattern's part after the decimal point and grouping uses the
+     * pattern's separator (a space for "### ### ### ##0.00"). Empty/non-numeric values pass through.
+     */
+    formatNumber(value, pattern) {
+      if (value === null || value === undefined || value === '') return '—';
+      const n = Number(value);
+      if (!isFinite(n)) return value;
+      const p = pattern || '### ### ### ##0.00';
+      const dot = p.lastIndexOf('.');
+      const decimals = dot >= 0 ? (p.length - dot - 1) : 0;
+      const groupSep = p.indexOf(' ') >= 0 ? ' ' : (p.indexOf(',') >= 0 ? ',' : '');
+      const parts = n.toFixed(decimals).split('.');
+      if (groupSep) parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, groupSep);
+      return parts.length > 1 ? parts[0] + '.' + parts[1] : parts[0];
+    },
   };
 }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -376,6 +376,7 @@ document.addEventListener('alpine:init', () => {
         if (opt) return opt.text;
       }
       if (col.date) return this.displayDate(v);
+      if (col.float) return this.displayNumber(v, col.pattern);
       if (col.widget === 'CHECKBOX') return v ? 'Yes' : 'No';
       return v;
     },
@@ -480,12 +481,21 @@ document.addEventListener('alpine:init', () => {
     // ----- Totals footer (aggregate fields, read-only) -------------------------------------------
     // The totals are server-managed: the DAO recomputes them synchronously on every line change and on
     // the master's own save, so the loaded record is authoritative (re-fetched after each item change).
-    totalValue(name) { return this.displayNumber(this.record[name]); },
+    totalValue(name, pattern) { return this.displayNumber(this.record[name], pattern); },
 
-    displayNumber(v) {
+    // Format a float using a DecimalFormat-style pattern (decimals from the part after '.', grouping
+    // from the pattern's separator). Defaults to grouped thousands with two decimals.
+    displayNumber(v, pattern) {
       if (v === null || v === undefined || v === '') return '—';
       const n = Number(v);
-      return isNaN(n) ? v : n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      if (isNaN(n)) return v;
+      const p = pattern || '### ### ### ##0.00';
+      const dot = p.lastIndexOf('.');
+      const decimals = dot >= 0 ? (p.length - dot - 1) : 0;
+      const groupSep = p.indexOf(' ') >= 0 ? ' ' : (p.indexOf(',') >= 0 ? ',' : '');
+      const parts = n.toFixed(decimals).split('.');
+      if (groupSep) parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, groupSep);
+      return parts.length > 1 ? parts[0] + '.' + parts[1] : parts[0];
     },
 
     backToList() { window.PineconeRouter.navigate('/${name}'); },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -122,7 +122,7 @@
       <table x-h-table data-borders="rows" class="w-full">
         <thead x-h-table-header>
           <tr x-h-table-row>
-            <template x-for="col in editColumns" :key="col.name"><th x-h-table-head scope="col" x-text="col.label"></th></template>
+            <template x-for="col in editColumns" :key="col.name"><th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="col.label"></th></template>
             <th x-h-table-head scope="col" class="text-right">Actions</th>
           </tr>
         </thead>
@@ -130,7 +130,7 @@
           <template x-for="(row, idx) in items" :key="row[itemsDef.primaryKey] != null ? row[itemsDef.primaryKey] : idx">
             <tr x-h-table-row data-hoverable="true">
               <template x-for="col in editColumns" :key="col.name">
-                <td x-h-table-cell x-text="cellDisplay(col, row)"></td>
+                <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellDisplay(col, row)"></td>
               </template>
               <td x-h-table-cell class="text-right">
                 <div class="hbox gap-1 justify-end items-center">
@@ -155,7 +155,7 @@
 #if($property.widgetLabel)#set($alabel = $property.widgetLabel)#else#set($alabel = $property.name)#end
         <div class="hbox justify-between gap-8">
           <span class="text-secondary">${alabel}</span>
-          <span class="font-semibold tabular-nums" x-text="totalValue('${property.name}')"></span>
+          <span class="font-semibold tabular-nums" x-text="totalValue('${property.name}', '${property.formatPattern}')"></span>
         </div>
 #end
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -62,7 +62,7 @@
               <tr x-h-table-row>
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.widgetIsMajor)
-                <th x-h-table-head scope="col" data-hoverable="true" data-activable="true" @click="cycleSort('${property.name}')">
+                <th x-h-table-head scope="col" data-hoverable="true" data-activable="true"#if($property.isNumberType) class="text-right"#end @click="cycleSort('${property.name}')">
                   <div class="hbox items-center justify-between">
                     ${property.name}
                     <i role="img" data-lucide="arrow-up"      class="size-4" x-show="isSortedAsc('${property.name}')"></i>
@@ -87,6 +87,10 @@
                   <td x-h-table-cell x-text="lookupText('${property.name}', row.${property.name})"></td>
 #elseif($property.isDateType)
                   <td x-h-table-cell x-text="displayValue(row.${property.name}, true)"></td>
+#elseif($property.isFloatType)
+                  <td x-h-table-cell class="text-right" x-text="formatNumber(row.${property.name}, '${property.formatPattern}')"></td>
+#elseif($property.isNumberType)
+                  <td x-h-table-cell class="text-right" x-text="displayValue(row.${property.name})"></td>
 #else
                   <td x-h-table-cell x-text="displayValue(row.${property.name})"></td>
 #end
@@ -146,8 +150,9 @@
         </div>
 #end
 
-        <!-- Every property of the selected record (the table above shows only the major ones). -->
-        <div class="vbox gap-3 p-4">
+        <!-- Every property of the selected record (the table above shows only the major ones). A
+             condensed two-column grid (matches the master-detail pane). -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 p-4">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement)
 #if($property.widgetLabel)#set($plabel = $property.widgetLabel)#else#set($plabel = $property.name)#end
@@ -156,6 +161,8 @@
             <span x-h-text.muted class="text-xs">${plabel}</span>
 #if($property.widgetType == "DROPDOWN")
             <span x-text="lookupText('${property.name}', selected?.${property.name})"></span>
+#elseif($property.isFloatType)
+            <span x-text="formatNumber(selected?.${property.name}, '${property.formatPattern}')"></span>
 #else
             <span x-text="displayValue(selected?.${property.name}, $isDate)"></span>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -150,9 +150,12 @@
         </div>
 #end
 
-        <!-- Every property of the selected record (the table above shows only the major ones). A
+        <!-- Every property of the selected record (the table above shows only the major ones). A framed
              condensed two-column grid (matches the master-detail pane). -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 p-4">
+        <div x-h-card class="m-4">
+          <div x-h-card-header><h3 x-h-card-title>Details</h3></div>
+          <div x-h-card-content>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement)
 #if($property.widgetLabel)#set($plabel = $property.widgetLabel)#else#set($plabel = $property.name)#end
@@ -169,6 +172,8 @@
           </div>
 #end
 #end
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
@@ -26,6 +26,10 @@ App.registerDetail('${masterEntity}', {
     { name: '${property.name}', lookup: { url: '${property.widgetDropdownControllerUrl}', key: '${property.widgetDropDownKey}', text: '${property.widgetDropDownValue}' } },
 #elseif($property.isDateType)
     { name: '${property.name}', date: true },
+#elseif($property.isFloatType)
+    { name: '${property.name}', number: true, float: true, pattern: '${property.formatPattern}' },
+#elseif($property.isNumberType)
+    { name: '${property.name}', number: true },
 #else
     { name: '${property.name}' },
 #end
@@ -44,7 +48,7 @@ App.registerDetail('${masterEntity}', {
 #if($property.widgetType == "DROPDOWN")
     { name: '${property.name}', label: '${elabel}', widget: 'DROPDOWN', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, lookup: { url: '${property.widgetDropdownControllerUrl}', key: '${property.widgetDropDownKey}', text: '${property.widgetDropDownValue}', entity: '${property.relationshipEntityName}', creatable: #if($property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings")true#{else}false#end } },
 #else
-    { name: '${property.name}', label: '${elabel}', widget: '${property.widgetType}', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, date: #if($property.isDateType)true#{else}false#end#calcMeta($property) },
+    { name: '${property.name}', label: '${elabel}', widget: '${property.widgetType}', required: #if($property.isRequiredProperty == "true")true#{else}false#end, readonly: #if($ereadonly)true#{else}false#end, date: #if($property.isDateType)true#{else}false#end#if($property.isNumberType), number: true#end#if($property.isFloatType), float: true, pattern: '${property.formatPattern}'#end#calcMeta($property) },
 #end
 #end
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
@@ -32,6 +32,27 @@ document.addEventListener('alpine:init', () => {
       this.detailDefs = App.detailsFor('${name}');
       await this.load();
       this.loadLookups();
+      this.selectFromRoute();
+    },
+
+    // Deep link / reload support: /${name}/:id pre-selects that record once the list is loaded.
+    selectFromRoute() {
+      const params = (window.PineconeRouter.context && window.PineconeRouter.context.params) || {};
+      const id = params.id;
+      if (id === undefined || id === null || id === '') return;
+      const match = this.masters.find(m => String(m.${primaryKeysString}) === String(id));
+      if (match) { this.selected = match; this.refreshIcons(); }
+    },
+
+    // Reflect the selected record in the URL (/${name}/:id) without re-rendering, and notify the
+    // embedding shell so the top-level address bar stays in sync (deep-link handled by selectFromRoute).
+    syncSelectionUrl(row) {
+      if (typeof window.history === 'undefined' || !window.history.replaceState) return;
+      const path = '/${name}' + (row ? '/' + encodeURIComponent(row.${primaryKeysString}) : '');
+      const url = '#' + path;
+      if (window.location.hash === url) return;
+      window.history.replaceState(window.history.state, '', url);
+      try { window.dispatchEvent(new HashChangeEvent('hashchange')); } catch (e) { /* older browsers */ }
     },
 
     async load() {
@@ -59,7 +80,7 @@ document.addEventListener('alpine:init', () => {
 
     get selectedId() { return this.selected ? this.selected.${primaryKeysString} : null; },
     isSelected(row) { return this.selected && row.${primaryKeysString} === this.selected.${primaryKeysString}; },
-    selectRow(row) { this.selected = row; this.refreshIcons(); },
+    selectRow(row) { this.selected = row; this.refreshIcons(); this.syncSelectionUrl(row); },
     // Render a property value for the details pane. Jackson serializes java.time as arrays
     // (LocalDate [y,m,d], LocalDateTime [y,m,d,h,mi,s,ns]); show those as readable date strings.
     displayValue(v, isDate) {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -31,7 +31,7 @@
             <tr x-h-table-row>
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.widgetIsMajor)
-              <th x-h-table-head scope="col">${property.name}</th>
+              <th x-h-table-head scope="col"#if($property.isNumberType) class="text-right"#end>${property.name}</th>
 #end
 #end
               <th x-h-table-head scope="col"></th>
@@ -47,6 +47,10 @@
                 <td x-h-table-cell x-text="lookupText('${property.name}', row.${property.name})"></td>
 #elseif($property.isDateType)
                 <td x-h-table-cell x-text="displayValue(row.${property.name}, true)"></td>
+#elseif($property.isFloatType)
+                <td x-h-table-cell class="text-right" x-text="formatNumber(row.${property.name}, '${property.formatPattern}')"></td>
+#elseif($property.isNumberType)
+                <td x-h-table-cell class="text-right" x-text="displayValue(row.${property.name})"></td>
 #else
                 <td x-h-table-cell x-text="displayValue(row.${property.name})"></td>
 #end
@@ -108,6 +112,8 @@
                 <span x-h-text.muted class="text-xs">${plabel}</span>
 #if($property.widgetType == "DROPDOWN")
                 <span x-text="lookupText('${property.name}', selected?.${property.name})"></span>
+#elseif($property.isFloatType)
+                <span x-text="formatNumber(selected?.${property.name}, '${property.formatPattern}')"></span>
 #else
                 <span x-text="displayValue(selected?.${property.name}, $isDate)"></span>
 #end
@@ -138,7 +144,7 @@
                   <thead x-h-table-header>
                     <tr x-h-table-row>
                       <template x-for="col in def.columns" :key="col.name">
-                        <th x-h-table-head scope="col" x-text="col.name"></th>
+                        <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="col.name"></th>
                       </template>
                       <th x-h-table-head scope="col"></th>
                     </tr>
@@ -147,7 +153,7 @@
                     <template x-for="row in rows" :key="row[def.primaryKey]">
                       <tr x-h-table-row data-hoverable="true">
                         <template x-for="col in def.columns" :key="col.name">
-                          <td x-h-table-cell x-text="cellValue(col, row)"></td>
+                          <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
                         </template>
                         <td x-h-table-cell data-row-actions>
                           <!-- This detail record's actionable user tasks (e.g. a triggered review), one button each. -->

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -324,6 +324,7 @@
     <template x-route="/${entity.name}" x-template.target.app="./views/${entity.perspectiveName}/${entity.name}-master.html"></template>
     <template x-route="/${entity.name}/create" x-template.target.app="./views/${entity.perspectiveName}/${entity.name}-form.html"></template>
     <template x-route="/${entity.name}/:id/edit" x-template.target.app="./views/${entity.perspectiveName}/${entity.name}-form.html"></template>
+    <template x-route="/${entity.name}/:id" x-template.target.app="./views/${entity.perspectiveName}/${entity.name}-master.html"></template>
 #end
 #end
     <!-- DOCUMENT entities (header-items): browse list + a full-page document editor at create/edit. -->

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
@@ -107,6 +107,17 @@ export function process(model, parameters) {
             } else if (p.dataTypeTypescript === "Date") {
                 p.isDateType = true;
                 e.hasDates = true;
+            } else if (p.dataTypeTypescript === "number") {
+                // All numeric values are right-aligned in tables. Floats are additionally formatted with
+                // the field's display pattern (the model's Pattern/widgetPattern), defaulting to grouped
+                // thousands with two decimals.
+                p.isNumberType = true;
+                const dt = (p.dataType || "").toUpperCase();
+                if (dt === "DECIMAL" || dt === "DOUBLE" || dt === "FLOAT" || dt === "REAL") {
+                    p.isFloatType = true;
+                    p.formatPattern = (p.widgetPattern && p.widgetPattern.trim()) ? p.widgetPattern : "### ### ### ##0.00";
+                    e.hasFloats = true;
+                }
             }
             p.inputRule = p.widgetPattern ? p.widgetPattern : "";
 


### PR DESCRIPTION
## Number formatting & alignment (all generated UIs)
- `parameterUtils` tags numeric properties (`isNumberType`) and floats (`isFloatType` + a display `formatPattern` from the model's Pattern/`widgetPattern`, defaulting to `### ### ### ##0.00`).
- Floats are formatted (grouped thousands, pattern-driven decimals) in list/master/document tables, detail panes, and the document **totals footer**; **all numeric columns are right-aligned** (header + cell), integers included.
- Helpers: `basePage.formatNumber`, document `displayNumber`, `detailPanel.cellValue`/document `cellDisplay`.

## Master select-URL
- Adds the `/<Entity>/:id` route for MASTER entities and makes `master-page` mirror the selected record into the URL (replaceState + shell sync) and pre-select on deep link - matching the manage/document lists (so Customer now behaves like Sales Invoices).

## Condensed detail pane
- The manage list-view detail pane now uses the condensed two-column grid, matching the master detail pane.

> Note: these are generator/template changes; existing generated apps must be regenerated to pick them up. The shared runtime helpers (`basePage`, `detailPanel`) apply immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)