### PR TITLE
feat(parsers): document template DSL parser + layout primitives

### DIFF
--- a/modules/parsers/document/README.md
+++ b/modules/parsers/document/README.md
@@ -1,0 +1,151 @@
+# Parsers - Document Template
+
+A lightweight, declarative document-template engine for printable business documents —
+Sales Invoice, Purchase Order, Quote, Delivery Note, Receipt, Statement, Credit Note.
+Philosophically a widget tree (think Flutter / Jetpack Compose) targeted at paper, not
+screens: templates are a tiny XML-like DSL with **only business-oriented tags** — no HTML,
+no CSS, no scripting, no programming language of any kind inside templates.
+
+The scope of this module is **parsing + document model + layout primitives**. Rendering
+backends (PDF via XSL-FO) plug into the `renderer` seam and live elsewhere.
+
+```xml
+<document>
+    <header>
+        <text align="right" style="title">Sales Invoice</text>
+    </header>
+    <section>
+        <field label="Invoice No">{{invoice.number}}</field>
+        <field label="Date">{{invoice.date}}</field>
+    </section>
+    <table source="invoice.items">
+        <column width="45%">{{description}}</column>
+        <column width="15%" align="center">{{quantity}}</column>
+        <column width="20%" align="right">{{price}}</column>
+        <column width="20%" align="right">{{amount}}</column>
+    </table>
+    <total align="right">{{invoice.total}}</total>
+</document>
+```
+
+Mustache placeholders (`{{...}}`) are **not evaluated** by the parser — they survive
+verbatim in text and attribute values; a later data-binding layer replaces them.
+
+## Usage
+
+```java
+DocumentParser parser = new DocumentParser();
+DocumentNode document = parser.parseDocument(source);   // requires a <document> root
+
+LayoutEngine engine = new LayoutEngine();
+LayoutNode layout = engine.layout(document);            // typed measurements + alignment
+```
+
+Every AST node carries its tag name, attributes (raw strings — validation happens later),
+children in document order, normalized text content, and its source line/column. The
+hierarchy is a sealed interface (`Node`) with one record per built-in tag, so consumers can
+pattern-match exhaustively:
+
+```java
+switch (node) {
+    case TableNode table -> layoutTable(table);
+    case TextNode text -> layoutText(text);
+    case CustomNode custom -> handleExtension(custom);
+    // ... the compiler enforces the rest
+}
+```
+
+## Built-in tags
+
+`document`, `page`, `header`, `footer`, `section`, `row`, `column`, `stack`, `text`,
+`field`, `table`, `image`, `line`, `space`, `total`, `if`, `for`
+
+## Attributes
+
+`id`, `width`, `height`, `flex`, `align`, `style`, `gap`, `padding`, `margin`, `label`,
+`source`, `src`, `repeatHeader`, `pageBreak` — all stored as plain strings.
+
+- **Alignment** (`align`): `left`, `center`, `right`, `justify`.
+- **Widths/heights**: `100` (px), `100px`, `50%`, `*` (fraction weight 1), `2*`, `3*`;
+  missing or `auto` sizes to content. `flex="2"` on a child of `row`/`column`/`stack` is
+  shorthand for `width="2*"` (an explicit `width` wins).
+
+## Extending with new tags
+
+Unknown tags are a parse error — a typo like `<colum>` in a printable document must fail
+fast rather than silently drop content. Extending the DSL is one line, no parser change:
+
+```java
+TagRegistry registry = TagRegistry.builtIn();
+registry.register("qrcode");                       // parses to CustomNode
+registry.register("barcode", BarcodeNode::new);    // or a CustomNode subclass
+Node root = new DocumentParser(registry).parse(source);
+```
+
+## Grammar (EBNF)
+
+```ebnf
+template       = [ bom ] , [ prolog ] , { misc } , element , { misc } ;
+prolog         = "<?xml" , { char } , "?>" ;
+misc           = comment | whitespace ;
+comment        = "<!--" , { char } , "-->" ;
+element        = self-closing | container ;
+self-closing   = "<" , name , { attribute } , [ S ] , "/>" ;
+container      = open-tag , content , close-tag ;
+open-tag       = "<" , name , { attribute } , [ S ] , ">" ;
+close-tag      = "</" , name , [ S ] , ">" ;              (* name must match the open tag *)
+content        = { text | element | comment } ;
+attribute      = S , name , [ S ] , "=" , [ S ] , value ;
+value          = '"' , { vchar - '"' } , '"'
+               | "'" , { vchar - "'" } , "'" ;
+vchar          = entity | char - "<" ;
+text           = { entity | char - "<" }- ;
+entity         = "&lt;" | "&gt;" | "&amp;" | "&quot;" | "&apos;" ;
+name           = ( letter | "_" ) , { letter | digit | "-" | "_" | "." } ;
+S              = whitespace ;
+
+measurement    = number , [ "px" ] | number , "%" | [ number ] , "*" | "auto" ;
+number         = digit , { digit } , [ "." , digit , { digit } ] ;
+alignment      = "left" | "center" | "right" | "justify" ;   (* case-insensitive *)
+```
+
+### Deliberate leniencies vs strict XML
+
+Templates are written by business users, so the parser is forgiving where strict XML is
+hostile:
+
+- A raw `&` that does not form one of the five named entities is **literal text** —
+  `Fish & Chips` just works. Only `&lt; &gt; &amp; &quot; &apos;` are decoded; numeric
+  character references (`&#65;`) are unsupported and stay literal.
+- Comments are skipped anywhere, the optional XML prolog is skipped unparsed, attribute
+  values may use single or double quotes.
+- No CDATA, no DOCTYPE, no processing instructions, no namespaces.
+- `{{` and `}}` have no lexical meaning — which is exactly why Mustache placeholders
+  survive parsing untouched.
+
+### Restrictions
+
+- Tag names are case-sensitive lowercase.
+- Duplicate attributes on one element are an error (determinism).
+- A literal `<` in text must be written `&lt;`.
+- Text whitespace is normalized: runs collapse to a single space, ends are trimmed.
+  There is no preformatted-text escape hatch (yet).
+
+Every syntax error reports its exact 1-based line and column; an unclosed element points
+at its **opening** tag.
+
+## Layout model
+
+`LayoutEngine.layout(ast)` produces a `LayoutNode` tree with typed `Measurement`s
+(`ABSOLUTE_PX` / `PERCENT` / `FRACTION` / `AUTO`) and `Alignment` per node, and resolves
+table column widths (`LayoutEngine.resolveColumnWidths` + `fractionShares`). It computes
+**no geometry** — coordinates, pagination, text measurement and `{{...}}` merging belong
+to the data-binding layer and the concrete `DocumentRenderer` (e.g. the XSL-FO/PDF
+backend).
+
+## Example templates
+
+One per supported document type under
+[`src/test/resources/templates/`](src/test/resources/templates/): `sales-invoice.print`,
+`purchase-order.print`, `quote.print`, `delivery-note.print`, `receipt.print`,
+`statement.print`, `credit-note.print`.

--- a/modules/parsers/document/pom.xml
+++ b/modules/parsers/document/pom.xml
@@ -5,23 +5,18 @@
 
 	<parent>
 		<groupId>org.eclipse.dirigible</groupId>
-		<artifactId>dirigible-modules-parent</artifactId>
+		<artifactId>dirigible-parsers-parent</artifactId>
 		<version>14.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<name>Parsers - Parent</name>
-	<artifactId>dirigible-parsers-parent</artifactId>
-	<packaging>pom</packaging>
-
-	<modules>
-		<module>typescript</module>
-		<module>apidoc</module>
-		<module>document</module>
-	</modules>
+	<name>Parsers - Document Template</name>
+	<artifactId>dirigible-parsers-document</artifactId>
+	<packaging>jar</packaging>
 
 	<properties>
-		<license.header.location>../../licensing-header.txt</license.header.location>
+		<license.header.location>../../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../../</parent.pom.folder>
 	</properties>
 
 </project>

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/Attributes.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/Attributes.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The immutable, insertion-ordered attribute collection of an AST node. Attribute values are kept
+ * as plain strings exactly as authored — Mustache placeholders like <code>{{invoice.number}}</code>
+ * are not evaluated; validation and data binding happen in later layers.
+ */
+public final class Attributes {
+
+    /** The shared empty collection. */
+    public static final Attributes EMPTY = new Attributes(List.of());
+
+    private final List<Attribute> attributes;
+    private final Map<String, Attribute> byName;
+
+    /**
+     * A single attribute as authored in the template.
+     *
+     * @param name the attribute name
+     * @param value the raw attribute value (placeholders untouched)
+     * @param position the position of the attribute name in the source
+     */
+    public record Attribute(String name, String value, SourcePosition position) {
+    }
+
+    private Attributes(List<Attribute> attributes) {
+        this.attributes = attributes;
+        Map<String, Attribute> map = new LinkedHashMap<>();
+        for (Attribute attribute : attributes) {
+            if (map.putIfAbsent(attribute.name(), attribute) != null) {
+                throw new IllegalArgumentException("Duplicate attribute '" + attribute.name() + "'");
+            }
+        }
+        this.byName = map;
+    }
+
+    /**
+     * Creates an attribute collection preserving the given order.
+     *
+     * @param attributes the attributes in document order
+     * @return the collection
+     */
+    public static Attributes of(List<Attribute> attributes) {
+        return attributes.isEmpty() ? EMPTY : new Attributes(List.copyOf(attributes));
+    }
+
+    /**
+     * The raw value of the named attribute.
+     *
+     * @param name the attribute name
+     * @return the value, or {@code null} when the attribute is absent
+     */
+    public String get(String name) {
+        Attribute attribute = byName.get(name);
+        return attribute == null ? null : attribute.value();
+    }
+
+    /**
+     * The raw value of the named attribute with a fallback.
+     *
+     * @param name the attribute name
+     * @param defaultValue the value to return when the attribute is absent
+     * @return the value or the fallback
+     */
+    public String getOrDefault(String name, String defaultValue) {
+        String value = get(name);
+        return value == null ? defaultValue : value;
+    }
+
+    /**
+     * Whether the named attribute is present.
+     *
+     * @param name the attribute name
+     * @return {@code true} when present
+     */
+    public boolean has(String name) {
+        return byName.containsKey(name);
+    }
+
+    /**
+     * The source position of the named attribute.
+     *
+     * @param name the attribute name
+     * @return the position, or {@code null} when the attribute is absent
+     */
+    public SourcePosition positionOf(String name) {
+        Attribute attribute = byName.get(name);
+        return attribute == null ? null : attribute.position();
+    }
+
+    /**
+     * The attribute names in document order.
+     *
+     * @return an unmodifiable, insertion-ordered set
+     */
+    public Set<String> names() {
+        return byName.keySet();
+    }
+
+    /**
+     * The attributes in document order.
+     *
+     * @return an unmodifiable list
+     */
+    public List<Attribute> asList() {
+        return attributes;
+    }
+
+    /**
+     * The number of attributes.
+     *
+     * @return the count
+     */
+    public int size() {
+        return attributes.size();
+    }
+
+    /**
+     * Whether the collection is empty.
+     *
+     * @return {@code true} when no attributes are present
+     */
+    public boolean isEmpty() {
+        return attributes.isEmpty();
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ColumnNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ColumnNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <column>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record ColumnNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public ColumnNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "column";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/CustomNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/CustomNode.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * The extension node for tags registered at runtime (e.g. {@code <qrcode>}). It is the only
+ * non-sealed member of the {@link Node} hierarchy: a class rather than a record so that custom node
+ * factories may subclass it with richer, tag-specific types.
+ */
+public non-sealed class CustomNode implements Node {
+
+    private final String tag;
+    private final SourcePosition position;
+    private final Attributes attributes;
+    private final List<Node> children;
+    private final String text;
+
+    /**
+     * Creates a custom node.
+     *
+     * @param tag the tag name, must not be blank
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public CustomNode(String tag, SourcePosition position, Attributes attributes, List<Node> children, String text) {
+        if (tag == null || tag.isBlank()) {
+            throw new IllegalArgumentException("Tag name must not be blank");
+        }
+        this.tag = tag;
+        this.position = position;
+        this.attributes = attributes == null ? Attributes.EMPTY : attributes;
+        this.children = children == null ? List.of() : List.copyOf(children);
+        this.text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return tag;
+    }
+
+    @Override
+    public SourcePosition position() {
+        return position;
+    }
+
+    @Override
+    public Attributes attributes() {
+        return attributes;
+    }
+
+    @Override
+    public List<Node> children() {
+        return children;
+    }
+
+    @Override
+    public String text() {
+        return text;
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/DocumentNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/DocumentNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <document>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record DocumentNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public DocumentNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "document";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/FieldNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/FieldNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <field>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record FieldNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public FieldNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "field";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/FooterNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/FooterNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <footer>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record FooterNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public FooterNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "footer";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ForNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ForNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <for>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record ForNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public ForNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "for";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/HeaderNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/HeaderNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <header>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record HeaderNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public HeaderNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "header";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/IfNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/IfNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <if>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record IfNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public IfNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "if";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ImageNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/ImageNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <image>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record ImageNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public ImageNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "image";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/LineNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/LineNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <line>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record LineNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public LineNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "line";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/Node.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/Node.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * A node of the document-template AST — the declarative widget tree of a printable business
+ * document. Every node carries its tag name, its attributes (raw strings), its child nodes in
+ * document order, its normalized text content, and its source position.
+ *
+ * <p>
+ * The hierarchy is sealed over one record per built-in tag so that consumers (e.g. the layout
+ * engine) can pattern-match exhaustively; {@link CustomNode} is the non-sealed extension point for
+ * tags registered at runtime.
+ */
+public sealed interface Node permits DocumentNode, PageNode, HeaderNode, FooterNode, SectionNode, RowNode, ColumnNode, StackNode, TextNode,
+        FieldNode, TableNode, ImageNode, LineNode, SpaceNode, TotalNode, IfNode, ForNode, CustomNode {
+
+    /**
+     * The tag name, e.g. {@code "table"}.
+     *
+     * @return the tag name
+     */
+    String tag();
+
+    /**
+     * The attributes declared on the tag.
+     *
+     * @return the attributes, never {@code null}
+     */
+    Attributes attributes();
+
+    /**
+     * The child nodes in document order.
+     *
+     * @return an unmodifiable list, never {@code null}
+     */
+    List<Node> children();
+
+    /**
+     * The normalized text content: all text segments concatenated, whitespace runs collapsed to single
+     * spaces and trimmed. Mustache placeholders are preserved verbatim.
+     *
+     * @return the text, never {@code null} (empty when the node has no text)
+     */
+    String text();
+
+    /**
+     * The position of the node's opening tag in the template source.
+     *
+     * @return the position
+     */
+    SourcePosition position();
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/PageNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/PageNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <page>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record PageNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public PageNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "page";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/RowNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/RowNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <row>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record RowNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public RowNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "row";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SectionNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SectionNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <section>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record SectionNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public SectionNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "section";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SourcePosition.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SourcePosition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+/**
+ * A 1-based line and column location in the template source, attached to every AST node and
+ * attribute so that later validation and rendering errors can point at the exact spot.
+ *
+ * @param line the 1-based line number
+ * @param column the 1-based column number
+ */
+public record SourcePosition(int line, int column) {
+
+    /**
+     * Creates a position.
+     *
+     * @param line the 1-based line number
+     * @param column the 1-based column number
+     * @return the position
+     */
+    public static SourcePosition of(int line, int column) {
+        return new SourcePosition(line, column);
+    }
+
+    /**
+     * The human-readable form used in error messages.
+     *
+     * @return {@code "line L, column C"}
+     */
+    @Override
+    public String toString() {
+        return "line " + line + ", column " + column;
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SpaceNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/SpaceNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <space>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record SpaceNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public SpaceNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "space";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/StackNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/StackNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <stack>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record StackNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public StackNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "stack";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TableNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TableNode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code
+ *
+<table>
+ * } tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record TableNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public TableNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "table";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TextNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TextNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <text>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record TextNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public TextNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "text";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TotalNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/TotalNode.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import java.util.List;
+
+/**
+ * AST node for the {@code <total>} tag.
+ *
+ * @param position the position of the opening tag in the source
+ * @param attributes the attributes declared on the tag
+ * @param children the child nodes in document order
+ * @param text the normalized text content
+ */
+public record TotalNode(SourcePosition position, Attributes attributes, List<Node> children, String text) implements Node {
+
+    /**
+     * Normalizes null components and defensively copies the children.
+     *
+     * @param position the position of the opening tag in the source
+     * @param attributes the attributes declared on the tag
+     * @param children the child nodes in document order
+     * @param text the normalized text content
+     */
+    public TotalNode {
+        attributes = attributes == null ? Attributes.EMPTY : attributes;
+        children = children == null ? List.of() : List.copyOf(children);
+        text = text == null ? "" : text;
+    }
+
+    @Override
+    public String tag() {
+        return "total";
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/Alignment.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/Alignment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+/**
+ * The horizontal alignment values of the document DSL's {@code align} attribute.
+ */
+public enum Alignment {
+
+    /** Align to the left edge — the default. */
+    LEFT,
+    /** Center horizontally. */
+    CENTER,
+    /** Align to the right edge. */
+    RIGHT,
+    /** Stretch text to both edges. */
+    JUSTIFY;
+
+    /**
+     * Parses a raw attribute value, case-insensitively.
+     *
+     * @param raw the value as authored; {@code null} and blank parse to {@link #LEFT}
+     * @return the alignment
+     * @throws IllegalArgumentException when the value is not a valid alignment
+     */
+    public static Alignment parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return LEFT;
+        }
+        return switch (raw.trim()
+                          .toLowerCase()) {
+            case "left" -> LEFT;
+            case "center" -> CENTER;
+            case "right" -> RIGHT;
+            case "justify" -> JUSTIFY;
+            default -> throw new IllegalArgumentException("Invalid alignment: '" + raw + "'");
+        };
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutEngine.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutEngine.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.ColumnNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.RowNode;
+import org.eclipse.dirigible.parsers.document.StackNode;
+import org.eclipse.dirigible.parsers.document.TableNode;
+
+/**
+ * Normalizes a parsed template into a {@link LayoutNode} tree: raw {@code width}/{@code height}/
+ * {@code align}/{@code flex} attribute strings become typed {@link Measurement}s and
+ * {@link Alignment}s, and table column widths can be resolved including fraction distribution.
+ *
+ * <p>
+ * The engine deliberately does NOT compute geometry: no coordinates, no pagination or
+ * {@code pageBreak} handling, no text measurement or wrapping, no percent-of-what resolution (that
+ * needs a concrete page width), no image loading, no Mustache evaluation and no
+ * {@code if}/{@code for} expansion. The layout tree stays template-shaped; a concrete
+ * {@code DocumentRenderer} adds geometry against a real page. Other attributes ({@code gap},
+ * {@code padding}, {@code margin}, {@code style}, ...) stay raw and reachable via
+ * {@code layoutNode.source().attributes()}.
+ */
+public final class LayoutEngine {
+
+    /**
+     * Creates an engine; instances are stateless and reusable.
+     */
+    public LayoutEngine() {}
+
+    /**
+     * Normalizes an AST into its layout tree.
+     *
+     * @param root the AST root
+     * @return the layout tree root
+     * @throws LayoutException when a {@code width}, {@code height}, {@code flex} or {@code align} value
+     *         is invalid, pointing at the attribute's source position
+     */
+    public LayoutNode layout(Node root) {
+        return layoutNode(root, false);
+    }
+
+    private LayoutNode layoutNode(Node node, boolean inFlexContainer) {
+        Measurement width = measurement(node, "width");
+        Measurement height = measurement(node, "height");
+        if (inFlexContainer && width.type() == Measurement.Type.AUTO && node.attributes()
+                                                                            .has("flex")) {
+            // flex="2" on a row/column/stack child is shorthand for width="2*"; explicit width wins
+            String flex = node.attributes()
+                              .get("flex");
+            try {
+                width = Measurement.parse(flex.trim() + "*");
+            } catch (IllegalArgumentException e) {
+                throw new LayoutException("Invalid flex value: '" + flex + "'", node.attributes()
+                                                                                    .positionOf("flex"));
+            }
+        }
+        Alignment alignment;
+        try {
+            alignment = Alignment.parse(node.attributes()
+                                            .get("align"));
+        } catch (IllegalArgumentException e) {
+            throw new LayoutException(e.getMessage(), node.attributes()
+                                                          .positionOf("align"));
+        }
+        boolean childrenInFlexContainer = node instanceof RowNode || node instanceof ColumnNode || node instanceof StackNode;
+        List<LayoutNode> children = new ArrayList<>(node.children()
+                                                        .size());
+        for (Node child : node.children()) {
+            children.add(layoutNode(child, childrenInFlexContainer));
+        }
+        return new LayoutNode(node, width, height, alignment, children);
+    }
+
+    private Measurement measurement(Node node, String attribute) {
+        try {
+            return Measurement.parse(node.attributes()
+                                         .get(attribute));
+        } catch (IllegalArgumentException e) {
+            throw new LayoutException(e.getMessage(), node.attributes()
+                                                          .positionOf(attribute));
+        }
+    }
+
+    /**
+     * The widths of a table's column definitions in declaration order; a column without a {@code width}
+     * defaults to {@code *} (fraction weight 1).
+     *
+     * @param table the table node
+     * @return the column widths
+     * @throws LayoutException when a column width is invalid
+     */
+    public static List<Measurement> resolveColumnWidths(TableNode table) {
+        List<Measurement> widths = new ArrayList<>();
+        for (Node child : table.children()) {
+            if (!(child instanceof ColumnNode column)) {
+                continue;
+            }
+            String raw = column.attributes()
+                               .get("width");
+            try {
+                Measurement width = Measurement.parse(raw);
+                widths.add(width.type() == Measurement.Type.AUTO ? Measurement.fraction(1) : width);
+            } catch (IllegalArgumentException e) {
+                throw new LayoutException(e.getMessage(), column.attributes()
+                                                                .positionOf("width"));
+            }
+        }
+        return widths;
+    }
+
+    /**
+     * The normalized weight of every measurement in the list: fraction entries share proportionally
+     * (e.g. {@code 4*, *, 2*, 2*} yields {@code 4/9, 1/9, 2/9, 2/9}); absolute, percent and auto
+     * entries get weight {@code 0} — a renderer sizes them first and distributes the leftover space by
+     * these weights.
+     *
+     * @param widths the column widths
+     * @return the weights, same size and order as the input
+     */
+    public static double[] fractionShares(List<Measurement> widths) {
+        double totalWeight = 0;
+        for (Measurement width : widths) {
+            if (width.type() == Measurement.Type.FRACTION) {
+                totalWeight += width.value();
+            }
+        }
+        double[] shares = new double[widths.size()];
+        if (totalWeight == 0) {
+            return shares;
+        }
+        for (int i = 0; i < widths.size(); i++) {
+            Measurement width = widths.get(i);
+            if (width.type() == Measurement.Type.FRACTION) {
+                shares[i] = width.value() / totalWeight;
+            }
+        }
+        return shares;
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutException.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import org.eclipse.dirigible.parsers.document.SourcePosition;
+
+/**
+ * Signals an invalid layout value (e.g. {@code width="banana"}) in an otherwise well-formed
+ * template, pointing at the offending attribute's source position.
+ */
+public class LayoutException extends RuntimeException {
+
+    /** The serial version UID. */
+    private static final long serialVersionUID = 1L;
+
+    /** The source position of the offending value. */
+    private final SourcePosition position;
+
+    /**
+     * Creates the exception.
+     *
+     * @param message the problem description
+     * @param position the source position of the offending value, may be {@code null} when unknown
+     */
+    public LayoutException(String message, SourcePosition position) {
+        super(position == null ? message : message + " at " + position);
+        this.position = position;
+    }
+
+    /**
+     * The source position of the offending value.
+     *
+     * @return the position, or {@code null} when unknown
+     */
+    public SourcePosition getPosition() {
+        return position;
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutNode.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/LayoutNode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.Node;
+
+/**
+ * One node of the normalized layout tree: the source AST node plus its resolved measurements and
+ * alignment. Carries no geometry — coordinates, pagination and text measurement belong to a
+ * concrete renderer.
+ *
+ * @param source the AST node this layout node was derived from
+ * @param width the resolved width
+ * @param height the resolved height
+ * @param alignment the resolved horizontal alignment
+ * @param children the child layout nodes in document order
+ */
+public record LayoutNode(Node source, Measurement width, Measurement height, Alignment alignment, List<LayoutNode> children) {
+
+    /**
+     * Defensively copies the children.
+     *
+     * @param source the AST node this layout node was derived from
+     * @param width the resolved width
+     * @param height the resolved height
+     * @param alignment the resolved horizontal alignment
+     * @param children the child layout nodes in document order
+     */
+    public LayoutNode {
+        children = children == null ? List.of() : List.copyOf(children);
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/Measurement.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/layout/Measurement.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+/**
+ * A parsed width/height/gap value of the document DSL. The supported forms are {@code 100} (pixels
+ * — a bare number is absolute), {@code 100px}, {@code 50%}, {@code *} (fraction weight 1), and
+ * {@code 2*} (fraction weight 2); a missing or {@code auto} value is {@link #AUTO}.
+ *
+ * @param type the measurement kind
+ * @param value the numeric amount; {@code 0} for {@link Type#AUTO}
+ */
+public record Measurement(Type type, double value) {
+
+    /** The measurement kinds. */
+    public enum Type {
+        /** An absolute length in pixels ({@code 100}, {@code 100px}). */
+        ABSOLUTE_PX,
+        /** A percentage of the enclosing space ({@code 50%}). */
+        PERCENT,
+        /** A weight in the space left after absolute and percent siblings ({@code *}, {@code 2*}). */
+        FRACTION,
+        /** Size to content — the default when no value is given. */
+        AUTO
+    }
+
+    /** The shared AUTO measurement. */
+    public static final Measurement AUTO = new Measurement(Type.AUTO, 0);
+
+    /**
+     * Validates the amount.
+     *
+     * @param type the measurement kind
+     * @param value the numeric amount
+     */
+    public Measurement {
+        if (value < 0) {
+            throw new IllegalArgumentException("Measurement value must not be negative: " + value);
+        }
+    }
+
+    /**
+     * Parses a raw attribute value.
+     *
+     * @param raw the value as authored, e.g. {@code "50%"}; {@code null}, blank and {@code "auto"}
+     *        parse to {@link #AUTO}
+     * @return the measurement
+     * @throws IllegalArgumentException when the value is not a valid measurement
+     */
+    public static Measurement parse(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return AUTO;
+        }
+        String value = raw.trim();
+        if (value.equalsIgnoreCase("auto")) {
+            return AUTO;
+        }
+        try {
+            if (value.equals("*")) {
+                return fraction(1);
+            }
+            if (value.endsWith("*")) {
+                return fraction(parseAmount(value.substring(0, value.length() - 1)));
+            }
+            if (value.endsWith("%")) {
+                return percent(parseAmount(value.substring(0, value.length() - 1)));
+            }
+            if (value.endsWith("px")) {
+                return px(parseAmount(value.substring(0, value.length() - 2)));
+            }
+            return px(parseAmount(value));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid measurement: '" + raw + "'");
+        }
+    }
+
+    private static double parseAmount(String amount) {
+        String trimmed = amount.trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Missing amount");
+        }
+        // strictly digits with at most one decimal point — Double.parseDouble alone would also
+        // accept scientific notation, hex floats and type suffixes like "1d"
+        boolean dotSeen = false;
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            if (c == '.') {
+                if (dotSeen || trimmed.length() == 1) {
+                    throw new IllegalArgumentException("Invalid amount");
+                }
+                dotSeen = true;
+            } else if (c < '0' || c > '9') {
+                throw new IllegalArgumentException("Invalid amount");
+            }
+        }
+        return Double.parseDouble(trimmed);
+    }
+
+    /**
+     * An absolute pixel measurement.
+     *
+     * @param value the length in pixels
+     * @return the measurement
+     */
+    public static Measurement px(double value) {
+        return new Measurement(Type.ABSOLUTE_PX, value);
+    }
+
+    /**
+     * A percentage measurement.
+     *
+     * @param value the percentage
+     * @return the measurement
+     */
+    public static Measurement percent(double value) {
+        return new Measurement(Type.PERCENT, value);
+    }
+
+    /**
+     * A fraction-weight measurement.
+     *
+     * @param value the weight
+     * @return the measurement
+     */
+    public static Measurement fraction(double value) {
+        return new Measurement(Type.FRACTION, value);
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/DocumentParser.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/DocumentParser.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.dirigible.parsers.document.Attributes;
+import org.eclipse.dirigible.parsers.document.DocumentNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.SourcePosition;
+
+/**
+ * The hand-written recursive-descent parser of the document-template DSL. It produces the typed
+ * {@link Node} AST and deliberately does NOT evaluate Mustache placeholders — <code>{{...}}</code>
+ * sequences in text and attribute values survive verbatim for a later data-binding layer.
+ *
+ * <p>
+ * The grammar is XML-like with business-user leniencies: only the five named entities
+ * ({@code &lt; &gt; &amp; &quot; &apos;}) are decoded and a raw {@code &} that does not form one is
+ * literal text; comments and an optional XML prolog are skipped; attribute values may use single or
+ * double quotes. Unknown tags are a parse error — extend the DSL by registering tags on a
+ * {@link TagRegistry}. Parsing is deterministic and instances are stateless per parse, so a parser
+ * may be reused and shared.
+ */
+public final class DocumentParser {
+
+    private final TagRegistry registry;
+
+    /**
+     * Creates a parser over the built-in tag registry.
+     */
+    public DocumentParser() {
+        this(TagRegistry.builtIn());
+    }
+
+    /**
+     * Creates a parser over a custom tag registry.
+     *
+     * @param registry the registry resolving tag names to node factories
+     */
+    public DocumentParser(TagRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+    }
+
+    /**
+     * Parses a template into its AST.
+     *
+     * @param source the template source
+     * @return the root node
+     * @throws ParseException on any syntax error, with the exact line and column
+     */
+    public Node parse(String source) {
+        Objects.requireNonNull(source, "source");
+        Scanner scanner = new Scanner(source);
+        if (scanner.lookingAt("\uFEFF")) {
+            scanner.skip(1);
+        }
+        skipMisc(scanner);
+        skipProlog(scanner);
+        skipMisc(scanner);
+        if (scanner.eof() || scanner.peek() != '<') {
+            throw scanner.error("Expected '<' to start the root element");
+        }
+        Node root = parseElement(scanner);
+        skipMisc(scanner);
+        if (!scanner.eof()) {
+            throw scanner.error("Unexpected content after the root element");
+        }
+        return root;
+    }
+
+    /**
+     * Parses a template and requires the root element to be {@code <document>}.
+     *
+     * @param source the template source
+     * @return the root document node
+     * @throws ParseException on any syntax error or when the root is not {@code <document>}
+     */
+    public DocumentNode parseDocument(String source) {
+        Node root = parse(source);
+        if (root instanceof DocumentNode document) {
+            return document;
+        }
+        throw new ParseException("Root element must be <document> but was <" + root.tag() + ">", root.position()
+                                                                                                     .line(),
+                root.position()
+                    .column());
+    }
+
+    private Node parseElement(Scanner scanner) {
+        SourcePosition start = scanner.position();
+        scanner.skip(1); // the '<'
+        String tag = parseName(scanner, "tag name");
+        NodeFactory factory = registry.factory(tag);
+        if (factory == null) {
+            throw scanner.errorAt("Unknown tag <" + tag + ">. Register it via TagRegistry.register(...)", start);
+        }
+        List<Attributes.Attribute> attributes = new ArrayList<>();
+        while (true) {
+            skipWhitespace(scanner);
+            if (scanner.eof()) {
+                throw scanner.errorAt("Unclosed element <" + tag + ">", start);
+            }
+            if (scanner.lookingAt("/>")) {
+                scanner.skip(2);
+                return factory.create(tag, start, Attributes.of(attributes), List.of(), "");
+            }
+            if (scanner.peek() == '>') {
+                scanner.skip(1);
+                return parseContent(scanner, tag, start, factory, attributes);
+            }
+            parseAttribute(scanner, attributes);
+        }
+    }
+
+    private void parseAttribute(Scanner scanner, List<Attributes.Attribute> attributes) {
+        SourcePosition position = scanner.position();
+        String name = parseName(scanner, "attribute name");
+        for (Attributes.Attribute existing : attributes) {
+            if (existing.name()
+                        .equals(name)) {
+                throw scanner.errorAt("Duplicate attribute '" + name + "'", position);
+            }
+        }
+        skipWhitespace(scanner);
+        if (scanner.eof() || scanner.peek() != '=') {
+            throw scanner.error("Expected '=' after attribute name '" + name + "'");
+        }
+        scanner.skip(1);
+        skipWhitespace(scanner);
+        if (scanner.eof() || (scanner.peek() != '"' && scanner.peek() != '\'')) {
+            throw scanner.error("Attribute value must be quoted");
+        }
+        SourcePosition quotePosition = scanner.position();
+        char quote = scanner.next();
+        StringBuilder value = new StringBuilder();
+        while (true) {
+            if (scanner.eof()) {
+                throw scanner.errorAt("Unterminated attribute value", quotePosition);
+            }
+            char c = scanner.peek();
+            if (c == quote) {
+                scanner.skip(1);
+                break;
+            }
+            if (c == '&') {
+                value.append(readEntityOrAmpersand(scanner));
+            } else {
+                value.append(scanner.next());
+            }
+        }
+        attributes.add(new Attributes.Attribute(name, value.toString(), position));
+    }
+
+    private Node parseContent(Scanner scanner, String tag, SourcePosition start, NodeFactory factory,
+            List<Attributes.Attribute> attributes) {
+        List<Node> children = new ArrayList<>();
+        StringBuilder text = new StringBuilder();
+        while (true) {
+            if (scanner.eof()) {
+                throw scanner.errorAt("Unclosed element <" + tag + ">", start);
+            }
+            if (scanner.lookingAt("<!--")) {
+                skipComment(scanner);
+            } else if (scanner.lookingAt("</")) {
+                SourcePosition closePosition = scanner.position();
+                scanner.skip(2);
+                String closeTag = parseName(scanner, "closing tag name");
+                skipWhitespace(scanner);
+                if (scanner.eof() || scanner.peek() != '>') {
+                    throw scanner.error("Expected '>' to end the closing tag </" + closeTag + ">");
+                }
+                scanner.skip(1);
+                if (!closeTag.equals(tag)) {
+                    throw scanner.errorAt("Mismatched closing tag: expected </" + tag + ">, found </" + closeTag + ">", closePosition);
+                }
+                return factory.create(tag, start, Attributes.of(attributes), children, normalize(text));
+            } else if (scanner.peek() == '<') {
+                children.add(parseElement(scanner));
+            } else if (scanner.peek() == '&') {
+                text.append(readEntityOrAmpersand(scanner));
+            } else {
+                text.append(scanner.next());
+            }
+        }
+    }
+
+    private String parseName(Scanner scanner, String what) {
+        if (scanner.eof() || !isNameStart(scanner.peek())) {
+            throw scanner.error("Invalid " + what);
+        }
+        StringBuilder name = new StringBuilder();
+        name.append(scanner.next());
+        while (!scanner.eof() && isNameChar(scanner.peek())) {
+            name.append(scanner.next());
+        }
+        return name.toString();
+    }
+
+    private static boolean isNameStart(char c) {
+        return Character.isLetter(c) || c == '_';
+    }
+
+    private static boolean isNameChar(char c) {
+        return Character.isLetterOrDigit(c) || c == '-' || c == '_' || c == '.';
+    }
+
+    /**
+     * Decodes one of the five named entities, or returns a literal ampersand when the input does not
+     * form one — the business-user leniency that keeps "Fruit & Veg" a valid text.
+     */
+    private char readEntityOrAmpersand(Scanner scanner) {
+        if (scanner.lookingAt("&lt;")) {
+            scanner.skip(4);
+            return '<';
+        }
+        if (scanner.lookingAt("&gt;")) {
+            scanner.skip(4);
+            return '>';
+        }
+        if (scanner.lookingAt("&amp;")) {
+            scanner.skip(5);
+            return '&';
+        }
+        if (scanner.lookingAt("&quot;")) {
+            scanner.skip(6);
+            return '"';
+        }
+        if (scanner.lookingAt("&apos;")) {
+            scanner.skip(6);
+            return '\'';
+        }
+        scanner.skip(1);
+        return '&';
+    }
+
+    private void skipProlog(Scanner scanner) {
+        if (!scanner.lookingAt("<?xml")) {
+            return;
+        }
+        SourcePosition start = scanner.position();
+        while (!scanner.lookingAt("?>")) {
+            if (scanner.eof()) {
+                throw scanner.errorAt("Unterminated XML prolog", start);
+            }
+            scanner.skip(1);
+        }
+        scanner.skip(2);
+    }
+
+    private void skipMisc(Scanner scanner) {
+        while (true) {
+            skipWhitespace(scanner);
+            if (scanner.lookingAt("<!--")) {
+                skipComment(scanner);
+            } else {
+                return;
+            }
+        }
+    }
+
+    private void skipComment(Scanner scanner) {
+        SourcePosition start = scanner.position();
+        scanner.skip(4); // the '<!--'
+        while (!scanner.lookingAt("-->")) {
+            if (scanner.eof()) {
+                throw scanner.errorAt("Unterminated comment", start);
+            }
+            scanner.skip(1);
+        }
+        scanner.skip(3);
+    }
+
+    private static void skipWhitespace(Scanner scanner) {
+        while (!scanner.eof() && Character.isWhitespace(scanner.peek())) {
+            scanner.skip(1);
+        }
+    }
+
+    /** Collapses whitespace runs to single spaces and trims — deterministic text content. */
+    private static String normalize(StringBuilder text) {
+        StringBuilder normalized = new StringBuilder(text.length());
+        boolean pendingSpace = false;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+                pendingSpace = normalized.length() > 0;
+            } else {
+                if (pendingSpace) {
+                    normalized.append(' ');
+                    pendingSpace = false;
+                }
+                normalized.append(c);
+            }
+        }
+        return normalized.toString();
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/NodeFactory.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/NodeFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.Attributes;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.SourcePosition;
+
+/**
+ * Builds an AST node for a parsed element. The {@link TagRegistry} maps each tag name to one
+ * factory; registering a factory is how new tags extend the DSL without touching the parser.
+ */
+@FunctionalInterface
+public interface NodeFactory {
+
+    /**
+     * Creates the node for a fully parsed element.
+     *
+     * @param tag the tag name
+     * @param position the position of the opening tag in the source
+     * @param attributes the parsed attributes
+     * @param children the parsed child nodes in document order
+     * @param text the normalized text content
+     * @return the AST node
+     */
+    Node create(String tag, SourcePosition position, Attributes attributes, List<Node> children, String text);
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/ParseException.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/ParseException.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+/**
+ * Signals a syntax error in a document template. The message always names the exact 1-based line
+ * and column, e.g. {@code "Mismatched closing tag: expected </row>, found </column> at line 12,
+ * column 5"}. Unchecked because template errors are end-user data errors surfaced at a single parse
+ * call site.
+ */
+public class ParseException extends RuntimeException {
+
+    /** The serial version UID. */
+    private static final long serialVersionUID = 1L;
+
+    /** The 1-based line of the error. */
+    private final int line;
+
+    /** The 1-based column of the error. */
+    private final int column;
+
+    /**
+     * Creates the exception.
+     *
+     * @param message the problem description, without position suffix
+     * @param line the 1-based line of the error
+     * @param column the 1-based column of the error
+     */
+    public ParseException(String message, int line, int column) {
+        super(message + " at line " + line + ", column " + column);
+        this.line = line;
+        this.column = column;
+    }
+
+    /**
+     * The 1-based line of the error.
+     *
+     * @return the line
+     */
+    public int getLine() {
+        return line;
+    }
+
+    /**
+     * The 1-based column of the error.
+     *
+     * @return the column
+     */
+    public int getColumn() {
+        return column;
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/Scanner.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/Scanner.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import org.eclipse.dirigible.parsers.document.SourcePosition;
+
+/**
+ * A character-level cursor over the template source with 1-based line/column tracking. All position
+ * arithmetic lives here so every {@link ParseException} carries a correct location.
+ */
+final class Scanner {
+
+    private final String source;
+    private int pos = 0;
+    private int line = 1;
+    private int column = 1;
+
+    Scanner(String source) {
+        this.source = source;
+    }
+
+    boolean eof() {
+        return pos >= source.length();
+    }
+
+    char peek() {
+        return source.charAt(pos);
+    }
+
+    boolean lookingAt(String prefix) {
+        return source.startsWith(prefix, pos);
+    }
+
+    char next() {
+        char c = source.charAt(pos++);
+        // \n and a lone \r advance the line; the \n of a \r\n pair does the advancing for both
+        if (c == '\n' || (c == '\r' && (pos >= source.length() || source.charAt(pos) != '\n'))) {
+            line++;
+            column = 1;
+        } else {
+            column++;
+        }
+        return c;
+    }
+
+    void skip(int count) {
+        for (int i = 0; i < count; i++) {
+            next();
+        }
+    }
+
+    int line() {
+        return line;
+    }
+
+    int column() {
+        return column;
+    }
+
+    SourcePosition position() {
+        return SourcePosition.of(line, column);
+    }
+
+    ParseException error(String message) {
+        return new ParseException(message, line, column);
+    }
+
+    ParseException errorAt(String message, SourcePosition position) {
+        return new ParseException(message, position.line(), position.column());
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/TagRegistry.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/parser/TagRegistry.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.dirigible.parsers.document.ColumnNode;
+import org.eclipse.dirigible.parsers.document.CustomNode;
+import org.eclipse.dirigible.parsers.document.DocumentNode;
+import org.eclipse.dirigible.parsers.document.FieldNode;
+import org.eclipse.dirigible.parsers.document.FooterNode;
+import org.eclipse.dirigible.parsers.document.ForNode;
+import org.eclipse.dirigible.parsers.document.HeaderNode;
+import org.eclipse.dirigible.parsers.document.IfNode;
+import org.eclipse.dirigible.parsers.document.ImageNode;
+import org.eclipse.dirigible.parsers.document.LineNode;
+import org.eclipse.dirigible.parsers.document.PageNode;
+import org.eclipse.dirigible.parsers.document.RowNode;
+import org.eclipse.dirigible.parsers.document.SectionNode;
+import org.eclipse.dirigible.parsers.document.SpaceNode;
+import org.eclipse.dirigible.parsers.document.StackNode;
+import org.eclipse.dirigible.parsers.document.TableNode;
+import org.eclipse.dirigible.parsers.document.TextNode;
+import org.eclipse.dirigible.parsers.document.TotalNode;
+
+/**
+ * The tag-name-to-factory registry the parser resolves elements against. Tag names are
+ * case-sensitive lowercase. Unknown tags are a parse error — a typo like {@code <colum>} in a
+ * printable document must fail fast rather than silently drop content — so extending the DSL is an
+ * explicit, one-line registration:
+ *
+ * <pre>
+ * TagRegistry registry = TagRegistry.builtIn();
+ * registry.register("qrcode"); // parses to CustomNode
+ * </pre>
+ */
+public final class TagRegistry {
+
+    private final Map<String, NodeFactory> factories = new LinkedHashMap<>();
+
+    private TagRegistry() {}
+
+    /**
+     * Creates a registry pre-populated with the built-in tags: document, page, header, footer, section,
+     * row, column, stack, text, field, table, image, line, space, total, if, for.
+     *
+     * @return the registry
+     */
+    public static TagRegistry builtIn() {
+        TagRegistry registry = new TagRegistry();
+        registry.register("document",
+                (tag, position, attributes, children, text) -> new DocumentNode(position, attributes, children, text));
+        registry.register("page", (tag, position, attributes, children, text) -> new PageNode(position, attributes, children, text));
+        registry.register("header", (tag, position, attributes, children, text) -> new HeaderNode(position, attributes, children, text));
+        registry.register("footer", (tag, position, attributes, children, text) -> new FooterNode(position, attributes, children, text));
+        registry.register("section", (tag, position, attributes, children, text) -> new SectionNode(position, attributes, children, text));
+        registry.register("row", (tag, position, attributes, children, text) -> new RowNode(position, attributes, children, text));
+        registry.register("column", (tag, position, attributes, children, text) -> new ColumnNode(position, attributes, children, text));
+        registry.register("stack", (tag, position, attributes, children, text) -> new StackNode(position, attributes, children, text));
+        registry.register("text", (tag, position, attributes, children, text) -> new TextNode(position, attributes, children, text));
+        registry.register("field", (tag, position, attributes, children, text) -> new FieldNode(position, attributes, children, text));
+        registry.register("table", (tag, position, attributes, children, text) -> new TableNode(position, attributes, children, text));
+        registry.register("image", (tag, position, attributes, children, text) -> new ImageNode(position, attributes, children, text));
+        registry.register("line", (tag, position, attributes, children, text) -> new LineNode(position, attributes, children, text));
+        registry.register("space", (tag, position, attributes, children, text) -> new SpaceNode(position, attributes, children, text));
+        registry.register("total", (tag, position, attributes, children, text) -> new TotalNode(position, attributes, children, text));
+        registry.register("if", (tag, position, attributes, children, text) -> new IfNode(position, attributes, children, text));
+        registry.register("for", (tag, position, attributes, children, text) -> new ForNode(position, attributes, children, text));
+        return registry;
+    }
+
+    /**
+     * Registers an extension tag that parses to {@link CustomNode}.
+     *
+     * @param tag the tag name
+     */
+    public void register(String tag) {
+        register(tag, CustomNode::new);
+    }
+
+    /**
+     * Registers an extension tag with a custom node factory, replacing any previous registration.
+     *
+     * @param tag the tag name
+     * @param factory the factory producing the node
+     */
+    public void register(String tag, NodeFactory factory) {
+        if (tag == null || tag.isBlank()) {
+            throw new IllegalArgumentException("Tag name must not be blank");
+        }
+        if (factory == null) {
+            throw new IllegalArgumentException("Factory must not be null");
+        }
+        factories.put(tag, factory);
+    }
+
+    /**
+     * Whether the tag is registered.
+     *
+     * @param tag the tag name
+     * @return {@code true} when registered
+     */
+    public boolean isRegistered(String tag) {
+        return factories.containsKey(tag);
+    }
+
+    /**
+     * The factory for a registered tag.
+     *
+     * @param tag the tag name
+     * @return the factory, or {@code null} when the tag is not registered
+     */
+    public NodeFactory factory(String tag) {
+        return factories.get(tag);
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/renderer/DocumentRenderer.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/renderer/DocumentRenderer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.renderer;
+
+import org.eclipse.dirigible.parsers.document.layout.LayoutNode;
+
+/**
+ * The extension seam for concrete rendering backends. A renderer receives the normalized layout
+ * tree (data already merged, {@code if}/{@code for} expanded by the caller's data-binding layer)
+ * and produces its output form — e.g. an XSL-FO document for the platform's PDF pipeline.
+ *
+ * @param <T> the output type, e.g. {@code String} for an XSL-FO renderer
+ */
+public interface DocumentRenderer<T> {
+
+    /**
+     * Renders the layout tree.
+     *
+     * @param root the layout tree root
+     * @return the rendered output
+     */
+    T render(LayoutNode root);
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/SampleTemplatesTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/SampleTemplatesTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.junit.Test;
+
+/**
+ * Parses the shipped example templates — one per supported business document — and deep-asserts the
+ * canonical sales invoice.
+ */
+public class SampleTemplatesTest {
+
+    private static final List<String> TEMPLATES =
+            List.of("sales-invoice", "purchase-order", "quote", "delivery-note", "receipt", "statement", "credit-note");
+
+    private final DocumentParser parser = new DocumentParser();
+
+    private static String load(String name) throws IOException {
+        try (InputStream in = SampleTemplatesTest.class.getResourceAsStream("/templates/" + name + ".print")) {
+            assertNotNull("Missing sample template: " + name, in);
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    @Test
+    public void allSampleTemplatesParse() throws IOException {
+        for (String template : TEMPLATES) {
+            DocumentNode document = parser.parseDocument(load(template));
+            assertEquals(template, document.attributes()
+                                           .get("id"));
+        }
+    }
+
+    @Test
+    public void salesInvoiceHasTheExpectedStructure() throws IOException {
+        DocumentNode document = parser.parseDocument(load("sales-invoice"));
+
+        assertEquals(1, document.children()
+                                .size());
+        Node page = document.children()
+                            .get(0);
+        assertTrue(page instanceof PageNode);
+        assertEquals("595", page.attributes()
+                                .get("width"));
+
+        List<Node> parts = page.children();
+        assertTrue(parts.get(0) instanceof HeaderNode);
+        assertTrue(parts.get(1) instanceof SectionNode);
+        assertTrue(parts.get(2) instanceof SectionNode);
+        assertTrue(parts.get(3) instanceof SpaceNode);
+        assertTrue(parts.get(4) instanceof TableNode);
+        assertTrue(parts.get(5) instanceof SectionNode);
+        assertTrue(parts.get(6) instanceof FooterNode);
+
+        TableNode table = (TableNode) parts.get(4);
+        assertEquals("invoice.items", table.attributes()
+                                           .get("source"));
+        assertEquals(4, table.children()
+                             .size());
+        ColumnNode description = (ColumnNode) table.children()
+                                                   .get(0);
+        assertEquals("45%", description.attributes()
+                                       .get("width"));
+        assertEquals("{{description}}", description.text());
+
+        SectionNode totals = (SectionNode) parts.get(5);
+        Node lastTotalsChild = totals.children()
+                                     .get(totals.children()
+                                                .size()
+                                             - 1);
+        assertTrue(lastTotalsChild instanceof TotalNode);
+        assertEquals("{{invoice.total}}", lastTotalsChild.text());
+        assertTrue(totals.children()
+                         .get(1) instanceof IfNode);
+
+        FooterNode footer = (FooterNode) parts.get(6);
+        assertEquals("Terms & Conditions apply — Page {{page}} of {{pages}}", footer.children()
+                                                                                    .get(0)
+                                                                                    .text());
+    }
+
+    @Test
+    public void receiptKeepsTheRawAmpersand() throws IOException {
+        DocumentNode document = parser.parseDocument(load("receipt"));
+        String all = flattenText(document);
+        assertTrue(all.contains("Cash & Card"));
+    }
+
+    private static String flattenText(Node node) {
+        StringBuilder text = new StringBuilder(node.text());
+        for (Node child : node.children()) {
+            text.append(' ')
+                .append(flattenText(child));
+        }
+        return text.toString();
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/AlignmentTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/AlignmentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class AlignmentTest {
+
+    @Test
+    public void parsesAllValuesCaseInsensitively() {
+        assertEquals(Alignment.LEFT, Alignment.parse("left"));
+        assertEquals(Alignment.CENTER, Alignment.parse("Center"));
+        assertEquals(Alignment.RIGHT, Alignment.parse("RIGHT"));
+        assertEquals(Alignment.JUSTIFY, Alignment.parse("justify"));
+    }
+
+    @Test
+    public void missingValueDefaultsToLeft() {
+        assertEquals(Alignment.LEFT, Alignment.parse(null));
+        assertEquals(Alignment.LEFT, Alignment.parse(""));
+        assertEquals(Alignment.LEFT, Alignment.parse("   "));
+    }
+
+    @Test
+    public void rejectsUnknownValues() {
+        try {
+            Alignment.parse("middle");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid alignment: 'middle'", e.getMessage());
+        }
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/LayoutEngineTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/LayoutEngineTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.TableNode;
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.junit.Test;
+
+public class LayoutEngineTest {
+
+    private final DocumentParser parser = new DocumentParser();
+    private final LayoutEngine engine = new LayoutEngine();
+
+    @Test
+    public void layoutTreeMirrorsTheAst() {
+        Node root = parser.parse("<document><section><text>Hi</text></section></document>");
+        LayoutNode layout = engine.layout(root);
+        assertSame(root, layout.source());
+        assertEquals(1, layout.children()
+                              .size());
+        assertEquals(1, layout.children()
+                              .get(0)
+                              .children()
+                              .size());
+        assertEquals("text", layout.children()
+                                   .get(0)
+                                   .children()
+                                   .get(0)
+                                   .source()
+                                   .tag());
+    }
+
+    @Test
+    public void defaultsAreAutoAndLeft() {
+        LayoutNode layout = engine.layout(parser.parse("<document/>"));
+        assertSame(Measurement.AUTO, layout.width());
+        assertSame(Measurement.AUTO, layout.height());
+        assertEquals(Alignment.LEFT, layout.alignment());
+    }
+
+    @Test
+    public void explicitValuesAreResolved() {
+        LayoutNode layout = engine.layout(parser.parse("<document width=\"595\" height=\"842\" align=\"center\"/>"));
+        assertEquals(Measurement.px(595), layout.width());
+        assertEquals(Measurement.px(842), layout.height());
+        assertEquals(Alignment.CENTER, layout.alignment());
+    }
+
+    @Test
+    public void flexBecomesFractionInsideFlexContainers() {
+        Node root = parser.parse("<document><row><stack flex=\"2\"/><stack flex=\"1\"/></row></document>");
+        LayoutNode row = engine.layout(root)
+                               .children()
+                               .get(0);
+        assertEquals(Measurement.fraction(2), row.children()
+                                                 .get(0)
+                                                 .width());
+        assertEquals(Measurement.fraction(1), row.children()
+                                                 .get(1)
+                                                 .width());
+    }
+
+    @Test
+    public void explicitWidthWinsOverFlex() {
+        Node root = parser.parse("<document><row><stack flex=\"2\" width=\"100\"/></row></document>");
+        LayoutNode stack = engine.layout(root)
+                                 .children()
+                                 .get(0)
+                                 .children()
+                                 .get(0);
+        assertEquals(Measurement.px(100), stack.width());
+    }
+
+    @Test
+    public void flexOutsideFlexContainersIsIgnored() {
+        Node root = parser.parse("<document><section flex=\"2\"/></document>");
+        LayoutNode section = engine.layout(root)
+                                   .children()
+                                   .get(0);
+        assertSame(Measurement.AUTO, section.width());
+    }
+
+    @Test
+    public void resolvesColumnWidthsWithFractionDefault() {
+        Node root = parser.parse("""
+                <document>
+                    <table source="invoice.items">
+                        <column width="4*">{{a}}</column>
+                        <column>{{b}}</column>
+                        <column width="2*">{{c}}</column>
+                        <column width="2*">{{d}}</column>
+                    </table>
+                </document>
+                """);
+        TableNode table = (TableNode) root.children()
+                                          .get(0);
+        List<Measurement> widths = LayoutEngine.resolveColumnWidths(table);
+        assertEquals(List.of(Measurement.fraction(4), Measurement.fraction(1), Measurement.fraction(2), Measurement.fraction(2)), widths);
+    }
+
+    @Test
+    public void fractionSharesNormalizeWeights() {
+        double[] shares = LayoutEngine.fractionShares(
+                List.of(Measurement.fraction(4), Measurement.fraction(1), Measurement.fraction(2), Measurement.fraction(2)));
+        assertEquals(4.0 / 9, shares[0], 0.000001);
+        assertEquals(1.0 / 9, shares[1], 0.000001);
+        assertEquals(2.0 / 9, shares[2], 0.000001);
+        assertEquals(2.0 / 9, shares[3], 0.000001);
+    }
+
+    @Test
+    public void fractionSharesSkipAbsoluteAndPercentEntries() {
+        double[] shares = LayoutEngine.fractionShares(List.of(Measurement.px(100), Measurement.fraction(1), Measurement.fraction(2)));
+        assertEquals(0, shares[0], 0.000001);
+        assertEquals(1.0 / 3, shares[1], 0.000001);
+        assertEquals(2.0 / 3, shares[2], 0.000001);
+    }
+
+    @Test
+    public void fractionSharesWithoutFractionsAreAllZero() {
+        double[] shares = LayoutEngine.fractionShares(List.of(Measurement.px(100), Measurement.percent(50)));
+        assertEquals(0, shares[0], 0.000001);
+        assertEquals(0, shares[1], 0.000001);
+    }
+
+    @Test
+    public void invalidWidthFailsWithTheAttributePosition() {
+        Node root = parser.parse("<document>\n  <text width=\"banana\">x</text>\n</document>");
+        try {
+            engine.layout(root);
+            fail("Expected LayoutException");
+        } catch (LayoutException e) {
+            assertEquals(2, e.getPosition()
+                             .line());
+            assertEquals(9, e.getPosition()
+                             .column());
+        }
+    }
+
+    @Test
+    public void invalidAlignFailsWithTheAttributePosition() {
+        Node root = parser.parse("<document><text align=\"middle\">x</text></document>");
+        try {
+            engine.layout(root);
+            fail("Expected LayoutException");
+        } catch (LayoutException e) {
+            assertEquals(17, e.getPosition()
+                              .column());
+        }
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/MeasurementTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/layout/MeasurementTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.layout;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+public class MeasurementTest {
+
+    private static void assertMeasurement(Measurement.Type type, double value, String raw) {
+        Measurement measurement = Measurement.parse(raw);
+        assertEquals(type, measurement.type());
+        assertEquals(value, measurement.value(), 0.000001);
+    }
+
+    @Test
+    public void parsesAbsolutePixels() {
+        assertMeasurement(Measurement.Type.ABSOLUTE_PX, 100, "100");
+        assertMeasurement(Measurement.Type.ABSOLUTE_PX, 100, "100px");
+        assertMeasurement(Measurement.Type.ABSOLUTE_PX, 12.5, "12.5");
+        assertMeasurement(Measurement.Type.ABSOLUTE_PX, 0, "0");
+    }
+
+    @Test
+    public void parsesPercent() {
+        assertMeasurement(Measurement.Type.PERCENT, 50, "50%");
+        assertMeasurement(Measurement.Type.PERCENT, 33.3, "33.3%");
+    }
+
+    @Test
+    public void parsesFractions() {
+        assertMeasurement(Measurement.Type.FRACTION, 1, "*");
+        assertMeasurement(Measurement.Type.FRACTION, 2, "2*");
+        assertMeasurement(Measurement.Type.FRACTION, 3, "3*");
+        assertMeasurement(Measurement.Type.FRACTION, 1.5, "1.5*");
+    }
+
+    @Test
+    public void parsesAuto() {
+        assertSame(Measurement.AUTO, Measurement.parse(null));
+        assertSame(Measurement.AUTO, Measurement.parse(""));
+        assertSame(Measurement.AUTO, Measurement.parse("  "));
+        assertSame(Measurement.AUTO, Measurement.parse("auto"));
+        assertSame(Measurement.AUTO, Measurement.parse("AUTO"));
+    }
+
+    @Test
+    public void toleratesSurroundingWhitespace() {
+        assertMeasurement(Measurement.Type.PERCENT, 50, " 50% ");
+    }
+
+    @Test
+    public void rejectsInvalidValues() {
+        for (String invalid : new String[] {"10em", "px", "-5", "*2", "5%%", "abc", "1e3", "1d", ".", "1.2.3", "%"}) {
+            try {
+                Measurement.parse(invalid);
+                fail("Expected IllegalArgumentException for '" + invalid + "'");
+            } catch (IllegalArgumentException e) {
+                assertTrue("Message should name the raw input: " + e.getMessage(), e.getMessage()
+                                                                                    .contains(invalid.trim()));
+            }
+        }
+    }
+
+    @Test
+    public void rejectsNegativeConstruction() {
+        try {
+            Measurement.px(-1);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/DocumentParserTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/DocumentParserTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.dirigible.parsers.document.DocumentNode;
+import org.eclipse.dirigible.parsers.document.FieldNode;
+import org.eclipse.dirigible.parsers.document.HeaderNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.SectionNode;
+import org.eclipse.dirigible.parsers.document.TextNode;
+import org.junit.Test;
+
+public class DocumentParserTest {
+
+    private final DocumentParser parser = new DocumentParser();
+
+    @Test
+    public void parsesNestedStructureInDocumentOrder() {
+        Node root = parser.parse("""
+                <document>
+                    <header>
+                        <text align="right" style="title">Sales Invoice</text>
+                    </header>
+                    <section>
+                        <field label="Invoice No">{{invoice.number}}</field>
+                        <field label="Date">{{invoice.date}}</field>
+                    </section>
+                </document>
+                """);
+        assertTrue(root instanceof DocumentNode);
+        assertEquals(2, root.children()
+                            .size());
+        assertTrue(root.children()
+                       .get(0) instanceof HeaderNode);
+        assertTrue(root.children()
+                       .get(1) instanceof SectionNode);
+        Node section = root.children()
+                           .get(1);
+        assertEquals(2, section.children()
+                               .size());
+        FieldNode first = (FieldNode) section.children()
+                                             .get(0);
+        assertEquals("Invoice No", first.attributes()
+                                        .get("label"));
+        assertEquals("{{invoice.number}}", first.text());
+    }
+
+    @Test
+    public void parsesAttributesWithSingleAndDoubleQuotes() {
+        Node root = parser.parse("<document><text align='right' style=\"title caption\">Hi</text></document>");
+        Node text = root.children()
+                        .get(0);
+        assertEquals("right", text.attributes()
+                                  .get("align"));
+        assertEquals("title caption", text.attributes()
+                                          .get("style"));
+    }
+
+    @Test
+    public void selfClosingTagHasNoChildrenAndEmptyText() {
+        Node root = parser.parse("<document><line/><space height=\"20\" /></document>");
+        assertEquals(2, root.children()
+                            .size());
+        Node space = root.children()
+                         .get(1);
+        assertEquals("space", space.tag());
+        assertEquals(0, space.children()
+                             .size());
+        assertEquals("", space.text());
+        assertEquals("20", space.attributes()
+                                .get("height"));
+    }
+
+    @Test
+    public void textIsTrimmedAndWhitespaceCollapsed() {
+        Node root = parser.parse("<document><text>  Hello \n\t  World  </text></document>");
+        assertEquals("Hello World", root.children()
+                                        .get(0)
+                                        .text());
+    }
+
+    @Test
+    public void whitespaceOnlyContentIsEmptyText() {
+        Node root = parser.parse("<document><section>\n   \n</section></document>");
+        assertEquals("", root.children()
+                             .get(0)
+                             .text());
+    }
+
+    @Test
+    public void mixedContentConcatenatesTextAroundChildren() {
+        Node root = parser.parse("<document><text>Total: <line/> due now</text></document>");
+        TextNode text = (TextNode) root.children()
+                                       .get(0);
+        assertEquals("Total: due now", text.text());
+        assertEquals(1, text.children()
+                            .size());
+        assertEquals("line", text.children()
+                                 .get(0)
+                                 .tag());
+    }
+
+    @Test
+    public void attributeValuesKeepInnerWhitespaceVerbatim() {
+        Node root = parser.parse("<document><field label=\"Invoice   No\"/></document>");
+        assertEquals("Invoice   No", root.children()
+                                         .get(0)
+                                         .attributes()
+                                         .get("label"));
+    }
+
+    @Test
+    public void nodePositionsPointAtTheOpeningTag() {
+        Node root = parser.parse("<document>\n  <header>\n    <text>Hi</text>\n  </header>\n</document>");
+        assertEquals(1, root.position()
+                            .line());
+        assertEquals(1, root.position()
+                            .column());
+        Node header = root.children()
+                          .get(0);
+        assertEquals(2, header.position()
+                              .line());
+        assertEquals(3, header.position()
+                              .column());
+        Node text = header.children()
+                          .get(0);
+        assertEquals(3, text.position()
+                            .line());
+        assertEquals(5, text.position()
+                            .column());
+    }
+
+    @Test
+    public void attributePositionIsTracked() {
+        Node root = parser.parse("<document>\n  <text align=\"right\">Hi</text>\n</document>");
+        assertEquals(2, root.children()
+                            .get(0)
+                            .attributes()
+                            .positionOf("align")
+                            .line());
+        assertEquals(9, root.children()
+                            .get(0)
+                            .attributes()
+                            .positionOf("align")
+                            .column());
+    }
+
+    @Test
+    public void parseDocumentReturnsTypedRoot() {
+        DocumentNode document = parser.parseDocument("<document id=\"x\"/>");
+        assertEquals("x", document.attributes()
+                                  .get("id"));
+    }
+
+    @Test
+    public void parseDocumentRejectsOtherRoots() {
+        try {
+            parser.parseDocument("<page/>");
+        } catch (ParseException e) {
+            assertTrue(e.getMessage()
+                        .contains("Root element must be <document>"));
+            return;
+        }
+        throw new AssertionError("Expected ParseException");
+    }
+
+    @Test
+    public void parserIsReusable() {
+        Node first = parser.parse("<document/>");
+        Node second = parser.parse("<document/>");
+        assertEquals(first.tag(), second.tag());
+        assertSame(first.getClass(), second.getClass());
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/LeniencyTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/LeniencyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.dirigible.parsers.document.Node;
+import org.junit.Test;
+
+/**
+ * The business-user leniencies where the DSL deliberately diverges from strict XML.
+ */
+public class LeniencyTest {
+
+    private final DocumentParser parser = new DocumentParser();
+
+    @Test
+    public void namedEntitiesDecodeInText() {
+        Node root = parser.parse("<document><text>&lt;a&gt; &amp; &quot;b&quot; &apos;c&apos;</text></document>");
+        assertEquals("<a> & \"b\" 'c'", root.children()
+                                            .get(0)
+                                            .text());
+    }
+
+    @Test
+    public void namedEntitiesDecodeInAttributeValues() {
+        Node root = parser.parse("<document><field label=\"Terms &amp; Conditions\"/></document>");
+        assertEquals("Terms & Conditions", root.children()
+                                               .get(0)
+                                               .attributes()
+                                               .get("label"));
+    }
+
+    @Test
+    public void rawAmpersandIsLiteralText() {
+        Node root = parser.parse("<document><text>Fruit & Veg</text></document>");
+        assertEquals("Fruit & Veg", root.children()
+                                        .get(0)
+                                        .text());
+    }
+
+    @Test
+    public void malformedEntityWithoutSemicolonIsLiteral() {
+        Node root = parser.parse("<document><text>Fish &amp Chips</text></document>");
+        assertEquals("Fish &amp Chips", root.children()
+                                            .get(0)
+                                            .text());
+    }
+
+    @Test
+    public void numericCharacterReferencesAreUnsupportedAndLiteral() {
+        Node root = parser.parse("<document><text>&#65;</text></document>");
+        assertEquals("&#65;", root.children()
+                                  .get(0)
+                                  .text());
+    }
+
+    @Test
+    public void commentsAreSkippedEverywhere() {
+        Node root = parser.parse("""
+                <!-- before root -->
+                <document>
+                    <!-- contains <tags> and -- dashes -->
+                    <text>Hi</text>
+                </document>
+                <!-- after root -->
+                """);
+        assertEquals(1, root.children()
+                            .size());
+        assertEquals("Hi", root.children()
+                               .get(0)
+                               .text());
+    }
+
+    @Test
+    public void prologIsSkipped() {
+        Node root = parser.parse("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document/>");
+        assertEquals("document", root.tag());
+    }
+
+    @Test
+    public void commentBetweenPrologAndRootIsSkipped() {
+        Node root = parser.parse("<?xml version=\"1.0\"?>\n<!-- x -->\n<document/>");
+        assertEquals("document", root.tag());
+    }
+
+    @Test
+    public void bomIsSkipped() {
+        Node root = parser.parse("\uFEFF<document/>");
+        assertEquals("document", root.tag());
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/MustachePreservationTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/MustachePreservationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.dirigible.parsers.document.Node;
+import org.junit.Test;
+
+/**
+ * The parser must never evaluate Mustache placeholders — they are plain text for a later
+ * data-binding layer.
+ */
+public class MustachePreservationTest {
+
+    private final DocumentParser parser = new DocumentParser();
+
+    @Test
+    public void placeholderInTextSurvivesVerbatim() {
+        Node root = parser.parse("<document><total align=\"right\">{{invoice.total}}</total></document>");
+        assertEquals("{{invoice.total}}", root.children()
+                                              .get(0)
+                                              .text());
+    }
+
+    @Test
+    public void placeholderInAttributeSurvivesVerbatim() {
+        Node root = parser.parse("<document><image src=\"{{company.logo}}\"/></document>");
+        assertEquals("{{company.logo}}", root.children()
+                                             .get(0)
+                                             .attributes()
+                                             .get("src"));
+    }
+
+    @Test
+    public void tripleStacheSurvivesVerbatim() {
+        Node root = parser.parse("<document><text>{{{raw.html}}}</text></document>");
+        assertEquals("{{{raw.html}}}", root.children()
+                                           .get(0)
+                                           .text());
+    }
+
+    @Test
+    public void mustacheSectionsAreJustText() {
+        Node root = parser.parse("<document><text>{{#items}} {{name}} {{/items}}</text></document>");
+        assertEquals("{{#items}} {{name}} {{/items}}", root.children()
+                                                           .get(0)
+                                                           .text());
+    }
+
+    @Test
+    public void placeholderAdjacentToEntityKeepsBoth() {
+        Node root = parser.parse("<document><text>{{a}} &amp; {{b}}</text></document>");
+        assertEquals("{{a}} & {{b}}", root.children()
+                                          .get(0)
+                                          .text());
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/ParseErrorTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/ParseErrorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ * Every syntax error must carry the exact 1-based line and column.
+ */
+public class ParseErrorTest {
+
+    private final DocumentParser parser = new DocumentParser();
+
+    private ParseException expectError(String source) {
+        try {
+            parser.parse(source);
+        } catch (ParseException e) {
+            return e;
+        }
+        fail("Expected ParseException");
+        return null; // unreachable
+    }
+
+    @Test
+    public void unclosedElementPointsAtTheOpeningTag() {
+        ParseException e = expectError("<document>\n  <row>\n    <text>Hi</text>\n");
+        assertTrue(e.getMessage()
+                    .contains("Unclosed element <row>"));
+        assertEquals(2, e.getLine());
+        assertEquals(3, e.getColumn());
+    }
+
+    @Test
+    public void mismatchedClosingTag() {
+        ParseException e = expectError("<document>\n  <row>x</column>\n</document>");
+        assertTrue(e.getMessage()
+                    .contains("expected </row>, found </column>"));
+        assertEquals(2, e.getLine());
+        assertEquals(9, e.getColumn());
+    }
+
+    @Test
+    public void missingEqualsAfterAttributeName() {
+        ParseException e = expectError("<document><text align\"right\">x</text></document>");
+        assertTrue(e.getMessage()
+                    .contains("Expected '=' after attribute name 'align'"));
+        assertEquals(1, e.getLine());
+    }
+
+    @Test
+    public void unquotedAttributeValue() {
+        ParseException e = expectError("<document><text align=right>x</text></document>");
+        assertTrue(e.getMessage()
+                    .contains("Attribute value must be quoted"));
+        assertEquals(23, e.getColumn());
+    }
+
+    @Test
+    public void unterminatedAttributeValuePointsAtTheOpeningQuote() {
+        ParseException e = expectError("<document><text align=\"right>x</text></document>");
+        assertTrue(e.getMessage()
+                    .contains("Unterminated attribute value"));
+        assertEquals(23, e.getColumn());
+    }
+
+    @Test
+    public void unterminatedCommentPointsAtItsStart() {
+        ParseException e = expectError("<document>\n<!-- oops\n</document>");
+        assertTrue(e.getMessage()
+                    .contains("Unterminated comment"));
+        assertEquals(2, e.getLine());
+        assertEquals(1, e.getColumn());
+    }
+
+    @Test
+    public void duplicateAttribute() {
+        ParseException e = expectError("<document><text align=\"left\" align=\"right\">x</text></document>");
+        assertTrue(e.getMessage()
+                    .contains("Duplicate attribute 'align'"));
+        assertEquals(30, e.getColumn());
+    }
+
+    @Test
+    public void contentAfterRoot() {
+        ParseException e = expectError("<document/>\n<text>x</text>");
+        assertTrue(e.getMessage()
+                    .contains("Unexpected content after the root element"));
+        assertEquals(2, e.getLine());
+    }
+
+    @Test
+    public void textBeforeRoot() {
+        ParseException e = expectError("hello <document/>");
+        assertTrue(e.getMessage()
+                    .contains("Expected '<' to start the root element"));
+    }
+
+    @Test
+    public void unknownTag() {
+        ParseException e = expectError("<document>\n  <colum width=\"45%\">x</colum>\n</document>");
+        assertTrue(e.getMessage()
+                    .contains("Unknown tag <colum>"));
+        assertEquals(2, e.getLine());
+        assertEquals(3, e.getColumn());
+    }
+
+    @Test
+    public void invalidTagName() {
+        ParseException e = expectError("<document><1text>x</1text></document>");
+        assertTrue(e.getMessage()
+                    .contains("Invalid tag name"));
+    }
+
+    @Test
+    public void unterminatedProlog() {
+        ParseException e = expectError("<?xml version=\"1.0\"");
+        assertTrue(e.getMessage()
+                    .contains("Unterminated XML prolog"));
+        assertEquals(1, e.getLine());
+        assertEquals(1, e.getColumn());
+    }
+
+    @Test
+    public void emptySourceExpectsRootElement() {
+        ParseException e = expectError("   \n  ");
+        assertTrue(e.getMessage()
+                    .contains("Expected '<' to start the root element"));
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/TagRegistryTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/parser/TagRegistryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eclipse.dirigible.parsers.document.CustomNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.junit.Test;
+
+/**
+ * Extending the DSL with new tags is a registry entry, never a parser change.
+ */
+public class TagRegistryTest {
+
+    @Test
+    public void unregisteredTagFailsWithPosition() {
+        try {
+            new DocumentParser().parse("<document><qrcode value=\"{{invoice.uuid}}\"/></document>");
+        } catch (ParseException e) {
+            assertTrue(e.getMessage()
+                        .contains("Unknown tag <qrcode>"));
+            assertEquals(11, e.getColumn());
+            return;
+        }
+        fail("Expected ParseException");
+    }
+
+    @Test
+    public void registeredTagParsesToCustomNode() {
+        TagRegistry registry = TagRegistry.builtIn();
+        registry.register("qrcode");
+        Node root = new DocumentParser(registry).parse("<document><qrcode value=\"{{invoice.uuid}}\">payload</qrcode></document>");
+        Node qrcode = root.children()
+                          .get(0);
+        assertTrue(qrcode instanceof CustomNode);
+        assertEquals("qrcode", qrcode.tag());
+        assertEquals("{{invoice.uuid}}", qrcode.attributes()
+                                               .get("value"));
+        assertEquals("payload", qrcode.text());
+    }
+
+    @Test
+    public void customFactoryMayProduceRicherNodes() {
+        class BarcodeNode extends CustomNode {
+            BarcodeNode(String tag, org.eclipse.dirigible.parsers.document.SourcePosition position,
+                    org.eclipse.dirigible.parsers.document.Attributes attributes, java.util.List<Node> children, String text) {
+                super(tag, position, attributes, children, text);
+            }
+        }
+        TagRegistry registry = TagRegistry.builtIn();
+        registry.register("barcode", BarcodeNode::new);
+        Node root = new DocumentParser(registry).parse("<document><barcode/></document>");
+        assertTrue(root.children()
+                       .get(0) instanceof BarcodeNode);
+    }
+
+    @Test
+    public void builtInsStillWorkOnACustomRegistry() {
+        TagRegistry registry = TagRegistry.builtIn();
+        registry.register("qrcode");
+        Node root = new DocumentParser(registry).parse("<document><text>Hi</text><qrcode/></document>");
+        assertEquals("text", root.children()
+                                 .get(0)
+                                 .tag());
+        assertEquals("qrcode", root.children()
+                                   .get(1)
+                                   .tag());
+    }
+
+    @Test
+    public void reRegisteringOverridesTheFactory() {
+        TagRegistry registry = TagRegistry.builtIn();
+        registry.register("text",
+                (tag, position, attributes, children, text) -> new CustomNode(tag, position, attributes, children, text.toUpperCase()));
+        Node root = new DocumentParser(registry).parse("<document><text>hi</text></document>");
+        assertEquals("HI", root.children()
+                               .get(0)
+                               .text());
+    }
+}

--- a/modules/parsers/document/src/test/resources/templates/credit-note.print
+++ b/modules/parsers/document/src/test/resources/templates/credit-note.print
@@ -1,0 +1,22 @@
+<!-- Credit Note — references the original invoice -->
+<document id="credit-note">
+    <page width="595" height="842" padding="40">
+        <header>
+            <text align="right" style="title">Credit Note</text>
+            <line/>
+        </header>
+        <section>
+            <field label="Credit Note No">{{creditNote.number}}</field>
+            <field label="Date">{{creditNote.date}}</field>
+            <field label="Original Invoice">{{creditNote.invoiceNumber}}</field>
+            <field label="Reason">{{creditNote.reason}}</field>
+        </section>
+        <table source="creditNote.items">
+            <column width="45%">{{description}}</column>
+            <column width="15%" align="center">{{quantity}}</column>
+            <column width="20%" align="right">{{price}}</column>
+            <column width="20%" align="right">{{amount}}</column>
+        </table>
+        <total align="right">{{creditNote.total}}</total>
+    </page>
+</document>

--- a/modules/parsers/document/src/test/resources/templates/delivery-note.print
+++ b/modules/parsers/document/src/test/resources/templates/delivery-note.print
@@ -1,0 +1,30 @@
+<!-- Delivery Note — no monetary total -->
+<document id="delivery-note">
+    <page width="595" height="842" padding="40">
+        <header>
+            <text align="right" style="title">Delivery Note</text>
+            <line/>
+        </header>
+        <section>
+            <field label="Delivery No">{{delivery.number}}</field>
+            <field label="Date">{{delivery.date}}</field>
+            <field label="Order Ref">{{delivery.orderNumber}}</field>
+            <field label="Carrier">{{delivery.carrier}}</field>
+        </section>
+        <table source="delivery.items">
+            <column width="3*">{{description}}</column>
+            <column width="*" align="right">{{ordered}}</column>
+            <column width="*" align="right">{{delivered}}</column>
+        </table>
+        <footer>
+            <row>
+                <column flex="1">
+                    <field label="Received by"></field>
+                </column>
+                <column flex="1" align="right">
+                    <field label="Date"></field>
+                </column>
+            </row>
+        </footer>
+    </page>
+</document>

--- a/modules/parsers/document/src/test/resources/templates/purchase-order.print
+++ b/modules/parsers/document/src/test/resources/templates/purchase-order.print
@@ -1,0 +1,57 @@
+<!-- Purchase Order -->
+<document id="purchase-order">
+
+    <page width="595" height="842" padding="40">
+
+        <header>
+            <text align="right" style="title">Purchase Order</text>
+            <line/>
+        </header>
+
+        <section>
+            <field label="PO No">{{order.number}}</field>
+            <field label="Date">{{order.date}}</field>
+            <field label="Expected Delivery">{{order.expectedDelivery}}</field>
+        </section>
+
+        <section id="parties">
+            <row gap="20">
+                <column flex="1">
+                    <text style="caption">Supplier</text>
+                    <field label="Name">{{supplier.name}}</field>
+                    <field label="Address">{{supplier.address}}</field>
+                </column>
+                <column flex="1">
+                    <text style="caption">Ship To</text>
+                    <field label="Warehouse">{{shipTo.name}}</field>
+                    <field label="Address">{{shipTo.address}}</field>
+                </column>
+            </row>
+        </section>
+
+        <table source="order.items">
+            <column width="3*">{{item}}</column>
+            <column width="2*" align="center">{{sku}}</column>
+            <column width="*" align="right">{{quantity}}</column>
+            <column width="2*" align="right">{{unitCost}}</column>
+            <column width="2*" align="right">{{total}}</column>
+        </table>
+
+        <section align="right" pageBreak="avoid">
+            <total align="right">{{order.total}}</total>
+        </section>
+
+        <footer>
+            <row>
+                <column flex="1">
+                    <field label="Approved by">{{order.approver}}</field>
+                </column>
+                <column flex="1" align="right">
+                    <field label="Signature"></field>
+                </column>
+            </row>
+        </footer>
+
+    </page>
+
+</document>

--- a/modules/parsers/document/src/test/resources/templates/quote.print
+++ b/modules/parsers/document/src/test/resources/templates/quote.print
@@ -1,0 +1,24 @@
+<!-- Quote -->
+<document id="quote">
+    <page width="595" height="842" padding="40">
+        <header>
+            <text align="right" style="title">Quote</text>
+            <line/>
+        </header>
+        <section>
+            <field label="Quote No">{{quote.number}}</field>
+            <field label="Date">{{quote.date}}</field>
+            <field label="Customer">{{customer.name}}</field>
+        </section>
+        <table source="quote.items">
+            <column width="45%">{{description}}</column>
+            <column width="15%" align="center">{{quantity}}</column>
+            <column width="20%" align="right">{{price}}</column>
+            <column width="20%" align="right">{{amount}}</column>
+        </table>
+        <total align="right">{{quote.total}}</total>
+        <if source="quote.validUntil">
+            <text>This quote is valid until {{quote.validUntil}}.</text>
+        </if>
+    </page>
+</document>

--- a/modules/parsers/document/src/test/resources/templates/receipt.print
+++ b/modules/parsers/document/src/test/resources/templates/receipt.print
@@ -1,0 +1,41 @@
+<!-- Receipt — narrow page, stack-only layout -->
+<document id="receipt">
+
+    <page width="280" padding="10">
+
+        <header>
+            <stack align="center">
+                <text style="title">{{store.name}}</text>
+                <text>{{store.address}}</text>
+            </stack>
+            <line/>
+        </header>
+
+        <section>
+            <field label="Receipt No">{{receipt.number}}</field>
+            <field label="Date">{{receipt.date}}</field>
+            <field label="Cashier">{{receipt.cashier}}</field>
+            <!-- payment method names may contain a raw ampersand -->
+            <field label="Paid via">Cash & Card</field>
+        </section>
+
+        <table source="receipt.items">
+            <column width="3*">{{description}}</column>
+            <column width="*" align="right">{{quantity}}</column>
+            <column width="2*" align="right">{{amount}}</column>
+        </table>
+
+        <total align="right">{{receipt.total}}</total>
+
+        <section>
+            <field label="Tendered">{{receipt.tendered}}</field>
+            <field label="Change">{{receipt.change}}</field>
+        </section>
+
+        <footer>
+            <text align="center">Thank you for shopping with us!</text>
+        </footer>
+
+    </page>
+
+</document>

--- a/modules/parsers/document/src/test/resources/templates/sales-invoice.print
+++ b/modules/parsers/document/src/test/resources/templates/sales-invoice.print
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<!-- Sales Invoice — the canonical example of the document template DSL -->
+<document id="sales-invoice">
+
+    <page width="595" height="842" padding="40">
+
+        <header>
+            <row gap="10">
+                <image src="{{company.logo}}" width="120" height="60"/>
+                <stack flex="1" align="right">
+                    <text align="right" style="title">
+                        Sales Invoice
+                    </text>
+                    <text style="subtitle">{{company.name}}</text>
+                </stack>
+            </row>
+            <line/>
+        </header>
+
+        <section>
+            <field label="Invoice No">
+                {{invoice.number}}
+            </field>
+            <field label="Date">
+                {{invoice.date}}
+            </field>
+            <field label="Due Date">
+                {{invoice.dueDate}}
+            </field>
+        </section>
+
+        <section id="parties">
+            <row gap="20">
+                <column flex="1">
+                    <text style="caption">Bill To</text>
+                    <field label="Customer">{{customer.name}}</field>
+                    <field label="Address">{{customer.address}}</field>
+                    <field label="VAT No">{{customer.vatNumber}}</field>
+                </column>
+                <column flex="1" align="right">
+                    <text style="caption">From</text>
+                    <field label="Company">{{company.name}}</field>
+                    <field label="Address">{{company.address}}</field>
+                </column>
+            </row>
+        </section>
+
+        <space height="20"/>
+
+        <table source="invoice.items" repeatHeader="true">
+            <column width="45%">
+                {{description}}
+            </column>
+            <column width="15%" align="center">
+                {{quantity}}
+            </column>
+            <column width="20%" align="right">
+                {{price}}
+            </column>
+            <column width="20%" align="right">
+                {{amount}}
+            </column>
+        </table>
+
+        <section id="totals" align="right">
+            <field label="Subtotal">{{invoice.subtotal}}</field>
+            <if source="invoice.hasDiscount">
+                <field label="Discount">{{invoice.discount}}</field>
+            </if>
+            <field label="VAT (20%)">{{invoice.vat}}</field>
+            <total align="right">
+                {{invoice.total}}
+            </total>
+        </section>
+
+        <footer>
+            <text align="center">Terms &amp; Conditions apply — Page {{page}} of {{pages}}</text>
+        </footer>
+
+    </page>
+
+</document>

--- a/modules/parsers/document/src/test/resources/templates/statement.print
+++ b/modules/parsers/document/src/test/resources/templates/statement.print
@@ -1,0 +1,23 @@
+<!-- Statement — iterates transactions with <for> -->
+<document id="statement">
+    <page width="595" height="842" padding="40">
+        <header>
+            <text align="right" style="title">Statement</text>
+            <line/>
+        </header>
+        <section>
+            <field label="Account">{{account.name}}</field>
+            <field label="Period">{{statement.period}}</field>
+            <field label="Opening Balance">{{statement.openingBalance}}</field>
+        </section>
+        <for source="statement.transactions">
+            <row gap="8">
+                <text width="20%">{{date}}</text>
+                <text flex="1">{{description}}</text>
+                <text width="20%" align="right">{{amount}}</text>
+            </row>
+        </for>
+        <line/>
+        <total align="right">{{statement.closingBalance}}</total>
+    </page>
+</document>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -372,6 +372,11 @@
                 <artifactId>dirigible-parsers-typescript</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-parsers-document</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## What

A lightweight, declarative document-template engine for printable business documents (Sales Invoice, Purchase Order, Quote, Delivery Note, Receipt, Statement, Credit Note) — the authoring layer that will feed the existing XSL-FO/FOP PDF pipeline. **This PR is the foundation only: parsing + typed AST + layout primitives. No PDF rendering yet.**

New pure-library Maven module `modules/parsers/document` → `dirigible-parsers-document` (zero new dependencies, Java 21).

## The DSL

A tiny XML-like language with only business-oriented tags — no HTML, no CSS, no scripting:

```xml
<document>
    <header>
        <text align="right" style="title">Sales Invoice</text>
    </header>
    <section>
        <field label="Invoice No">{{invoice.number}}</field>
    </section>
    <table source="invoice.items">
        <column width="45%">{{description}}</column>
        <column width="20%" align="right">{{amount}}</column>
    </table>
    <total align="right">{{invoice.total}}</total>
</document>
```

Mustache placeholders are **not evaluated** — they survive parsing verbatim for a later data-binding layer.

## Design

- **Hand-written scanner + recursive-descent parser**, business-user lenient where strict XML is hostile: a raw `&` is literal text ("Fruit & Veg" works), only the five named entities decode, comments/prolog skipped. Every error carries its exact line/column; an unclosed element points at its *opening* tag.
- **Sealed `Node` interface + one record per built-in tag** (17 tags) so consumers pattern-match exhaustively — the Flutter-widget-tree feel; a non-sealed `CustomNode` + `TagRegistry.register(...)` is the extension point (a new tag is one line, no parser change; unknown tags fail fast).
- **Layout primitives**: `Measurement` (`100`/`100px`/`50%`/`*`/`2*`/`auto`), `Alignment`, and a `LayoutEngine` normalizing the AST into a `LayoutNode` tree (flex→fraction, table column-width resolution incl. fraction shares). Deliberately **no geometry** — pagination/coordinates belong to a concrete renderer.
- **`DocumentRenderer<T>`** is the seam the future XSL-FO/PDF backend implements.

## Testing

69 unit tests (parser structure, Mustache preservation, leniencies, exact error positions, tag-registry extension, measurements/alignment/layout, and a 7-template sample corpus — one per document type — with deep assertions on the sales invoice). Full grammar (EBNF) in the module README.

## Follow-up (separate PR)

The platform arc: intent generator emitting a standard `.print` template per document entity, CMS seeding (`Templates/<Entity>/Print/<lang>/`) for user-customizable templates, the Harmonia Print button with a language dialog, and the first XSL-FO renderer against `PDFFacade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)