### PR TITLE
Intent: sum roll-up maintains a balance field + sets a status relation

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -298,6 +298,25 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             base.put("countField", IntentNaming.pascalCase(rollup.getField()));
             base.put("op", op);
             base.put("sumField", sum ? IntentNaming.pascalCase(rollup.getOf()) : "");
+            // Optional (sum) capacity/balance/status: keep a `balance` field = capacity - sum, and set a
+            // `status` relation to whenFull/whenPartial at the thresholds. Empty string / -1 = not set.
+            boolean withCapacity = sum && rollup.getCapacity() != null && !rollup.getCapacity()
+                                                                                 .isBlank();
+            base.put("capacityField", withCapacity ? IntentNaming.pascalCase(rollup.getCapacity()) : "");
+            base.put("balanceField", withCapacity && rollup.getBalance() != null && !rollup.getBalance()
+                                                                                           .isBlank()
+                                                                                                   ? IntentNaming.pascalCase(
+                                                                                                           rollup.getBalance())
+                                                                                                   : "");
+            boolean withStatus = withCapacity && rollup.getStatus() != null && !rollup.getStatus()
+                                                                                      .isBlank();
+            base.put("statusField", withStatus ? IntentNaming.pascalCase(rollup.getStatus()) : "");
+            base.put("statusWhenFull", withStatus && rollup.getStatusWhenFull() != null ? rollup.getStatusWhenFull()
+                                                                                                .toString()
+                    : "");
+            base.put("statusWhenPartial", withStatus && rollup.getStatusWhenPartial() != null ? rollup.getStatusWhenPartial()
+                                                                                                      .toString()
+                    : "");
             // Recompute the value for the affected parent from the store on each child event.
             base.put("criteriaExpression", "Criteria.create().eq(\"" + fkProperty + "\", entity." + fkProperty + ")");
             String className = IntentNaming.pascalCase(rollup.getName());

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RollupIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RollupIntent.java
@@ -36,6 +36,28 @@ public class RollupIntent {
     private String op;
     /** The child field summed onto {@link #field} when {@link #op} is {@code sum}. */
     private String of;
+    /**
+     * Optional (sum roll-ups only): a numeric "capacity" field on the parent the sum is measured
+     * against - e.g. an invoice's {@code total} against which the paid sum is compared. Enables
+     * {@link #balance} and {@link #status} derivation.
+     */
+    private String capacity;
+    /**
+     * Optional (sum roll-ups only, requires {@link #capacity}): a parent field kept equal to
+     * {@code capacity - sum} (e.g. an invoice's outstanding {@code balance}).
+     */
+    private String balance;
+    /**
+     * Optional (sum roll-ups only, requires {@link #capacity}): a parent to-one relation set to
+     * {@link #statusWhenFull} when {@code sum >= capacity}, or {@link #statusWhenPartial} when
+     * {@code 0 < sum < capacity} (left unchanged at zero). E.g. an invoice's {@code Status} → PAID /
+     * PARTIAL as payments accumulate.
+     */
+    private String status;
+    /** Seed id set on {@link #status} when the sum reaches the capacity (fully consumed). */
+    private Integer statusWhenFull;
+    /** Seed id set on {@link #status} when the sum is positive but below the capacity. */
+    private Integer statusWhenPartial;
 
     public String getName() {
         return name;
@@ -83,5 +105,45 @@ public class RollupIntent {
 
     public void setOf(String of) {
         this.of = of;
+    }
+
+    public String getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(String capacity) {
+        this.capacity = capacity;
+    }
+
+    public String getBalance() {
+        return balance;
+    }
+
+    public void setBalance(String balance) {
+        this.balance = balance;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public Integer getStatusWhenFull() {
+        return statusWhenFull;
+    }
+
+    public void setStatusWhenFull(Integer statusWhenFull) {
+        this.statusWhenFull = statusWhenFull;
+    }
+
+    public Integer getStatusWhenPartial() {
+        return statusWhenPartial;
+    }
+
+    public void setStatusWhenPartial(Integer statusWhenPartial) {
+        this.statusWhenPartial = statusWhenPartial;
     }
 }

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -431,8 +431,22 @@ rollups:
 `entity` is the child being counted, `via` is the child's to-one relation pointing at the parent, and
 `field` is the integer field on the **parent** that holds the count.
 
+**Sum + balance + status (payment settlement).** With `op: sum` the roll-up keeps `field` equal to the
+sum of the children's `of` field. Add `capacity` (a numeric parent field the sum is measured against)
+to also maintain a `balance` field (= `capacity − sum`) and set a `status` relation to `statusWhenFull`
+(when `sum >= capacity`) or `statusWhenPartial` (when `0 < sum < capacity`; unchanged at zero):
+```yaml
+rollups:
+  # Invoice.paid = sum of its payment allocations; balance = total − paid; Status -> PAID / PARTIAL.
+  - { name: invoicePaid, entity: SalesInvoiceCustomerPayment, via: SalesInvoice, field: paid,
+      op: sum, of: amount,
+      capacity: total, balance: balance, status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
+```
+
 **Rules:** `via` must be a to-one (`manyToOne` / `oneToOne`) relation of the child entity; `field`
-must be an existing **integer** field on the parent entity.
+must be an existing field on the parent (**integer** for `count`, **numeric** for `sum`). For the sum
+extras: `capacity`/`balance` are numeric parent fields, `status` a to-one relation of the parent, and
+`statusWhenFull`/`statusWhenPartial` its target seed ids.
 
 ## Allowed values
 

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
@@ -53,6 +53,19 @@ public class ${className} implements MessageHandler {
             }
         }
         parent.${countField} = sum;
+#if($capacityField != "")
+        BigDecimal capacity = parent.${capacityField} == null ? BigDecimal.ZERO : parent.${capacityField};
+#if($balanceField != "")
+        // Outstanding balance = capacity - sum.
+        parent.${balanceField} = capacity.subtract(sum);
+#end
+#if($statusField != "")
+        // Derive status: fully consumed -> whenFull, partially -> whenPartial (unchanged at zero).
+        if (sum.signum() > 0) {
+            parent.${statusField} = sum.compareTo(capacity) >= 0 ? ${statusWhenFull} : ${statusWhenPartial};
+        }
+#end
+#end
         // System-managed denormalization - persist without re-publishing the parent "-updated" event.
         parents.updateWithoutEvent(parent);
 #else

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -572,6 +572,11 @@ export function generateFiles(model, parameters, templateSources) {
                                 countField: model.rollups[r].countField,
                                 op: model.rollups[r].op,
                                 sumField: model.rollups[r].sumField,
+                                capacityField: model.rollups[r].capacityField,
+                                balanceField: model.rollups[r].balanceField,
+                                statusField: model.rollups[r].statusField,
+                                statusWhenFull: model.rollups[r].statusWhenFull,
+                                statusWhenPartial: model.rollups[r].statusWhenPartial,
                                 topicSuffix: model.rollups[r].topicSuffix,
                                 criteriaExpression: model.rollups[r].criteriaExpression
                             };

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -635,6 +635,53 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void sum_rollup_with_capacity_maintains_balance_and_sets_status() {
+        // A sum roll-up with `capacity` also keeps a `balance` field (= capacity - sum) and derives a
+        // `status` relation: whenFull (>= capacity) / whenPartial (0 < sum < capacity). This is the
+        // payment-settlement engine: Bill.paid = sum of its payments, Bill.balance = total - paid,
+        // Bill.Status -> PAID / PARTIAL.
+        String yaml = """
+                name: billing
+                entities:
+                  - name: Bill
+                    fields:
+                      - { name: id,      type: integer, primaryKey: true, generated: true }
+                      - { name: total,   type: decimal, precision: 18, scale: 2 }
+                      - { name: paid,    type: decimal, precision: 18, scale: 2 }
+                      - { name: balance, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: Status, kind: manyToOne, to: BillStatus }
+                  - name: BillStatus
+                    kind: setting
+                    fields:
+                      - { name: id,   type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string,  required: true, length: 50 }
+                  - name: BillPayment
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: amount, type: decimal, precision: 18, scale: 2, required: true }
+                    relations:
+                      - { name: Bill, kind: manyToOne, to: Bill, composition: true, required: true }
+                rollups:
+                  - { name: billPaid, entity: BillPayment, via: Bill, field: paid, op: sum, of: amount,
+                      capacity: total, balance: balance, status: Status, statusWhenFull: 2, statusWhenPartial: 1 }
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "billing.glue");
+
+        String onCreate = contentOf("gen/events/BillPaidRollupOnCreate.java");
+        assertTrue(onCreate.contains("parent.Paid = sum"), "the sum roll-up should write the summed field");
+        assertTrue(onCreate.contains("parent.Balance = capacity.subtract(sum)"),
+                "with a capacity + balance, it should keep balance = capacity - sum");
+        assertTrue(onCreate.contains("parent.Status = sum.compareTo(capacity) >= 0 ? 2 : 1"),
+                "with a capacity + status, it should set the status relation to whenFull/whenPartial at the thresholds");
+    }
+
+    @Test
     void process_trigger_business_key_uses_the_flagged_field_not_the_primary_key() {
         // The trigger flags `orderNumber` as the business key; the listener must still LOAD the entity
         // by its primary key (findById), but start the process with the flagged field as the BPM


### PR DESCRIPTION
## What

Extends the intent **sum roll-up** so a settlement total can also drive an **outstanding balance** and a **document status** — the engine behind invoice payment allocation (`Invoice.paid` = ∑ payment allocations, `balance` = total − paid, `Status` → PAID / PARTIAL). Part 1 (foundation) of the payment-settlement feature.

A `op: sum` roll-up gains three optional extras:
```yaml
rollups:
  - { name: invoicePaid, entity: SalesInvoiceCustomerPayment, via: SalesInvoice, field: paid,
      op: sum, of: amount,
      capacity: total, balance: balance, status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
```
- **`capacity`** — a numeric parent field the sum is measured against (e.g. `total`).
- **`balance`** — a parent field kept equal to `capacity − sum`.
- **`status` + `statusWhenFull` / `statusWhenPartial`** — a to-one parent relation set to the *full* seed id when `sum >= capacity`, the *partial* id when `0 < sum < capacity`, left unchanged at zero.

All three are written in the **same `updateWithoutEvent`** as the summed field, so it stays one system write (no extra events, no onUpdate re-fire).

## Changes
- `RollupIntent` — `capacity` / `balance` / `status` / `statusWhenFull` / `statusWhenPartial`.
- `GlueIntentGenerator.buildRollups` — emits them (sum roll-ups only); `generateUtils.js` rollup case passes them through.
- `Rollup.java.template` — sets `balance` and `status` in the `sum` branch.
- `IntentEngineIT.sum_rollup_with_capacity_maintains_balance_and_sets_status` — asserts the generated handler writes `balance = capacity − sum` and the status ternary.
- Documented in `intent-assistant-guide.md`.

Backward compatible: existing count/sum roll-ups without the new keys generate exactly as before.

## Next
This is the foundation for the payment-settlement design. Follow-ups: the `link`/`allocate` junction sugar + auto-pay listener (`onPayment` create) and the `onInvoice` (ISSUED) allocation delegate; then the read-only allocation UI. `engine-intent` compiles; `IntentEngineIT` covers the new behavior (verify on a full rebuild + regenerate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)