### PR TITLE
fix(harmonia): document edit-save returns to the list

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -255,7 +255,8 @@ document.addEventListener('alpine:init', () => {
         const payload = this.toPayload();
         if (this.isEdit) {
           await App.services.api.put(this.apiPath + '/' + encodeURIComponent(this.id), payload);
-          await this.loadHeader();
+          this.backToList();
+          return;
         } else {
           // Create the header, then stay on the document (now in edit mode) so items can be added.
           const created = await App.services.api.post(this.apiPath, payload);


### PR DESCRIPTION
Editing a document and saving now navigates back to the list (consistent with the manage/master forms). Create still stays on the document in edit mode so line items can be added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)