### PR TITLE
[Security] Logout does not terminate the identity provider session for OAuth2/OIDC setups (Cognito/Keycloak)

### DIFF
--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoLogoutSuccessHandler.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoLogoutSuccessHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.cognito;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Logs the user out of AWS Cognito after the local session is cleared. Spring's default logout only
+ * clears the local session, leaving the Cognito hosted-UI session alive - so the next login
+ * silently re-authenticates the just-logged-out user without a credential prompt. Cognito does not
+ * implement the standard OIDC end-session endpoint, so this handler redirects the browser to
+ * Cognito's proprietary {@code /logout} endpoint ({@code logout_uri} must be registered as an
+ * allowed sign-out URL on the Cognito app client).
+ */
+@Profile("cognito")
+@Component
+class CognitoLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private static final String LOGOUT_PATH = "/logout";
+
+    private final String logoutEndpoint;
+    private final String clientId;
+    private final String logoutRedirectUri;
+
+    CognitoLogoutSuccessHandler(@Value("${DIRIGIBLE_COGNITO_DOMAIN}") String cognitoDomain,
+            @Value("${spring.security.oauth2.client.registration.cognito.client-id}") String clientId,
+            @Value("${DIRIGIBLE_HOST}") String host) {
+        this.logoutEndpoint = cognitoDomain + LOGOUT_PATH;
+        this.clientId = clientId;
+        this.logoutRedirectUri = host;
+    }
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+        String logoutUrl = logoutEndpoint + "?client_id=" + encode(clientId) + "&logout_uri=" + encode(logoutRedirectUri);
+        response.sendRedirect(logoutUrl);
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -66,7 +66,8 @@ public class CognitoSecurityConfiguration {
      */
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator,
-            ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter) throws Exception {
+            ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter, CognitoLogoutSuccessHandler cognitoLogoutSuccessHandler)
+            throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -78,6 +79,10 @@ public class CognitoSecurityConfiguration {
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
                                                                  .jwtAuthenticationConverter(
                                                                          jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
+            .logout(logout -> logout.deleteCookies("JSESSIONID")
+                                    .invalidateHttpSession(true)
+                                    .clearAuthentication(true)
+                                    .logoutSuccessHandler(cognitoLogoutSuccessHandler))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakLogoutSuccessHandler.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakLogoutSuccessHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.keycloak;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Performs OIDC RP-initiated logout against Keycloak. Spring's default logout only clears the local
+ * session, which leaves the Keycloak SSO session alive - so the next login silently
+ * re-authenticates the just-logged-out user without a credential prompt. After the local session is
+ * cleared this handler redirects the browser to Keycloak's end-session endpoint, terminating that
+ * SSO session and sending the user back to the configured host.
+ */
+@Profile("keycloak")
+@Component
+class KeycloakLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private static final String END_SESSION_PATH = "/protocol/openid-connect/logout";
+
+    private final String endSessionEndpoint;
+    private final String clientId;
+    private final String postLogoutRedirectUri;
+
+    KeycloakLogoutSuccessHandler(@Value("${spring.security.oauth2.client.provider.keycloak.issuer-uri}") String issuerUri,
+            @Value("${spring.security.oauth2.client.registration.keycloak.client-id}") String clientId,
+            @Value("${DIRIGIBLE_HOST}") String host) {
+        this.endSessionEndpoint = issuerUri + END_SESSION_PATH;
+        this.clientId = clientId;
+        this.postLogoutRedirectUri = host;
+    }
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+            throws IOException {
+        StringBuilder logoutUrl = new StringBuilder(endSessionEndpoint).append("?client_id=")
+                                                                       .append(encode(clientId))
+                                                                       .append("&post_logout_redirect_uri=")
+                                                                       .append(encode(postLogoutRedirectUri));
+        idTokenValue(authentication).ifPresent(idToken -> logoutUrl.append("&id_token_hint=")
+                                                                   .append(encode(idToken)));
+        response.sendRedirect(logoutUrl.toString());
+    }
+
+    private static Optional<String> idTokenValue(Authentication authentication) {
+        if (authentication instanceof OAuth2AuthenticationToken token && token.getPrincipal() instanceof OidcUser oidcUser
+                && oidcUser.getIdToken() != null) {
+            return Optional.of(oidcUser.getIdToken()
+                                       .getTokenValue());
+        }
+        return Optional.empty();
+    }
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -73,8 +73,8 @@ public class KeycloakSecurityConfiguration {
      */
     @Bean
     SecurityFilterChain configure(HttpSecurity http, TenantContextInitFilter tenantContextInitFilter,
-            HttpSecurityURIConfigurator httpSecurityURIConfigurator, ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter)
-            throws Exception {
+            HttpSecurityURIConfigurator httpSecurityURIConfigurator, ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter,
+            KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler) throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
@@ -88,6 +88,10 @@ public class KeycloakSecurityConfiguration {
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())
                                                                  .jwtAuthenticationConverter(
                                                                          jwtAuthenticationConverter(scopeRoleJwtAuthoritiesConverter))))
+            .logout(logout -> logout.deleteCookies("JSESSIONID")
+                                    .invalidateHttpSession(true)
+                                    .clearAuthentication(true)
+                                    .logoutSuccessHandler(keycloakLogoutSuccessHandler))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
@@ -52,6 +52,12 @@ public class OAuth2SecurityConfiguration {
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(Customizer.withDefaults())
             .oauth2ResourceServer(oauth2 -> oauth2.jwt(jwt -> jwt.decoder(jwtDecoder())))
+            // GitHub OAuth exposes no RP-initiated logout (no end-session endpoint), so only the local
+            // session can be cleared here; an active github.com session may still re-authenticate silently.
+            .logout(logout -> logout.deleteCookies("JSESSIONID")
+                                    .invalidateHttpSession(true)
+                                    .clearAuthentication(true)
+                                    .logoutSuccessUrl("/"))
             .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.ALWAYS));
 
         httpSecurityURIConfigurator.configure(http);


### PR DESCRIPTION
Configures logout to terminate the identity provider session for the Cognito and Keycloak setups, so users are prompted to re-authenticate after logging out instead of being silently logged back in. The generic OAuth2 (GitHub) chain now also fully clears the local session on logout.

Closes #6108