### PR TITLE
fix(harmonia): document page number-format literal broke generation (Velocity ## comment)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -489,10 +489,13 @@ document.addEventListener('alpine:init', () => {
       if (v === null || v === undefined || v === '') return '—';
       const n = Number(v);
       if (isNaN(n)) return v;
-      const p = pattern || '### ### ### ##0.00';
-      const dot = p.lastIndexOf('.');
-      const decimals = dot >= 0 ? (p.length - dot - 1) : 0;
-      const groupSep = p.indexOf(' ') >= 0 ? ' ' : (p.indexOf(',') >= 0 ? ',' : '');
+      let decimals = 2;
+      let groupSep = ' ';
+      if (pattern) {
+        const dot = pattern.lastIndexOf('.');
+        decimals = dot >= 0 ? (pattern.length - dot - 1) : 0;
+        groupSep = pattern.indexOf(' ') >= 0 ? ' ' : (pattern.indexOf(',') >= 0 ? ',' : '');
+      }
       const parts = n.toFixed(decimals).split('.');
       if (groupSep) parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, groupSep);
       return parts.length > 1 ? parts[0] + '.' + parts[1] : parts[0];


### PR DESCRIPTION
Regression from #6098. The `displayNumber` default literal `'### ### ### ##0.00'` in `document-page.js.template` is **Velocity-processed**: `##` starts a line comment, which ate the rest of the line and left an unterminated string -> `SyntaxError` in the generated `<Entity>DocumentPage.js`, breaking the document **New/Edit** page.

Fix: derive the defaults (2 decimals, space grouping) in code rather than from a literal pattern, so no `#` appears in the template. The pattern still flows in via the per-field `formatPattern` variable (those are variable substitutions, not re-parsed by Velocity, so they were always fine).

Verified: all generated JS in the sample now parses (`node --check`), and the formatted totals/list cells render with the correct `### ### ### ##0.00` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)