### PR TITLE
feat(harmonia): Reports sidebar group (all apps) + settings splitter 25/75

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
@@ -42,9 +42,15 @@ document.addEventListener('alpine:init', () => {
 
     async load() {
       try {
+        // The application shell sets aggregateReports to collect reports from EVERY published app
+        // (walk the whole registry); a generated app walks only its own project's gen tree.
+        const aggregate = !!(App.config && App.config.aggregateReports);
         const project = (App.config && App.config.projectName) || '';
-        if (!project) { this.loaded = true; return; }
-        const r = await fetch('/services/core/repository/registry/public/' + project + '/gen', {
+        const base = aggregate
+          ? '/services/core/repository/registry/public'
+          : (project ? '/services/core/repository/registry/public/' + project + '/gen' : '');
+        if (!base) { this.loaded = true; return; }
+        const r = await fetch(base, {
           headers: { 'Accept': 'application/json' }, credentials: 'same-origin',
         });
         if (!r.ok) { this.loaded = true; return; }
@@ -54,9 +60,9 @@ document.addEventListener('alpine:init', () => {
         const seen = new Set();
         this.items = found
           .filter(x => { if (seen.has(x.url)) return false; seen.add(x.url); return true; })
-          .sort((a, b) => a.name.localeCompare(b.name));
+          .sort((a, b) => a.label.localeCompare(b.label));
         this.loaded = true;
-        this._enrich(project);
+        this._enrich();
       } catch (e) {
         console.error('reports: discovery failed', e);
         this.loaded = true;
@@ -66,11 +72,12 @@ document.addEventListener('alpine:init', () => {
     // Enrich each discovered report from its .report model file (project root): the human label, the
     // description (shown on the dashboard tile), and the dashboard exclude flag. Best-effort — a
     // missing/unreadable .report just leaves the defaults (label = humanized name, shown on dashboard).
-    async _enrich(project) {
+    async _enrich() {
       await Promise.all(this.items.map(async (it) => {
         if (it.dashboard === undefined) it.dashboard = true;
+        if (!it.project) return;
         try {
-          const r = await fetch('/services/core/repository/registry/public/' + project + '/' + it.name + '.report', {
+          const r = await fetch('/services/core/repository/registry/public/' + it.project + '/' + it.name + '.report', {
             headers: { 'Accept': 'application/json' }, credentials: 'same-origin',
           });
           if (!r.ok) return;
@@ -92,7 +99,10 @@ document.addEventListener('alpine:init', () => {
         const path = res && res.path;
         if (res && res.name === 'index.html' && path && path.indexOf('/reports/') >= 0) {
           const m = path.match(/\/reports\/([^/]+)\/index\.html$/);
-          if (m) out.push({ name: m[1], label: humanizeReportName(m[1]), url: path.replace('/registry/public/', '/services/web/') });
+          if (m) {
+          const pm = path.match(/\/registry\/public\/([^/]+)\//);
+          out.push({ name: m[1], label: humanizeReportName(m[1]), url: path.replace('/registry/public/', '/services/web/'), project: pm ? pm[1] : '' });
+        }
         }
       });
       (node.collections || []).forEach(c => this._walk(c, out));

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -215,8 +215,8 @@
 
           <!-- Settings: master-detail. Left lists every app's SETTING entities; selecting one hosts that
                app at the entity's route in the detail iframe (cross-app, so it is hosted, not inlined). -->
-          <div x-show="settingsMode" class="flex-1 size-full">
-            <div x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+          <div x-show="settingsMode" class="vbox flex-1 size-full">
+            <div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
               <div x-h-split-panel data-size="25%" data-min="200">
                 <div class="vbox gap-2 p-3">
                   <span x-h-text.muted class="text-sm">Configuration &amp; nomenclature across all applications.</span>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -204,43 +204,14 @@
             </ul>
           </div>
 
-          <!-- Built-in pages render here (Pinecone); a hosted domain app shows in the iframe instead. -->
-          <div id="app" x-show="!hostedUrl && !settingsMode" class="size-full overflow-auto flex-1">
+          <!-- Built-in pages (incl. the Settings master-detail) render here via Pinecone; a hosted
+               domain app shows in the iframe instead. -->
+          <div id="app" x-show="!hostedUrl" class="size-full overflow-auto flex-1">
             <!-- Pinecone Router renders the matched built-in view fragment here. -->
           </div>
-          <div x-show="hostedUrl && !settingsMode" class="flex-1 size-full" style="position: relative;">
+          <div x-show="hostedUrl" class="flex-1 size-full" style="position: relative;">
             <iframe :src="hostedUrl" title="Application" @load="onIframeLoad($event)"
                     style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
-          </div>
-
-          <!-- Settings: master-detail. Left lists every app's SETTING entities; selecting one hosts that
-               app at the entity's route in the detail iframe (cross-app, so it is hosted, not inlined). -->
-          <div x-show="settingsMode" class="vbox flex-1 size-full">
-            <div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
-              <div x-h-split-panel data-size="25%" data-min="200">
-                <div class="vbox gap-2 p-3">
-                  <span x-h-text.muted class="text-sm">Configuration &amp; nomenclature across all applications.</span>
-                  <template x-for="item in settingsItems" :key="item.id">
-                    <button x-h-button data-variant="outline" class="justify-start"
-                            :data-state="isSettingActive(item) ? 'selected' : ''" @click="selectSetting(item)">
-                      <i role="img" data-lucide="settings"></i>
-                      <span x-text="item.label"></span>
-                    </button>
-                  </template>
-                </div>
-              </div>
-              <div x-h-split-panel data-size="75%" style="position: relative;">
-                <div x-show="!settingsUrl" x-h-info-page class="p-4">
-                  <div x-h-info-page-header>
-                    <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>
-                    <div x-h-info-page-title>Select a setting</div>
-                    <div x-h-info-page-description>Choose a configuration entity on the left to manage it here.</div>
-                  </div>
-                </div>
-                <iframe x-show="settingsUrl" :src="settingsUrl" title="Settings"
-                        style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
-              </div>
-            </div>
           </div>
         </div>
       </div>
@@ -289,10 +260,10 @@
     <template x-route="/inbox" x-template.target.app="/services/web/application-core/shell/views/_inbox.html"></template>
     <template x-route="/documents" x-template.target.app="/services/web/application-core/shell/views/_documents.html"></template>
     <template x-route="/reports" x-template.target.app="/services/web/application-core/shell/views/_reports.html"></template>
-    <!-- Settings: list (/settings) or a selected entity (/settings/<perspective-id>). No template - the
-         settings master-detail layout above renders it (driven by settingsMode). -->
-    <template x-route="/settings"></template>
-    <template x-route="/settings/:id"></template>
+    <!-- Settings: list (/settings) or a selected entity (/settings/<perspective-id>). The master-detail
+         fragment renders into #app (visible) so its split lays out correctly. -->
+    <template x-route="/settings" x-template.target.app="./views/_settings.html"></template>
+    <template x-route="/settings/:id" x-template.target.app="./views/_settings.html"></template>
     <!-- Hosted domain apps: /app/<perspective-id>[/<inner-route>]. No template - the iframe renders them;
          the optional inner segment mirrors the embedded app's own hash route (deep-linkable). -->
     <template x-route="/app/:id/:inner*"></template>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -109,19 +109,31 @@
                 </div>
               </div>
             </template>
+
+            <!-- Reports: one entry per report, discovered at runtime across every published app
+                 (the reports store walks the whole registry). Selecting one shows it on /reports. -->
+            <div x-h-sidebar-group x-show="$store.reports.items.length > 0" x-cloak>
+              <div x-h-sidebar-group-label>Reports</div>
+              <div x-h-sidebar-group-content>
+                <ul x-h-sidebar-menu>
+                  <template x-for="r in $store.reports.items" :key="r.url">
+                    <li x-h-sidebar-menu-item>
+                      <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/reports') && $store.reports.selected && $store.reports.selected.url === r.url" @click="$store.reports.selected = r; navigate('/reports')">
+                        <i role="img" data-lucide="bar-chart-3"></i><span x-text="r.label"></span>
+                      </button>
+                    </li>
+                  </template>
+                </ul>
+              </div>
+            </div>
           </div>
 
-          <!-- Settings + Reports pinned to the footer. Settings aggregates every app's SETTING entities. -->
+          <!-- Settings pinned to the footer; it aggregates every app's SETTING entities. -->
           <div x-h-sidebar-footer>
             <ul x-h-sidebar-menu>
               <li x-h-sidebar-menu-item x-show="settingsItems.length > 0">
                 <button x-h-sidebar-menu-button :data-active="settingsMode" @click="openSettings()">
                   <i role="img" data-lucide="settings"></i><span>Settings</span>
-                </button>
-              </li>
-              <li x-h-sidebar-menu-item>
-                <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/reports')" @click="navigate('/reports')">
-                  <i role="img" data-lucide="bar-chart-3"></i><span>Reports</span>
                 </button>
               </li>
             </ul>
@@ -205,7 +217,7 @@
                app at the entity's route in the detail iframe (cross-app, so it is hosted, not inlined). -->
           <div x-show="settingsMode" class="flex-1 size-full">
             <div x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
-              <div x-h-split-panel data-size="22%" data-min="200">
+              <div x-h-split-panel data-size="25%" data-min="200">
                 <div class="vbox gap-2 p-3">
                   <span x-h-text.muted class="text-sm">Configuration &amp; nomenclature across all applications.</span>
                   <template x-for="item in settingsItems" :key="item.id">
@@ -217,7 +229,7 @@
                   </template>
                 </div>
               </div>
-              <div x-h-split-panel data-size="78%" style="position: relative;">
+              <div x-h-split-panel data-size="75%" style="position: relative;">
                 <div x-show="!settingsUrl" x-h-info-page class="p-4">
                   <div x-h-info-page-header>
                     <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -208,13 +208,18 @@ document.addEventListener('alpine:init', () => {
       this.closeSideNav();
     },
 
-    /** Select a setting entity: host its app at that entity's route in the settings detail iframe. */
+    /** Select a setting entity: host its app at that entity's route in the settings detail iframe.
+     *  Update the URL with replaceState (no Pinecone re-render) so the master-detail split keeps the
+     *  layout it computed when first shown; the detail iframe just swaps its src. */
     selectSetting(item) {
       if (this.settingsSelected !== item.id) {
         this.settingsSelected = item.id;
         this.settingsUrl = item.path || '';
         this.currentPath = '/settings/' + encodeURIComponent(item.id);
-        window.PineconeRouter.navigate('/settings/' + encodeURIComponent(item.id));
+        const url = '#/settings/' + encodeURIComponent(item.id);
+        if (window.location.hash !== url && window.history && window.history.replaceState) {
+          window.history.replaceState(window.history.state, '', url);
+        }
         this.refreshIcons();
       }
     },

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/config.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/config.js
@@ -12,5 +12,7 @@ App.config = {
   projectName: 'application',
   basePath: '/services/web/application',
   // No own entities; the built-in stores (inbox/documents/reports) call platform services directly.
-  restBase: ''
+  restBase: '',
+  // The application shell aggregates reports from every published app (not just its own project).
+  aggregateReports: true
 };

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  Settings master-detail for the application shell, Pinecone-routed into #app (so the split is laid out
+  while visible - an inline x-show=display:none block measures 0x0 and ignores data-size). No own
+  x-data: it inherits the shell's `app` component (settingsItems / selectSetting / settingsUrl).
+-->
+<div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
+  <div x-h-split-panel data-size="25%" data-min="200">
+    <div class="vbox gap-2 p-3">
+      <span x-h-text.muted class="text-sm">Configuration &amp; nomenclature across all applications.</span>
+      <template x-for="item in settingsItems" :key="item.id">
+        <button x-h-button data-variant="outline" class="justify-start"
+                :data-state="isSettingActive(item) ? 'selected' : ''" @click="selectSetting(item)">
+          <i role="img" data-lucide="settings"></i>
+          <span x-text="item.label"></span>
+        </button>
+      </template>
+    </div>
+  </div>
+  <div x-h-split-panel data-size="75%" style="position: relative;">
+    <div x-show="!settingsUrl" x-h-info-page class="p-4">
+      <div x-h-info-page-header>
+        <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>
+        <div x-h-info-page-title>Select a setting</div>
+        <div x-h-info-page-description>Choose a configuration entity on the left to manage it here.</div>
+      </div>
+    </div>
+    <iframe x-show="settingsUrl" :src="settingsUrl" title="Settings"
+            style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
+  </div>
+</div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/settings.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/settings.html.template
@@ -11,7 +11,7 @@
   <div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
 
     <!-- Master: the setting entities -->
-    <div x-h-split-panel data-size="20%" data-min="200">
+    <div x-h-split-panel data-size="25%" data-min="200">
       <div class="vbox gap-2 p-4">
         <span x-h-text.muted>Configuration &amp; nomenclature for ${projectName}.</span>
 #foreach($entity in $models)
@@ -27,7 +27,7 @@
     </div>
 
     <!-- Detail: the selected setting's content, loaded inline -->
-    <div x-h-split-panel data-size="80%">
+    <div x-h-split-panel data-size="75%">
       <div x-show="!selected" x-h-info-page class="p-4">
         <div x-h-info-page-header>
           <div x-h-info-page-media.icon><svg x-h-icon.circle-info role="img" aria-label="info"></svg></div>


### PR DESCRIPTION
- **Reports** moved from the app-shell footer into a **sidebar group** (matching the generated own shell): one entry per report, selecting one opens it on `/reports`.
- The shared **reports store** now aggregates across the whole registry when `App.config.aggregateReports` is set (the application shell sets it), so reports from every published app appear - each enriched from its own project's `.report`. Generated apps keep their single-project behavior.
- **Settings** master-detail splitter set to **25% / 75%**.

> Note: the sample currently has no `.report` artifacts, so the Reports group stays hidden until a report is generated; the wiring is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)