### PR TITLE
chore(intent): formatting of PLURALIZE_OVERRIDES

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
@@ -32,8 +32,7 @@ public final class IntentNaming {
      * Plural overrides for (humanized) labels whose last word must not be naively pluralized (keyed
      * lower-case). Both the humanized singular and the raw identifier map to the same plural.
      */
-    private static final Map<String, String> PLURALIZE_OVERRIDES =
-            Map.of("unit of measure", "Units of Measure", "uom", "Units of Measure");
+    private static final Map<String, String> PLURALIZE_OVERRIDES = Map.of("unit of measure", "Units of Measure", "uom", "Units of Measure");
 
     /**
      * The intent's base name used for single-file outputs ({@code <base>.edm}, {@code <base>.roles})


### PR DESCRIPTION
Cosmetic: collapse the PLURALIZE_OVERRIDES map declaration to one line (formatter). No behavior change.