### PR TITLE
fix(harmonia): create/edit form returns to the list after save (was stuck in the shell)

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/app.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/app.js
@@ -24,7 +24,7 @@ window.App = {
       if (!controllerUrl || !entity) return '';
       const i = controllerUrl.indexOf('/api/');
       const base = (i >= 0 ? controllerUrl.substring(0, i) : controllerUrl).replace('/services/java/', '/services/web/');
-      return base + '/index.html?embedded=1#/' + entity + '/create?embedded=1';
+      return base + '/index.html?embedded=1#/' + entity + '/create?embedded=1&dialog=1';
     },
   },
   config: {},

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/baseFormPage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/baseFormPage.js
@@ -130,10 +130,16 @@ function baseFormPage() {
       window.PineconeRouter.navigate(this.returnToParam() || defaultRoute);
     },
 
-    // This form is hosted inside an FK combobox's "Add" iframe dialog (opened with ?embedded=1).
-    // On a successful create it must report the new record to the parent and NOT navigate away.
+    // Hosted without its own chrome (the shell-hosted app OR an FK "Add" dialog both pass ?embedded).
+    // Controls whether this form renders its own toolbar - NOT whether save navigates.
     get isEmbedded() {
       return this.queryParam('embedded') === '1' || this.queryParam('embedded') === 'true';
+    },
+
+    // Hosted specifically inside an FK combobox's "Add" iframe dialog (opened with ?dialog=1). Only in
+    // this case does a create report the new record to the opener instead of navigating to the list.
+    get isDialog() {
+      return this.queryParam('dialog') === '1' || this.queryParam('dialog') === 'true';
     },
 
     // Tell the hosting window a record was created so the opener can refresh + select it.

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -165,9 +165,9 @@ document.addEventListener('alpine:init', () => {
           await App.services.api.put(this.apiPath + '/' + encodeURIComponent(this.id), payload);
         } else {
           const created = await App.services.api.post(this.apiPath, payload);
-          // Opened as an FK "Add" iframe dialog: report the new record to the opener and stop here
-          // (no navigation - the parent closes the dialog and selects the created record).
-          if (this.isEmbedded) {
+          // Only when opened as an FK "Add" iframe dialog: report the new record to the opener and stop
+          // here (the parent closes the dialog and selects it). Otherwise fall through to the list.
+          if (this.isDialog) {
             this.emitCreated(created && (created.${primaryKeysString} != null ? created.${primaryKeysString} : created.id));
             return;
           }
@@ -241,9 +241,9 @@ document.addEventListener('alpine:init', () => {
     },
 
     cancel() {
-      // Opened as an FK "Add" iframe dialog: ask the parent to close the dialog instead of navigating
+      // Only when opened as an FK "Add" iframe dialog: ask the parent to close it instead of navigating
       // this iframe to a list.
-      if (this.isEmbedded) {
+      if (this.isDialog) {
         this.emitClose();
         return;
       }


### PR DESCRIPTION
## Problem
Opening a create form inside the application shell (e.g. `#/app/customer-payments-CustomerPayment/CustomerPayment/create`) and clicking **Create** spun the button forever and never completed. Same for **Customer** and the other manage/master forms.

## Cause
The shell hosts every app with `?embedded=true` (to hide the app's own chrome). The form reused that same `isEmbedded` flag to decide it was inside an FK "Add" iframe dialog, so on create it `postMessage`d the new record to the parent and **returned without navigating** - waiting for a dialog that never closes it.

## Fix
Separate the two concerns:
- `?embedded` - still only hides the form's own toolbar (used by shell-hosting *and* the FK dialog).
- `?dialog` (new) - set **only** by `relatedCreateUrl`, marks the genuine FK "Add" iframe.

`save()` and `cancel()` now branch on `isDialog`: a normal create/edit **navigates back to the list**; only a real FK "Add" dialog emits the created event and stays. Applies to all manage/master/setting forms (shared `form-page.js.template`); documents already navigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)