### PR TITLE
feat(documents): print templates — intent generation, CMS seeding, Print button, PDF rendering

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/pdf/Pdf.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/pdf/Pdf.java
@@ -12,9 +12,11 @@ package org.eclipse.dirigible.sdk.pdf;
 import org.eclipse.dirigible.components.api.pdf.PDFFacade;
 
 /**
- * Renders a Mustache-style template against a JSON data document and returns the resulting PDF
- * bytes. The platform handles font loading, page sizing, and basic CSS — useful for invoice,
- * report, and certificate generation without spinning up a full reporting engine.
+ * Transforms an XML data document through an XSLT/XSL-FO stylesheet with Apache FOP and returns the
+ * resulting PDF bytes — useful for invoice, report, and certificate generation without spinning up
+ * a full reporting engine. Placeholder substitution is NOT performed here: expand the stylesheet
+ * with a template engine (Mustache/Velocity) first, or use the document-template DSL pipeline
+ * ({@code dirigible-parsers-document}), which produces a ready XSL-FO stylesheet.
  * <p>
  * Write the returned bytes straight into an HTTP response with
  * {@code Content-Type: application/pdf}, or into the repository / filesystem via
@@ -25,7 +27,14 @@ public final class Pdf {
 
     private Pdf() {}
 
-    public static byte[] generate(String template, String dataJson) {
-        return PDFFacade.generate(template, dataJson);
+    /**
+     * Generates a PDF.
+     *
+     * @param template the XSLT/XSL-FO stylesheet ({@code xmlns:fo="http://www.w3.org/1999/XSL/Format"})
+     * @param dataXml the XML data document the stylesheet transforms
+     * @return the PDF bytes
+     */
+    public static byte[] generate(String template, String dataXml) {
+        return PDFFacade.generate(template, dataXml);
     }
 }

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/SynchronizersOrder.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/synchronizer/SynchronizersOrder.java
@@ -83,4 +83,7 @@ public interface SynchronizersOrder {
     /** The openapi. */
     int OPENAPI = 510;
 
+    /** The print template. */
+    int PRINT = 520;
+
 }

--- a/components/engine/engine-document/pom.xml
+++ b/components/engine/engine-document/pom.xml
@@ -9,8 +9,8 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<name>Components - Engine - Intent</name>
-	<artifactId>dirigible-components-engine-intent</artifactId>
+	<name>Components - Engine - Document</name>
+	<artifactId>dirigible-components-engine-document</artifactId>
 	<modelVersion>4.0.0</modelVersion>
 
 	<dependencies>
@@ -21,21 +21,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-core-database</artifactId>
+			<artifactId>dirigible-components-engine-cms</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-core-repository</artifactId>
+			<artifactId>dirigible-components-api-pdf</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.eclipse.dirigible</groupId>
-			<artifactId>dirigible-components-ide-workspace</artifactId>
-		</dependency>
-		<!-- Test: parse-validate the generated .print templates with the document-template parser -->
+		<!-- The .print template pipeline: parse, data-bind, render to XSL-FO -->
 		<dependency>
 			<groupId>org.eclipse.dirigible</groupId>
 			<artifactId>dirigible-parsers-document</artifactId>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintEndpoint.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintEndpoint.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * The print surface of generated applications:
+ * <ul>
+ * <li>{@code GET /services/print/{entity}/languages} — the languages a print template exists for
+ * (the child folders of the entity's CMS {@code Print} folder).</li>
+ * <li>{@code POST /services/print/{entity}?lang=en} — renders the entity's CMS print template with
+ * the posted JSON data and responds with the PDF.</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_SECURED + "print")
+class PrintEndpoint extends BaseEndpoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(PrintEndpoint.class);
+
+    private static final String DEFAULT_LANGUAGE = "en";
+
+    /**
+     * A plain Gson (no {@code @Expose} filtering) keeping JSON integers as longs — the data is
+     * map-shaped, not POJO-shaped.
+     */
+    private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                                                      .create();
+
+    private final PrintTemplateCmsStore cmsStore;
+
+    PrintEndpoint(PrintTemplateCmsStore cmsStore) {
+        this.cmsStore = cmsStore;
+    }
+
+    /**
+     * Lists the languages the given entity has print templates for.
+     *
+     * @param entity the domain entity name
+     * @return a JSON array of {@code {"code": "en", "name": "English"}} entries, empty when the entity
+     *         has no templates
+     */
+    @GetMapping(value = "/{entity}/languages", produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<List<Map<String, String>>> getLanguages(@PathVariable("entity") String entity) {
+        try {
+            List<Map<String, String>> languages = cmsStore.listLanguages(entity)
+                                                          .stream()
+                                                          .map(code -> Map.of("code", code, "name", displayName(code)))
+                                                          .toList();
+            return ResponseEntity.ok(languages);
+        } catch (IOException e) {
+            logger.error("Failed to list print template languages for entity [{}]", entity, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to list print template languages for entity [" + entity + "]", e);
+        }
+    }
+
+    /**
+     * Renders the entity's print template with the posted data and responds with the PDF.
+     *
+     * @param entity the domain entity name
+     * @param language the template language, defaults to {@code en}
+     * @param body the JSON data context, e.g. {@code {"document": {...}, "items": [...]}}
+     * @return the PDF bytes, served inline as {@code <entity>.pdf}
+     */
+    @PostMapping(value = "/{entity}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_PDF_VALUE)
+    ResponseEntity<byte[]> print(@PathVariable("entity") String entity,
+            @RequestParam(name = "lang", defaultValue = DEFAULT_LANGUAGE) String language, @RequestBody String body) {
+        String templateSource = findTemplate(entity, language);
+        Map<String, Object> data = GSON.fromJson(body, new TypeToken<Map<String, Object>>() {}.getType());
+
+        byte[] pdf = PrintRenderer.renderPdf(templateSource, data);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_PDF);
+        headers.setContentDisposition(ContentDisposition.inline()
+                                                        .filename(entity + ".pdf")
+                                                        .build());
+        return new ResponseEntity<>(pdf, headers, HttpStatus.OK);
+    }
+
+    private String findTemplate(String entity, String language) {
+        try {
+            return cmsStore.findTemplate(entity, language)
+                           .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                   "No print template found for entity [" + entity + "] and language [" + language + "]"));
+        } catch (IOException e) {
+            logger.error("Failed to read the print template for entity [{}] and language [{}]", entity, language, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to read the print template for entity [" + entity + "] and language [" + language + "]", e);
+        }
+    }
+
+    private static String displayName(String code) {
+        String name = Locale.forLanguageTag(code)
+                            .getDisplayLanguage(Locale.ENGLISH);
+        return name.isBlank() ? code : name;
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintRenderer.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintRenderer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import org.eclipse.dirigible.components.api.pdf.PDFFacade;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.binding.DataBinder;
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.eclipse.dirigible.parsers.document.renderer.XslFoRenderer;
+
+import java.util.Map;
+
+/**
+ * The {@code .print} rendering pipeline: parse the template, bind the data, render to a
+ * self-contained XSL-FO stylesheet and (optionally) transform it to a PDF.
+ */
+final class PrintRenderer {
+
+    /**
+     * The renderer's output is a self-contained stylesheet, so the transformation source carries no
+     * data of its own.
+     */
+    private static final String EMPTY_DATA_SOURCE = "<data/>";
+
+    private PrintRenderer() {}
+
+    /**
+     * Parses the template, binds the data and renders the XSL-FO stylesheet.
+     *
+     * @param templateSource the {@code .print} template source
+     * @param data the document data context
+     * @return the XSL-FO stylesheet with the data merged in
+     */
+    static String renderFo(String templateSource, Map<String, Object> data) {
+        Node bound = new DataBinder().bind(new DocumentParser().parse(templateSource), data);
+        return new XslFoRenderer().renderBound(bound);
+    }
+
+    /**
+     * Runs the full pipeline down to PDF bytes.
+     *
+     * @param templateSource the {@code .print} template source
+     * @param data the document data context
+     * @return the PDF bytes
+     */
+    static byte[] renderPdf(String templateSource, Map<String, Object> data) {
+        return PDFFacade.generate(renderFo(templateSource, data), EMPTY_DATA_SOURCE);
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintTemplateCmsStore.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintTemplateCmsStore.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import org.eclipse.dirigible.components.engine.cms.CmisConstants;
+import org.eclipse.dirigible.components.engine.cms.CmisContentStream;
+import org.eclipse.dirigible.components.engine.cms.CmisDocument;
+import org.eclipse.dirigible.components.engine.cms.CmisFolder;
+import org.eclipse.dirigible.components.engine.cms.CmisObject;
+import org.eclipse.dirigible.components.engine.cms.CmisSession;
+import org.eclipse.dirigible.components.engine.cms.CmisSessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The single CMS access point for print templates. Templates live under
+ * {@code Templates/<EntityName>/Print/<language>/} in the (tenant-scoped) CMS; the synchronizer
+ * seeds them there and the print endpoint reads them back.
+ */
+@Component
+class PrintTemplateCmsStore {
+
+    private static final Logger logger = LoggerFactory.getLogger(PrintTemplateCmsStore.class);
+
+    private static final String TEMPLATES_ROOT = "Templates";
+    private static final String PRINT_SEGMENT = "Print";
+    private static final String DEFAULT_LANGUAGE = "en";
+    private static final String DEFAULT_TEMPLATE_NAME = "standard.print";
+    private static final String TEMPLATE_EXTENSION = ".print";
+    private static final String TEMPLATE_MEDIA_TYPE = "text/xml";
+    private static final String PATH_SEPARATOR = "/";
+
+    /**
+     * Seeds the default template for the given entity at
+     * {@code Templates/<EntityName>/Print/en/standard.print} — create-if-absent only: an already
+     * existing document is a user customization and is never overwritten.
+     *
+     * @param entityName the domain entity name
+     * @param content the template source
+     * @throws IOException on CMS access failure
+     */
+    void seedDefaultTemplate(String entityName, String content) throws IOException {
+        String folderPath = printFolderPath(entityName) + PATH_SEPARATOR + DEFAULT_LANGUAGE;
+        String documentPath = folderPath + PATH_SEPARATOR + DEFAULT_TEMPLATE_NAME;
+
+        CmisSession session = CmisSessionFactory.getSession();
+        if (exists(session, documentPath)) {
+            logger.debug("Print template [{}] already exists - keeping the user's version", documentPath);
+            return;
+        }
+        CmisFolder folder = ensureFolder(session, folderPath);
+        createDocument(session, folder, DEFAULT_TEMPLATE_NAME, content);
+        logger.info("Seeded print template [{}]", documentPath);
+    }
+
+    /**
+     * Lists the language codes for which the given entity has print templates — the child folder names
+     * of {@code Templates/<EntityName>/Print}.
+     *
+     * @param entityName the domain entity name
+     * @return the language codes, empty when the folder is missing
+     * @throws IOException on CMS access failure
+     */
+    List<String> listLanguages(String entityName) throws IOException {
+        CmisSession session = CmisSessionFactory.getSession();
+        Optional<CmisFolder> printFolder = findFolder(session, printFolderPath(entityName));
+        if (printFolder.isEmpty()) {
+            return List.of();
+        }
+        List<String> languages = new ArrayList<>();
+        for (CmisObject child : printFolder.get()
+                                           .getChildren()) {
+            if (child instanceof CmisFolder) {
+                languages.add(child.getName());
+            }
+        }
+        return languages;
+    }
+
+    /**
+     * Finds the print template for the given entity and language — the first {@code .print} document
+     * (or any document as fallback) under {@code Templates/<EntityName>/Print/<language>}.
+     *
+     * @param entityName the domain entity name
+     * @param language the language code
+     * @return the template source, empty when no template exists
+     * @throws IOException on CMS access failure
+     */
+    Optional<String> findTemplate(String entityName, String language) throws IOException {
+        CmisSession session = CmisSessionFactory.getSession();
+        Optional<CmisFolder> languageFolder = findFolder(session, printFolderPath(entityName) + PATH_SEPARATOR + language);
+        if (languageFolder.isEmpty()) {
+            return Optional.empty();
+        }
+        CmisDocument template = null;
+        for (CmisObject child : languageFolder.get()
+                                              .getChildren()) {
+            if (child instanceof CmisDocument document) {
+                if (child.getName()
+                         .toLowerCase()
+                         .endsWith(TEMPLATE_EXTENSION)) {
+                    template = document;
+                    break;
+                }
+                if (template == null) {
+                    template = document;
+                }
+            }
+        }
+        if (template == null) {
+            return Optional.empty();
+        }
+        return Optional.of(readContent(template));
+    }
+
+    private String printFolderPath(String entityName) {
+        return PATH_SEPARATOR + TEMPLATES_ROOT + PATH_SEPARATOR + entityName + PATH_SEPARATOR + PRINT_SEGMENT;
+    }
+
+    /**
+     * The CMS signals a missing object with an {@code IOException} from {@code getObjectByPath} —
+     * absence is an expected outcome here, not an error.
+     */
+    private boolean exists(CmisSession session, String path) {
+        try {
+            session.getObjectByPath(path);
+            return true;
+        } catch (IOException ex) {
+            logger.debug("CMS object [{}] does not exist", path, ex);
+            return false;
+        }
+    }
+
+    private Optional<CmisFolder> findFolder(CmisSession session, String path) {
+        try {
+            CmisObject object = session.getObjectByPath(path);
+            if (object instanceof CmisFolder folder) {
+                return Optional.of(folder);
+            }
+            logger.warn("CMS object [{}] is not a folder but [{}]", path, object);
+            return Optional.empty();
+        } catch (IOException ex) {
+            logger.debug("CMS folder [{}] does not exist", path, ex);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Walks the given absolute folder path level by level, creating each missing level —
+     * {@code CmisFolder.createFolder} creates a single level only.
+     */
+    private CmisFolder ensureFolder(CmisSession session, String path) throws IOException {
+        CmisFolder current = session.getRootFolder();
+        StringBuilder currentPath = new StringBuilder();
+        for (String segment : path.split(PATH_SEPARATOR)) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            currentPath.append(PATH_SEPARATOR)
+                       .append(segment);
+            Optional<CmisFolder> existing = findFolder(session, currentPath.toString());
+            if (existing.isPresent()) {
+                current = existing.get();
+            } else {
+                current = current.createFolder(
+                        Map.of(CmisConstants.OBJECT_TYPE_ID, CmisConstants.OBJECT_TYPE_FOLDER, CmisConstants.NAME, segment));
+            }
+        }
+        return current;
+    }
+
+    private void createDocument(CmisSession session, CmisFolder folder, String name, String content) throws IOException {
+        Map<String, String> properties = Map.of(CmisConstants.OBJECT_TYPE_ID, CmisConstants.OBJECT_TYPE_DOCUMENT, CmisConstants.NAME, name);
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            CmisContentStream contentStream = session.getObjectFactory()
+                                                     .createContentStream(name, bytes.length, TEMPLATE_MEDIA_TYPE, inputStream);
+            folder.createDocument(properties, contentStream);
+        }
+    }
+
+    private String readContent(CmisDocument document) throws IOException {
+        try (InputStream inputStream = document.getContentStream()
+                                               .getStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintTemplateSynchronizer.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintTemplateSynchronizer.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.dirigible.commons.config.Configuration;
+import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
+import org.eclipse.dirigible.components.base.artefact.ArtefactPhase;
+import org.eclipse.dirigible.components.base.artefact.ArtefactService;
+import org.eclipse.dirigible.components.base.artefact.topology.TopologyWrapper;
+import org.eclipse.dirigible.components.base.synchronizer.MultitenantBaseSynchronizer;
+import org.eclipse.dirigible.components.base.synchronizer.SynchronizerCallback;
+import org.eclipse.dirigible.components.base.synchronizer.SynchronizersOrder;
+import org.eclipse.dirigible.components.engine.document.domain.PrintTemplate;
+import org.eclipse.dirigible.components.engine.document.service.PrintTemplateService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.List;
+
+/**
+ * Synchronizes {@code .print} files into {@link PrintTemplate} artefacts and seeds each template
+ * into the tenant-scoped CMS at {@code Templates/<EntityName>/Print/en/standard.print} —
+ * create-if-absent only, an existing CMS document is a user customization and is never overwritten.
+ * On delete the database row is removed; the CMS copy stays.
+ */
+@Component
+@Order(SynchronizersOrder.PRINT)
+class PrintTemplateSynchronizer extends MultitenantBaseSynchronizer<PrintTemplate, Long> {
+
+    /** The file extension of print templates. */
+    private static final String FILE_EXTENSION_PRINT = ".print";
+
+    private static final Logger logger = LoggerFactory.getLogger(PrintTemplateSynchronizer.class);
+
+    private final PrintTemplateService printTemplateService;
+    private final PrintTemplateCmsStore cmsStore;
+
+    private SynchronizerCallback callback;
+
+    PrintTemplateSynchronizer(PrintTemplateService printTemplateService, PrintTemplateCmsStore cmsStore) {
+        this.printTemplateService = printTemplateService;
+        this.cmsStore = cmsStore;
+    }
+
+    @Override
+    public boolean isAccepted(String type) {
+        return PrintTemplate.ARTEFACT_TYPE.equals(type);
+    }
+
+    @Override
+    protected List<PrintTemplate> parseImpl(String location, byte[] content) throws ParseException {
+        PrintTemplate printTemplate = new PrintTemplate();
+        Configuration.configureObject(printTemplate);
+        printTemplate.setLocation(location);
+        printTemplate.setName(FilenameUtils.getBaseName(location));
+        printTemplate.setType(PrintTemplate.ARTEFACT_TYPE);
+        printTemplate.setContent(new String(content, StandardCharsets.UTF_8));
+        printTemplate.updateKey();
+        try {
+            PrintTemplate maybe = getService().findByKey(printTemplate.getKey());
+            if (maybe != null) {
+                printTemplate.setId(maybe.getId());
+            }
+            printTemplate = getService().save(printTemplate);
+        } catch (Exception e) {
+            logger.error("Failed to save print template [{}]", printTemplate, e);
+            throw new ParseException(e.getMessage(), 0);
+        }
+        return List.of(printTemplate);
+    }
+
+    @Override
+    public ArtefactService<PrintTemplate, Long> getService() {
+        return printTemplateService;
+    }
+
+    @Override
+    public List<PrintTemplate> retrieve(String location) {
+        return getService().findByLocation(location);
+    }
+
+    @Override
+    public void setStatus(PrintTemplate artefact, ArtefactLifecycle lifecycle, String error) {
+        artefact.setLifecycle(lifecycle);
+        artefact.setError(error);
+        getService().save(artefact);
+    }
+
+    @Override
+    protected boolean completeImpl(TopologyWrapper<PrintTemplate> wrapper, ArtefactPhase flow) {
+        PrintTemplate printTemplate = wrapper.getArtefact();
+
+        switch (flow) {
+            case CREATE:
+                if (ArtefactLifecycle.NEW.equals(printTemplate.getLifecycle())) {
+                    seed(wrapper, ArtefactLifecycle.CREATED);
+                }
+                break;
+            case UPDATE:
+                if (ArtefactLifecycle.MODIFIED.equals(printTemplate.getLifecycle())) {
+                    seed(wrapper, ArtefactLifecycle.UPDATED);
+                }
+                if (ArtefactLifecycle.FAILED.equals(printTemplate.getLifecycle())) {
+                    return false;
+                }
+                break;
+            case DELETE:
+                if (ArtefactLifecycle.CREATED.equals(printTemplate.getLifecycle())
+                        || ArtefactLifecycle.UPDATED.equals(printTemplate.getLifecycle())
+                        || ArtefactLifecycle.FAILED.equals(printTemplate.getLifecycle())) {
+                    // remove the database row only - the seeded CMS document may carry user customizations
+                    try {
+                        getService().delete(printTemplate);
+                        callback.registerState(this, wrapper, ArtefactLifecycle.DELETED);
+                    } catch (Exception e) {
+                        callback.addError(e.getMessage());
+                        callback.registerState(this, wrapper, ArtefactLifecycle.DELETED, e);
+                    }
+                }
+                break;
+            case START:
+            case STOP:
+                break;
+        }
+        return true;
+    }
+
+    /**
+     * Seeds the template into the CMS (create-if-absent) and registers the given lifecycle state.
+     */
+    private void seed(TopologyWrapper<PrintTemplate> wrapper, ArtefactLifecycle lifecycle) {
+        PrintTemplate printTemplate = wrapper.getArtefact();
+        try {
+            cmsStore.seedDefaultTemplate(printTemplate.getName(), printTemplate.getContent());
+            callback.registerState(this, wrapper, lifecycle);
+        } catch (Exception e) {
+            logger.error("Failed to seed print template [{}] into the CMS", printTemplate.getKey(), e);
+            callback.addError(e.getMessage());
+            callback.registerState(this, wrapper, ArtefactLifecycle.FAILED, e);
+        }
+    }
+
+    @Override
+    public void cleanupImpl(PrintTemplate printTemplate) {
+        // never delete from the CMS - the seeded document may carry user customizations
+        try {
+            getService().delete(printTemplate);
+        } catch (Exception e) {
+            callback.addError(e.getMessage());
+            callback.registerState(this, printTemplate, ArtefactLifecycle.DELETED, e);
+        }
+    }
+
+    @Override
+    public void setCallback(SynchronizerCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public String getFileExtension() {
+        return FILE_EXTENSION_PRINT;
+    }
+
+    @Override
+    public String getArtefactType() {
+        return PrintTemplate.ARTEFACT_TYPE;
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/domain/PrintTemplate.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/domain/PrintTemplate.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document.domain;
+
+import org.eclipse.dirigible.components.base.artefact.Artefact;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * A print template artefact — the persisted projection of a {@code .print} file. The file's base
+ * name is the domain entity the template prints (e.g. {@code SalesInvoice.print} prints a
+ * {@code SalesInvoice}).
+ */
+@Entity
+@Table(name = "DIRIGIBLE_PRINT_TEMPLATES")
+public class PrintTemplate extends Artefact {
+
+    /** The artefact type. */
+    public static final String ARTEFACT_TYPE = "print";
+
+    /** The id. */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "PRINT_TEMPLATE_ID", nullable = false)
+    private Long id;
+
+    /** The template source. */
+    @Column(name = "PRINT_CONTENT", columnDefinition = "CLOB")
+    private String content;
+
+    /**
+     * Instantiates a new print template.
+     *
+     * @param location the location
+     * @param name the name
+     * @param description the description
+     */
+    public PrintTemplate(String location, String name, String description) {
+        super(location, name, ARTEFACT_TYPE, description, null);
+    }
+
+    /**
+     * Instantiates a new print template.
+     */
+    public PrintTemplate() {
+        super();
+    }
+
+    /**
+     * Gets the id.
+     *
+     * @return the id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the id.
+     *
+     * @param id the id to set
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the template source.
+     *
+     * @return the content
+     */
+    public String getContent() {
+        return content;
+    }
+
+    /**
+     * Sets the template source.
+     *
+     * @param content the content to set
+     */
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    /**
+     * To string.
+     *
+     * @return the string
+     */
+    @Override
+    public String toString() {
+        return "PrintTemplate{" + "id=" + id + ", location='" + location + '\'' + ", name='" + name + '\'' + ", type='" + type + '\''
+                + ", description='" + description + '\'' + ", key='" + key + '\'' + ", dependencies='" + dependencies + '\''
+                + ", createdBy=" + createdBy + ", createdAt=" + createdAt + ", updatedBy=" + updatedBy + ", updatedAt=" + updatedAt + '}';
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/repository/PrintTemplateRepository.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/repository/PrintTemplateRepository.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document.repository;
+
+import org.eclipse.dirigible.components.base.artefact.ArtefactRepository;
+import org.eclipse.dirigible.components.engine.document.domain.PrintTemplate;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The Spring Data repository for {@link PrintTemplate} artefacts.
+ */
+@Repository("printTemplateRepository")
+public interface PrintTemplateRepository extends ArtefactRepository<PrintTemplate, Long> {
+
+    /**
+     * Sets the running flag to all print templates.
+     *
+     * @param running the new running flag
+     */
+    @Override
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE PrintTemplate SET running = :running")
+    void setRunningToAll(@Param("running") boolean running);
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/service/PrintTemplateService.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/service/PrintTemplateService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document.service;
+
+import org.eclipse.dirigible.components.base.artefact.BaseArtefactService;
+import org.eclipse.dirigible.components.engine.document.domain.PrintTemplate;
+import org.eclipse.dirigible.components.engine.document.repository.PrintTemplateRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The artefact service for {@link PrintTemplate} entities.
+ */
+@Service
+@Transactional
+public class PrintTemplateService extends BaseArtefactService<PrintTemplate, Long> {
+
+    /**
+     * Instantiates a new print template service.
+     *
+     * @param printTemplateRepository the print template repository
+     */
+    public PrintTemplateService(PrintTemplateRepository printTemplateRepository) {
+        super(printTemplateRepository);
+    }
+}

--- a/components/engine/engine-document/src/test/java/org/eclipse/dirigible/components/engine/document/PrintRendererTest.java
+++ b/components/engine/engine-document/src/test/java/org/eclipse/dirigible/components/engine/document/PrintRendererTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@code .print} render pipeline (parse + bind + XSL-FO rendering).
+ */
+class PrintRendererTest {
+
+    private static final String TEMPLATE = """
+            <document id="sales-invoice">
+                <page>
+                    <section>
+                        <field label="Number">{{document.number}}</field>
+                        <field label="Customer">{{document.customer}}</field>
+                    </section>
+                    <table source="items">
+                        <column width="2*">{{name}}</column>
+                        <column width="*" align="right">{{amount}}</column>
+                    </table>
+                    <total align="right">{{document.total}}</total>
+                </page>
+            </document>
+            """;
+
+    @Test
+    void mergesDocumentValuesIntoFo() {
+        String fo = PrintRenderer.renderFo(TEMPLATE, data());
+
+        assertTrue(fo.contains("INV-001"), "document.number should be merged");
+        assertTrue(fo.contains("ACME Ltd."), "document.customer should be merged");
+        assertTrue(fo.contains("123.45"), "document.total should be merged");
+    }
+
+    @Test
+    void expandsTableRowsFromItems() {
+        String fo = PrintRenderer.renderFo(TEMPLATE, data());
+
+        assertTrue(fo.contains("Widget"), "first item should be rendered");
+        assertTrue(fo.contains("Gadget"), "second item should be rendered");
+        assertTrue(fo.contains("100.00"), "first item amount should be rendered");
+        assertTrue(fo.contains("23.45"), "second item amount should be rendered");
+    }
+
+    @Test
+    void unresolvedPlaceholdersNeverLeakRawBraces() {
+        String fo = PrintRenderer.renderFo(TEMPLATE, Map.of("items", List.of()));
+
+        assertFalse(fo.contains("{{"), "unresolved placeholders must render empty, not as raw braces");
+    }
+
+    private static Map<String, Object> data() {
+        return Map.of("document", Map.of("number", "INV-001", "customer", "ACME Ltd.", "total", "123.45"), "items",
+                List.of(Map.of("name", "Widget", "amount", "100.00"), Map.of("name", "Gadget", "amount", "23.45")));
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
@@ -47,7 +47,7 @@ public class IntentGenerationService {
      * project root are owned (and scrubbed) by the generation pass.
      */
     private static final Set<String> INTENT_OWNED_EXTENSIONS = Set.of(".edm", ".model", ".bpmn", ".form", ".report", ".roles", ".access",
-            ".dsm", ".schema", ".table", ".view", ".csvim", ".csv", ".glue");
+            ".dsm", ".schema", ".table", ".view", ".csvim", ".csv", ".glue", ".print");
 
     private final List<IntentTargetGenerator> generators;
     private final IRepository repository;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.print;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
+import org.eclipse.dirigible.components.intent.generator.IntentNaming;
+import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.FieldIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Emits one {@code <Entity>.print} standard print template per document (header-items) entity — the
+ * document-template DSL counterpart of the entity's Harmonia document view. The template is an
+ * authoring artifact at the project root: on publish the {@code PrintTemplateSynchronizer} seeds it
+ * into the CMS under {@code Templates/<Entity>/Print/<lang>/} where business users download and
+ * upload customizations through the Documents perspective; the generated file is only the
+ * never-customized default.
+ *
+ * <p>
+ * Document masters are detected exactly like the EDM generator's document layout: an entity is a
+ * document master when it is the composition parent of a child entity named {@code *Item}.
+ *
+ * <p>
+ * The data contract the template binds against (assembled by the Print action from the already
+ * loaded page state): a {@code document} object with the header entity's PascalCase properties
+ * (relation FKs already resolved to display labels by the client) and an {@code items} list with
+ * the line-item properties.
+ */
+@Component
+@Order(800)
+public class PrintIntentGenerator implements IntentTargetGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PrintIntentGenerator.class);
+
+    @Override
+    public String name() {
+        return "print";
+    }
+
+    @Override
+    public void generate(IntentGenerationContext context) {
+        IntentModel model = context.getModel();
+        Map<EntityIntent, EntityIntent> masters = documentMasters(model);
+        for (Map.Entry<EntityIntent, EntityIntent> master : masters.entrySet()) {
+            String fileName = master.getKey()
+                                    .getName()
+                    + ".print";
+            context.writeModelFile(fileName, buildTemplate(master.getKey(), master.getValue()));
+            LOGGER.debug("Generated standard print template [{}]", fileName);
+        }
+    }
+
+    /**
+     * The document masters of the model: entities that are the composition parent of a {@code *Item}
+     * child, mapped to that items entity (first {@code *Item} child wins, in declaration order — the
+     * same convention the EDM generator uses for the document layout).
+     *
+     * @param model the parsed intent model
+     * @return master entity to items entity, in declaration order
+     */
+    static Map<EntityIntent, EntityIntent> documentMasters(IntentModel model) {
+        Map<String, EntityIntent> byName = new LinkedHashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() != null) {
+                byName.put(entity.getName(), entity);
+            }
+        }
+        Map<EntityIntent, EntityIntent> masters = new LinkedHashMap<>();
+        for (EntityIntent child : model.getEntities()) {
+            String childName = child.getName();
+            if (childName == null || !childName.endsWith("Item")) {
+                continue;
+            }
+            for (RelationIntent relation : child.getRelations()) {
+                boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+                if (toOne && relation.isComposition() && relation.getTo() != null) {
+                    EntityIntent parent = byName.get(relation.getTo());
+                    if (parent != null && !masters.containsKey(parent)) {
+                        masters.put(parent, child);
+                    }
+                    break;
+                }
+            }
+        }
+        return masters;
+    }
+
+    /**
+     * Builds the standard template for one document master.
+     *
+     * @param master the header entity
+     * @param items the line-items entity
+     * @return the {@code .print} template source
+     */
+    static String buildTemplate(EntityIntent master, EntityIntent items) {
+        String label = IntentNaming.humanize(master.getName());
+        StringBuilder template = new StringBuilder(4096);
+        template.append("<!-- Standard print template for ")
+                .append(label)
+                .append(", generated from the intent model.\n")
+                .append("     The published copy is seeded into the CMS under Templates/")
+                .append(master.getName())
+                .append("/Print/<lang>/ where it\n")
+                .append("     can be customized (download/upload) through the Documents perspective. -->\n");
+        template.append("<document id=\"")
+                .append(IntentNaming.upperSnake(master.getName())
+                                    .toLowerCase()
+                                    .replace('_', '-'))
+                .append("-print\">\n");
+        template.append("    <page width=\"595\" height=\"842\" padding=\"40\">\n\n");
+
+        // header: humanized title + the document number (when a documentTitle field exists)
+        template.append("        <header>\n");
+        template.append("            <text align=\"right\" style=\"title\">")
+                .append(escape(label))
+                .append("</text>\n");
+        FieldIntent number = documentTitleField(master);
+        if (number != null) {
+            template.append("            <text align=\"right\" style=\"subtitle\">{{document.")
+                    .append(IntentNaming.pascalCase(number.getName()))
+                    .append("}}</text>\n");
+        }
+        template.append("            <line/>\n");
+        template.append("        </header>\n\n");
+
+        // header fields: plain non-aggregate fields + to-one relations (labels resolved client-side)
+        template.append("        <section>\n");
+        for (FieldIntent field : master.getFields()) {
+            if (field.isPrimaryKey() || field.isAggregate() || field == number) {
+                continue;
+            }
+            appendField(template, "            ", field.getName());
+        }
+        for (RelationIntent relation : master.getRelations()) {
+            if (isToOne(relation)) {
+                appendField(template, "            ", relation.getName());
+            }
+        }
+        template.append("        </section>\n\n");
+
+        // line items
+        template.append("        <table source=\"items\">\n");
+        List<FieldIntent> itemFields = itemColumns(items);
+        for (int i = 0; i < itemFields.size(); i++) {
+            FieldIntent field = itemFields.get(i);
+            String width = i == 0 ? "3*" : "*";
+            String align = isNumeric(field) ? " align=\"right\"" : "";
+            template.append("            <column width=\"")
+                    .append(width)
+                    .append("\"")
+                    .append(align)
+                    .append(" label=\"")
+                    .append(escape(IntentNaming.humanize(field.getName())))
+                    .append("\">{{")
+                    .append(IntentNaming.pascalCase(field.getName()))
+                    .append("}}</column>\n");
+        }
+        template.append("        </table>\n\n");
+
+        // totals: aggregate fields, the last one emphasized as the document total
+        List<FieldIntent> aggregates = new ArrayList<>();
+        for (FieldIntent field : master.getFields()) {
+            if (field.isAggregate()) {
+                aggregates.add(field);
+            }
+        }
+        if (!aggregates.isEmpty()) {
+            template.append("        <section align=\"right\">\n");
+            FieldIntent total = totalField(aggregates);
+            for (FieldIntent aggregate : aggregates) {
+                if (aggregate == total) {
+                    continue;
+                }
+                appendField(template, "            ", aggregate.getName());
+            }
+            template.append("            <total align=\"right\">{{document.")
+                    .append(IntentNaming.pascalCase(total.getName()))
+                    .append("}}</total>\n");
+            template.append("        </section>\n\n");
+        }
+
+        template.append("        <footer>\n");
+        template.append("            <text align=\"center\">")
+                .append(escape(label))
+                .append(" {{document.")
+                .append(number != null ? IntentNaming.pascalCase(number.getName()) : "Id")
+                .append("}}</text>\n");
+        template.append("        </footer>\n\n");
+        template.append("    </page>\n");
+        template.append("</document>\n");
+        return template.toString();
+    }
+
+    private static void appendField(StringBuilder template, String indent, String name) {
+        template.append(indent)
+                .append("<field label=\"")
+                .append(escape(IntentNaming.humanize(name)))
+                .append("\">{{document.")
+                .append(IntentNaming.pascalCase(name))
+                .append("}}</field>\n");
+    }
+
+    /** The line-item columns: every field except the PK; the master FK relation never shows. */
+    private static List<FieldIntent> itemColumns(EntityIntent items) {
+        List<FieldIntent> columns = new ArrayList<>();
+        for (FieldIntent field : items.getFields()) {
+            if (!field.isPrimaryKey()) {
+                columns.add(field);
+            }
+        }
+        return columns;
+    }
+
+    private static FieldIntent documentTitleField(EntityIntent master) {
+        for (FieldIntent field : master.getFields()) {
+            if (field.isDocumentTitle()) {
+                return field;
+            }
+        }
+        return null;
+    }
+
+    /** The field named {@code total} when present, else the last aggregate. */
+    private static FieldIntent totalField(List<FieldIntent> aggregates) {
+        for (FieldIntent aggregate : aggregates) {
+            if ("total".equalsIgnoreCase(aggregate.getName())) {
+                return aggregate;
+            }
+        }
+        return aggregates.get(aggregates.size() - 1);
+    }
+
+    private static boolean isToOne(RelationIntent relation) {
+        return ("manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind())) && !relation.isComposition();
+    }
+
+    private static boolean isNumeric(FieldIntent field) {
+        return switch (field.getType() == null ? "" : field.getType()) {
+            case "integer", "int", "long", "decimal", "double" -> true;
+            default -> false;
+        };
+    }
+
+    private static String escape(String text) {
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;");
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.print;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.eclipse.dirigible.parsers.document.DocumentNode;
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.junit.jupiter.api.Test;
+
+class PrintIntentGeneratorTest {
+
+    private static final String INTENT = """
+            name: sales
+            entities:
+              - name: SalesInvoiceStatus
+                kind: setting
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: SalesInvoice
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string, documentTitle: true }
+                  - { name: date, type: date, required: true }
+                  - { name: net, type: decimal, aggregate: true }
+                  - { name: total, type: decimal, aggregate: true }
+                relations:
+                  - { name: Status, kind: manyToOne, to: SalesInvoiceStatus }
+              - name: SalesInvoiceItem
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+                  - { name: quantity, type: decimal, required: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+              - name: Customer
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+            """;
+
+    private final IntentModel model = IntentParser.parse(INTENT);
+
+    @Test
+    void detectsOnlyDocumentMasters() {
+        Map<EntityIntent, EntityIntent> masters = PrintIntentGenerator.documentMasters(model);
+        assertEquals(1, masters.size());
+        EntityIntent master = masters.keySet()
+                                     .iterator()
+                                     .next();
+        assertEquals("SalesInvoice", master.getName());
+        assertEquals("SalesInvoiceItem", masters.get(master)
+                                                .getName());
+    }
+
+    @Test
+    void buildsAParseableStandardTemplate() {
+        Map<EntityIntent, EntityIntent> masters = PrintIntentGenerator.documentMasters(model);
+        EntityIntent master = masters.keySet()
+                                     .iterator()
+                                     .next();
+        String template = PrintIntentGenerator.buildTemplate(master, masters.get(master));
+
+        // must parse cleanly with the document-template DSL parser
+        DocumentNode document = new DocumentParser().parseDocument(template);
+        assertEquals("sales-invoice-print", document.attributes()
+                                                    .get("id"));
+
+        // title + number subtitle in the header, bound to the document data contract
+        assertTrue(template.contains(">Sales Invoice</text>"));
+        assertTrue(template.contains("{{document.Number}}"));
+        // header fields: date + the Status relation; never the PK or aggregates
+        assertTrue(template.contains("<field label=\"Date\">{{document.Date}}</field>"));
+        assertTrue(template.contains("<field label=\"Status\">{{document.Status}}</field>"));
+        assertFalse(template.contains("{{document.Id}}</field>"));
+        // items table bound to the items list, first column wide, numeric right-aligned
+        assertTrue(template.contains("<table source=\"items\">"));
+        assertTrue(template.contains("<column width=\"3*\" label=\"Name\">{{Name}}</column>"));
+        assertTrue(template.contains("<column width=\"*\" align=\"right\" label=\"Quantity\">{{Quantity}}</column>"));
+        // totals: net as a field, total emphasized
+        assertTrue(template.contains("<field label=\"Net\">{{document.Net}}</field>"));
+        assertTrue(template.contains("<total align=\"right\">{{document.Total}}</total>"));
+    }
+
+    @Test
+    void generationIsDeterministic() {
+        Map<EntityIntent, EntityIntent> masters = PrintIntentGenerator.documentMasters(model);
+        EntityIntent master = masters.keySet()
+                                     .iterator()
+                                     .next();
+        String first = PrintIntentGenerator.buildTemplate(master, masters.get(master));
+        String second = PrintIntentGenerator.buildTemplate(master, masters.get(master));
+        assertEquals(first, second);
+    }
+}

--- a/components/group/group-engines/pom.xml
+++ b/components/group/group-engines/pom.xml
@@ -103,6 +103,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-document</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-engine-websockets</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -81,6 +81,7 @@
         <module>engine/engine-security</module>
         <module>engine/engine-listeners</module>
         <module>engine/engine-intent</module>
+        <module>engine/engine-document</module>
         <module>engine/engine-odata</module>
         <module>engine/engine-open-telemetry</module>
         <module>engine/engine-camel</module>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -143,6 +143,11 @@ document.addEventListener('alpine:init', () => {
     draftMode: 'create',     // 'create' | 'edit'
     draftSaving: false,
     draftError: null,
+    // Print (renders the CMS-seeded .print template server-side to PDF)
+    printLangOpen: false,
+    printLanguages: [],
+    printBusy: false,
+    printError: null,
 
     apiPath: '/${javaPerspectiveName}/${name}Controller',
 
@@ -153,6 +158,66 @@ document.addEventListener('alpine:init', () => {
     // Any OTHER composition child of this master (not the line-items entity) renders as a normal panel —
     // like the line items, only once the document (header) exists (nothing to allocate against on Create).
     get secondaryDetails() { return this.itemsEnabled ? App.detailsFor('${name}').filter(d => d.entity !== '${documentItemsEntity}') : []; },
+
+    // ===== Print: the .print template lives in the CMS (Templates/${name}/Print/<lang>/), where it
+    // can be customized via the Documents perspective. One language prints directly; several ask.
+    async openPrint() {
+      this.printError = null;
+      this.printBusy = true;
+      let languages = [];
+      try {
+        languages = (await App.services.api.get('/services/print/${name}/languages', { baseUrl: '' })) || [];
+      } catch (e) {
+        console.error('Print languages lookup failed', e);
+      }
+      this.printBusy = false;
+      if (languages.length > 1) {
+        this.printLanguages = languages;
+        this.printLangOpen = true;
+      } else {
+        // zero languages still attempts the default: the server answers with a clear 404
+        await this.printDoc(languages.length === 1 ? languages[0].code : 'en');
+      }
+    },
+
+    async printDoc(lang) {
+      this.printError = null;
+      this.printBusy = true;
+      try {
+        const response = await fetch('/services/print/${name}?lang=' + encodeURIComponent(lang), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(this.printPayload()),
+        });
+        if (!response.ok) {
+          this.printError = response.status === 404
+            ? 'No print template found. Publish the project or upload one via Documents.'
+            : 'Print failed (' + response.status + ')';
+          return;
+        }
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 60000);
+      } catch (e) {
+        console.error('Print failed', e);
+        this.printError = 'Print failed';
+      } finally {
+        this.printBusy = false;
+      }
+    },
+
+    // The template data contract: `document` = the loaded record overlaid with current edits and
+    // dropdown FKs resolved to their display labels; `items` = the line items as loaded.
+    printPayload() {
+      const doc = Object.assign({}, this.record, this.form);
+#foreach($property in $properties)
+#if(($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS") && $property.aggregate != "true")
+      doc.${property.name} = ((this.options${property.name}.find(o => String(o.value) === String(doc.${property.name})) || {}).text) || doc.${property.name};
+#end
+#end
+      return { document: doc, items: this.items };
+    },
 
     async init() {
       const params = (window.PineconeRouter.context && window.PineconeRouter.context.params) || {};

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -264,6 +264,12 @@
       </template>
 #end
       <div x-h-toolbar-spacer></div>
+      <span class="text-sm text-secondary-foreground" x-show="printError" x-text="printError"></span>
+      <!-- Print: renders the CMS template (Templates/${name}/Print/<lang>/) to PDF; asks for the language when several exist -->
+      <button type="button" x-h-button data-variant="outline" x-show="isEdit" :disabled="printBusy" @click="openPrint()">
+        <span x-show="printBusy" x-h-spinner></span>
+        <i role="img" data-lucide="printer" x-show="!printBusy"></i><span>Print</span>
+      </button>
       <button type="button" x-h-button data-variant="transparent" @click="backToList()" :disabled="state === 'saving'">Cancel</button>
       <button type="button" x-h-button data-variant="primary" :disabled="state === 'saving'" @click="save()">
         <span x-show="state === 'saving'" x-h-spinner></span>
@@ -375,6 +381,27 @@
       <div x-h-dialog-footer>
         <button x-h-button data-variant="transparent" @click="deleteOpen = false">Cancel</button>
         <button x-h-button data-variant="negative" @click="confirmDeleteRow()">Delete</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Print language picker: shown when more than one template language exists under
+       Templates/${name}/Print/ in the CMS ("English" -> en, "Bulgarian" -> bg, ...) -->
+  <div x-h-dialog-overlay :data-open="printLangOpen">
+    <div x-h-dialog>
+      <div x-h-dialog-header>
+        <h2 x-h-dialog-title>Print</h2>
+        <p x-h-dialog-description>Choose the template language.</p>
+        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"></button>
+      </div>
+      <div x-h-dialog-content>
+        <div class="vbox gap-2">
+          <template x-for="lang in printLanguages" :key="lang.code">
+            <button type="button" x-h-button data-variant="outline" @click="printLangOpen = false; printDoc(lang.code)">
+              <i role="img" data-lucide="printer"></i><span x-text="lang.name"></span>
+            </button>
+          </template>
+        </div>
       </div>
     </div>
   </div>

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
@@ -9,8 +9,12 @@
  */
 package org.eclipse.dirigible.parsers.document.binding;
 
+import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -172,10 +176,24 @@ public final class DataBinder {
             Object resolved = scope.resolve(value.substring(open + 2, close)
                                                  .trim());
             if (resolved != null) {
-                result.append(resolved);
+                result.append(stringify(resolved));
             }
             cursor = close + 2;
         }
+    }
+
+    /**
+     * Floating-point values print in the generated forms' money pattern ({@code ### ### ### ##0.00} —
+     * thousands grouped by a space, two decimals), locale-independent for deterministic output; every
+     * other value prints via {@code toString}.
+     */
+    private static String stringify(Object resolved) {
+        if (resolved instanceof Double || resolved instanceof Float || resolved instanceof BigDecimal) {
+            DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.ROOT);
+            symbols.setGroupingSeparator(' ');
+            return new DecimalFormat("###,###,###,##0.00", symbols).format(resolved);
+        }
+        return String.valueOf(resolved);
     }
 
     private static boolean isTruthy(Object value) {

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.binding;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.dirigible.parsers.document.Attributes;
+import org.eclipse.dirigible.parsers.document.ForNode;
+import org.eclipse.dirigible.parsers.document.IfNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.RowNode;
+import org.eclipse.dirigible.parsers.document.TableNode;
+import org.eclipse.dirigible.parsers.document.parser.NodeFactory;
+import org.eclipse.dirigible.parsers.document.parser.TagRegistry;
+
+/**
+ * The data-binding layer that turns a parsed template into a data-shaped AST: Mustache placeholders
+ * ({@code {{invoice.number}}}) in text and attribute values are substituted from a map-based
+ * context, a {@code table}/{@code for} node's {@code source} list is expanded into one row per
+ * element (each rendered in the row's scope), and an {@code if} node keeps or drops its children by
+ * the truthiness of its {@code source}.
+ *
+ * <p>
+ * The context is plain {@code Map<String, Object>} / {@code List<Object>} data (e.g. a JSON-decoded
+ * entity). Paths walk nested maps ({@code customer.name}); inside a row scope a bare path
+ * ({@code quantity}) resolves against the row first, then the enclosing document context. An
+ * unresolved placeholder renders as an empty string — a printout must never show raw braces.
+ */
+public final class DataBinder {
+
+    private final TagRegistry registry;
+
+    /**
+     * Creates a binder over the built-in tag registry.
+     */
+    public DataBinder() {
+        this(TagRegistry.builtIn());
+    }
+
+    /**
+     * Creates a binder that rebuilds nodes through a custom tag registry — required when the template
+     * was parsed with registered extension tags.
+     *
+     * @param registry the registry the template was parsed with
+     */
+    public DataBinder(TagRegistry registry) {
+        this.registry = Objects.requireNonNull(registry, "registry");
+    }
+
+    /**
+     * Binds the template to the data.
+     *
+     * @param root the parsed template root
+     * @param data the document data context
+     * @return a new AST with placeholders substituted and {@code table}/{@code for}/{@code if} expanded
+     */
+    public Node bind(Node root, Map<String, Object> data) {
+        Objects.requireNonNull(root, "root");
+        Objects.requireNonNull(data, "data");
+        Scope scope = new Scope(data, null);
+        return rebuild(root, scope, bindChildren(root, scope));
+    }
+
+    private List<Node> bindChildren(Node node, Scope scope) {
+        List<Node> bound = new ArrayList<>();
+        for (Node child : node.children()) {
+            switch (child) {
+                case IfNode ifNode -> {
+                    if (isTruthy(scope.resolve(ifNode.attributes()
+                                                     .get("source")))) {
+                        bound.addAll(bindChildren(ifNode, scope));
+                    }
+                }
+                case ForNode forNode -> expandRows(forNode, scope, bound);
+                case TableNode table -> bound.add(expandTable(table, scope));
+                default -> bound.add(rebuild(child, scope, bindChildren(child, scope)));
+            }
+        }
+        return bound;
+    }
+
+    /**
+     * A table keeps its column definitions (widths/labels for the renderer) and gains one {@code row}
+     * of {@code column} cells per source element; each cell's content is the column template bound in
+     * the row's scope.
+     */
+    private TableNode expandTable(TableNode table, Scope scope) {
+        List<Node> children = new ArrayList<>();
+        List<Node> columns = new ArrayList<>();
+        for (Node child : table.children()) {
+            if (child instanceof org.eclipse.dirigible.parsers.document.ColumnNode) {
+                columns.add(child);
+                children.add(rebuildWithoutText(child));
+            }
+        }
+        for (Object element : asList(scope.resolve(table.attributes()
+                                                        .get("source")))) {
+            Scope rowScope = new Scope(asMap(element), scope);
+            List<Node> cells = new ArrayList<>();
+            for (Node column : columns) {
+                cells.add(rebuild(column, rowScope, bindChildren(column, rowScope)));
+            }
+            children.add(new RowNode(table.position(), Attributes.EMPTY, cells, ""));
+        }
+        return new TableNode(table.position(), bindAttributes(table, scope), children, table.text());
+    }
+
+    private void expandRows(ForNode forNode, Scope scope, List<Node> target) {
+        for (Object element : asList(scope.resolve(forNode.attributes()
+                                                          .get("source")))) {
+            Scope rowScope = new Scope(asMap(element), scope);
+            target.addAll(bindChildren(forNode, rowScope));
+        }
+    }
+
+    private Node rebuild(Node node, Scope scope, List<Node> children) {
+        NodeFactory factory = registry.factory(node.tag());
+        if (factory == null) {
+            throw new IllegalStateException("Tag <" + node.tag() + "> is not registered in the binder's registry");
+        }
+        return factory.create(node.tag(), node.position(), bindAttributes(node, scope), children, substitute(node.text(), scope));
+    }
+
+    /** A column definition kept for the renderer: attributes stay, the cell template is dropped. */
+    private Node rebuildWithoutText(Node column) {
+        NodeFactory factory = registry.factory(column.tag());
+        return factory.create(column.tag(), column.position(), column.attributes(), List.of(), "");
+    }
+
+    private Attributes bindAttributes(Node node, Scope scope) {
+        if (node.attributes()
+                .isEmpty()) {
+            return Attributes.EMPTY;
+        }
+        List<Attributes.Attribute> bound = new ArrayList<>();
+        for (Attributes.Attribute attribute : node.attributes()
+                                                  .asList()) {
+            bound.add(new Attributes.Attribute(attribute.name(), substitute(attribute.value(), scope), attribute.position()));
+        }
+        return Attributes.of(bound);
+    }
+
+    /** Replaces every {@code {{path}}} in the value; unresolved paths become empty strings. */
+    private static String substitute(String value, Scope scope) {
+        if (value == null || !value.contains("{{")) {
+            return value;
+        }
+        StringBuilder result = new StringBuilder(value.length());
+        int cursor = 0;
+        while (true) {
+            int open = value.indexOf("{{", cursor);
+            if (open < 0) {
+                result.append(value, cursor, value.length());
+                return result.toString();
+            }
+            int close = value.indexOf("}}", open + 2);
+            if (close < 0) {
+                result.append(value, cursor, value.length());
+                return result.toString();
+            }
+            result.append(value, cursor, open);
+            Object resolved = scope.resolve(value.substring(open + 2, close)
+                                                 .trim());
+            if (resolved != null) {
+                result.append(resolved);
+            }
+            cursor = close + 2;
+        }
+    }
+
+    private static boolean isTruthy(Object value) {
+        return switch (value) {
+            case null -> false;
+            case Boolean bool -> bool;
+            case String string -> !string.isBlank() && !string.equalsIgnoreCase("false");
+            case Number number -> number.doubleValue() != 0;
+            case List<?> list -> !list.isEmpty();
+            case Map<?, ?> map -> !map.isEmpty();
+            default -> true;
+        };
+    }
+
+    private static List<?> asList(Object value) {
+        return value instanceof List<?> list ? list : List.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object value) {
+        return value instanceof Map ? (Map<String, Object>) value : Map.of();
+    }
+
+    /** A row scope resolving against its own data first, then the enclosing scope. */
+    private record Scope(Map<String, Object> data, Scope parent) {
+
+        Object resolve(String path) {
+            if (path == null || path.isBlank()) {
+                return null;
+            }
+            Object resolved = resolveLocal(path.trim());
+            return resolved == null && parent != null ? parent.resolve(path) : resolved;
+        }
+
+        private Object resolveLocal(String path) {
+            Object current = data;
+            for (String segment : path.split("\\.")) {
+                if (!(current instanceof Map<?, ?> map)) {
+                    return null;
+                }
+                current = map.get(segment);
+            }
+            return current;
+        }
+    }
+}

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRenderer.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRenderer.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.renderer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.dirigible.parsers.document.ColumnNode;
+import org.eclipse.dirigible.parsers.document.CustomNode;
+import org.eclipse.dirigible.parsers.document.DocumentNode;
+import org.eclipse.dirigible.parsers.document.FieldNode;
+import org.eclipse.dirigible.parsers.document.FooterNode;
+import org.eclipse.dirigible.parsers.document.ForNode;
+import org.eclipse.dirigible.parsers.document.HeaderNode;
+import org.eclipse.dirigible.parsers.document.IfNode;
+import org.eclipse.dirigible.parsers.document.ImageNode;
+import org.eclipse.dirigible.parsers.document.LineNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.PageNode;
+import org.eclipse.dirigible.parsers.document.RowNode;
+import org.eclipse.dirigible.parsers.document.SectionNode;
+import org.eclipse.dirigible.parsers.document.SpaceNode;
+import org.eclipse.dirigible.parsers.document.StackNode;
+import org.eclipse.dirigible.parsers.document.TableNode;
+import org.eclipse.dirigible.parsers.document.TextNode;
+import org.eclipse.dirigible.parsers.document.TotalNode;
+import org.eclipse.dirigible.parsers.document.layout.Alignment;
+import org.eclipse.dirigible.parsers.document.layout.LayoutEngine;
+import org.eclipse.dirigible.parsers.document.layout.LayoutNode;
+import org.eclipse.dirigible.parsers.document.layout.Measurement;
+
+/**
+ * Renders a data-bound layout tree into a self-contained XSLT stylesheet with literal XSL-FO — the
+ * exact input the platform's FOP-based PDF facade transforms into a PDF (the stylesheet matches any
+ * data document, e.g. {@code <data/>}, because all data was already merged by the
+ * {@code DataBinder}).
+ *
+ * <p>
+ * Deliberate v1 simplifications: {@code header}/{@code footer} render once in the flow (not as
+ * repeated page regions), {@code repeatHeader} and {@code pageBreak} are ignored, a data-less
+ * {@code table} is skipped entirely (FOP rejects an empty table body), and measurements map
+ * 1&nbsp;px&nbsp;=&nbsp;1&nbsp;pt.
+ */
+public final class XslFoRenderer implements DocumentRenderer<String> {
+
+    private static final double DEFAULT_PAGE_WIDTH = 595;
+    private static final double DEFAULT_PAGE_HEIGHT = 842;
+    private static final double DEFAULT_PAGE_PADDING = 40;
+
+    /**
+     * Creates a renderer; instances are stateless and reusable.
+     */
+    public XslFoRenderer() {}
+
+    @Override
+    public String render(LayoutNode root) {
+        LayoutNode page = findPage(root);
+        double width = pageDimension(page, "width", DEFAULT_PAGE_WIDTH);
+        double height = pageDimension(page, "height", DEFAULT_PAGE_HEIGHT);
+        double padding = pageDimension(page, "padding", DEFAULT_PAGE_PADDING);
+
+        StringBuilder fo = new StringBuilder(8192);
+        fo.append("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:fo="http://www.w3.org/1999/XSL/Format">
+                <xsl:template match="/">
+                <fo:root font-family="Helvetica" font-size="10pt">
+                """);
+        fo.append("<fo:layout-master-set><fo:simple-page-master master-name=\"page\" page-width=\"")
+          .append(points(width))
+          .append("\" page-height=\"")
+          .append(points(height))
+          .append("\" margin=\"")
+          .append(points(padding))
+          .append("\"><fo:region-body/></fo:simple-page-master></fo:layout-master-set>\n");
+        fo.append("<fo:page-sequence master-reference=\"page\"><fo:flow flow-name=\"xsl-region-body\">\n");
+        appendChildren(fo, page == null ? root : page);
+        fo.append("</fo:flow></fo:page-sequence>\n");
+        fo.append("</fo:root>\n</xsl:template>\n</xsl:stylesheet>\n");
+        return fo.toString();
+    }
+
+    private static LayoutNode findPage(LayoutNode root) {
+        if (root.source() instanceof PageNode) {
+            return root;
+        }
+        for (LayoutNode child : root.children()) {
+            if (child.source() instanceof PageNode) {
+                return child;
+            }
+        }
+        return null;
+    }
+
+    private static double pageDimension(LayoutNode page, String attribute, double fallback) {
+        if (page == null) {
+            return fallback;
+        }
+        String raw = page.source()
+                         .attributes()
+                         .get(attribute);
+        if (raw == null || raw.isBlank()) {
+            return fallback;
+        }
+        Measurement measurement = Measurement.parse(raw);
+        return measurement.type() == Measurement.Type.ABSOLUTE_PX ? measurement.value() : fallback;
+    }
+
+    private void appendChildren(StringBuilder fo, LayoutNode node) {
+        for (LayoutNode child : node.children()) {
+            appendNode(fo, child);
+        }
+    }
+
+    private void appendNode(StringBuilder fo, LayoutNode node) {
+        switch (node.source()) {
+            case HeaderNode ignored -> appendBlockContainer(fo, node, "space-after=\"10pt\"");
+            case FooterNode ignored -> appendBlockContainer(fo, node, "space-before=\"14pt\" font-size=\"8pt\" color=\"#666666\"");
+            case SectionNode ignored -> appendBlockContainer(fo, node, "space-after=\"8pt\"");
+            case StackNode ignored -> appendBlockContainer(fo, node, "");
+            case ColumnNode ignored -> appendBlockContainer(fo, node, "");
+            case TextNode text -> appendText(fo, node, text);
+            case FieldNode field -> appendField(fo, node, field);
+            case TotalNode total -> appendTotal(fo, node, total);
+            case RowNode ignored -> appendRow(fo, node);
+            case TableNode ignored -> appendTable(fo, node);
+            case ImageNode image -> appendImage(fo, node, image);
+            case LineNode ignored -> fo.append(
+                    "<fo:block space-before=\"4pt\" space-after=\"4pt\"><fo:leader leader-pattern=\"rule\" leader-length=\"100%\" rule-thickness=\"0.5pt\" color=\"#999999\"/></fo:block>\n");
+            case SpaceNode ignored -> fo.append("<fo:block space-after=\"")
+                                        .append(points(heightOr(node, 10)))
+                                        .append("\"><fo:leader/></fo:block>\n");
+            case DocumentNode ignored -> appendChildren(fo, node);
+            case PageNode ignored -> appendChildren(fo, node);
+            case IfNode ignored -> appendChildren(fo, node); // pre-expanded by the DataBinder
+            case ForNode ignored -> appendChildren(fo, node); // pre-expanded by the DataBinder
+            case CustomNode custom -> {
+                appendTextBlock(fo, node, custom.text(), "");
+                appendChildren(fo, node);
+            }
+        }
+    }
+
+    private void appendBlockContainer(StringBuilder fo, LayoutNode node, String extraAttributes) {
+        fo.append("<fo:block")
+          .append(alignAttribute(node))
+          .append(extraAttributes.isEmpty() ? "" : " " + extraAttributes)
+          .append(">\n");
+        if (!node.source()
+                 .text()
+                 .isEmpty()) {
+            fo.append("<fo:block>")
+              .append(escape(node.source()
+                                 .text()))
+              .append("</fo:block>\n");
+        }
+        appendChildren(fo, node);
+        fo.append("</fo:block>\n");
+    }
+
+    private void appendText(StringBuilder fo, LayoutNode node, TextNode text) {
+        String style = text.attributes()
+                           .getOrDefault("style", "");
+        String styleAttributes = switch (style) {
+            case "title" -> " font-size=\"18pt\" font-weight=\"bold\"";
+            case "subtitle" -> " font-size=\"12pt\" color=\"#444444\"";
+            case "caption" -> " font-size=\"9pt\" font-weight=\"bold\" color=\"#666666\"";
+            default -> "";
+        };
+        appendTextBlock(fo, node, text.text(), styleAttributes);
+    }
+
+    private void appendTextBlock(StringBuilder fo, LayoutNode node, String text, String styleAttributes) {
+        fo.append("<fo:block")
+          .append(alignAttribute(node))
+          .append(styleAttributes)
+          .append(">")
+          .append(escape(text))
+          .append("</fo:block>\n");
+        appendChildren(fo, node);
+    }
+
+    private void appendField(StringBuilder fo, LayoutNode node, FieldNode field) {
+        String label = field.attributes()
+                            .getOrDefault("label", "");
+        fo.append("<fo:block")
+          .append(alignAttribute(node))
+          .append(">");
+        if (!label.isEmpty()) {
+            fo.append("<fo:inline font-weight=\"bold\">")
+              .append(escape(label))
+              .append(": </fo:inline>");
+        }
+        fo.append(escape(field.text()))
+          .append("</fo:block>\n");
+    }
+
+    private void appendTotal(StringBuilder fo, LayoutNode node, TotalNode total) {
+        fo.append("<fo:block")
+          .append(alignAttribute(node))
+          .append(" font-size=\"12pt\" font-weight=\"bold\" space-before=\"6pt\">")
+          .append(escape(total.text()))
+          .append("</fo:block>\n");
+    }
+
+    /** A free-standing row is a single-row table whose columns come from the children's widths. */
+    private void appendRow(StringBuilder fo, LayoutNode node) {
+        if (node.children()
+                .isEmpty()) {
+            return;
+        }
+        fo.append("<fo:table table-layout=\"fixed\" width=\"100%\">\n");
+        List<Measurement> widths = new ArrayList<>();
+        for (LayoutNode child : node.children()) {
+            widths.add(child.width());
+        }
+        appendColumnDefinitions(fo, widths);
+        fo.append("<fo:table-body><fo:table-row>\n");
+        for (LayoutNode child : node.children()) {
+            fo.append("<fo:table-cell>");
+            appendNode(fo, child);
+            fo.append("</fo:table-cell>\n");
+        }
+        fo.append("</fo:table-row></fo:table-body></fo:table>\n");
+    }
+
+    /**
+     * A data table: column definitions carry widths and optional {@code label}s (a header row is
+     * emitted when any label is present); the {@code row} children are the data rows.
+     */
+    private void appendTable(StringBuilder fo, LayoutNode node) {
+        List<LayoutNode> columns = new ArrayList<>();
+        List<LayoutNode> rows = new ArrayList<>();
+        for (LayoutNode child : node.children()) {
+            if (child.source() instanceof ColumnNode) {
+                columns.add(child);
+            } else if (child.source() instanceof RowNode) {
+                rows.add(child);
+            }
+        }
+        if (rows.isEmpty()) {
+            return; // FOP rejects an empty fo:table-body
+        }
+        fo.append("<fo:table table-layout=\"fixed\" width=\"100%\" space-after=\"8pt\">\n");
+        List<Measurement> widths = new ArrayList<>();
+        for (LayoutNode column : columns) {
+            widths.add(column.width()
+                             .type() == Measurement.Type.AUTO ? Measurement.fraction(1) : column.width());
+        }
+        appendColumnDefinitions(fo, widths);
+        boolean hasLabels = columns.stream()
+                                   .anyMatch(column -> column.source()
+                                                             .attributes()
+                                                             .has("label"));
+        if (hasLabels) {
+            fo.append("<fo:table-header><fo:table-row border-bottom=\"0.5pt solid #999999\">\n");
+            for (LayoutNode column : columns) {
+                fo.append("<fo:table-cell padding=\"2pt\"><fo:block font-weight=\"bold\"")
+                  .append(alignAttribute(column))
+                  .append(">")
+                  .append(escape(column.source()
+                                       .attributes()
+                                       .getOrDefault("label", "")))
+                  .append("</fo:block></fo:table-cell>\n");
+            }
+            fo.append("</fo:table-row></fo:table-header>\n");
+        }
+        fo.append("<fo:table-body>\n");
+        for (LayoutNode row : rows) {
+            fo.append("<fo:table-row>\n");
+            for (LayoutNode cell : row.children()) {
+                fo.append("<fo:table-cell padding=\"2pt\"><fo:block")
+                  .append(alignAttribute(cell))
+                  .append(">")
+                  .append(escape(cell.source()
+                                     .text()))
+                  .append("</fo:block></fo:table-cell>\n");
+            }
+            fo.append("</fo:table-row>\n");
+        }
+        fo.append("</fo:table-body></fo:table>\n");
+    }
+
+    private void appendColumnDefinitions(StringBuilder fo, List<Measurement> widths) {
+        for (Measurement width : widths) {
+            fo.append("<fo:table-column column-width=\"")
+              .append(switch (width.type()) {
+                  case ABSOLUTE_PX -> points(width.value());
+                  case PERCENT -> trim(width.value()) + "%";
+                  case FRACTION -> "proportional-column-width(" + trim(width.value()) + ")";
+                  case AUTO -> "proportional-column-width(1)";
+              })
+              .append("\"/>\n");
+        }
+    }
+
+    private void appendImage(StringBuilder fo, LayoutNode node, ImageNode image) {
+        String src = image.attributes()
+                          .getOrDefault("src", "");
+        if (src.isEmpty()) {
+            return;
+        }
+        fo.append("<fo:block")
+          .append(alignAttribute(node))
+          .append("><fo:external-graphic src=\"")
+          .append(escape(src))
+          .append("\"");
+        if (node.width()
+                .type() == Measurement.Type.ABSOLUTE_PX) {
+            fo.append(" content-width=\"")
+              .append(points(node.width()
+                                 .value()))
+              .append("\"");
+        }
+        fo.append("/></fo:block>\n");
+    }
+
+    private static String alignAttribute(LayoutNode node) {
+        if (node.alignment() == Alignment.LEFT) {
+            return "";
+        }
+        return " text-align=\"" + node.alignment()
+                                      .name()
+                                      .toLowerCase()
+                + "\"";
+    }
+
+    private static double heightOr(LayoutNode node, double fallback) {
+        return node.height()
+                   .type() == Measurement.Type.ABSOLUTE_PX ? node.height()
+                                                                 .value()
+                           : fallback;
+    }
+
+    private static String points(double value) {
+        return trim(value) + "pt";
+    }
+
+    private static String trim(double value) {
+        return value == Math.rint(value) ? String.valueOf((long) value) : String.valueOf(value);
+    }
+
+    private static String escape(String text) {
+        StringBuilder escaped = new StringBuilder(text.length());
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            switch (c) {
+                case '&' -> escaped.append("&amp;");
+                case '<' -> escaped.append("&lt;");
+                case '>' -> escaped.append("&gt;");
+                default -> escaped.append(c);
+            }
+        }
+        return escaped.toString();
+    }
+
+    /**
+     * Convenience for the common pipeline: normalize the bound AST and render it.
+     *
+     * @param boundRoot the data-bound AST (output of the {@code DataBinder})
+     * @return the XSL-FO stylesheet
+     */
+    public String renderBound(Node boundRoot) {
+        return render(new LayoutEngine().layout(boundRoot));
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.binding;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.parsers.document.ColumnNode;
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.RowNode;
+import org.eclipse.dirigible.parsers.document.TableNode;
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.junit.Test;
+
+public class DataBinderTest {
+
+    private final DocumentParser parser = new DocumentParser();
+    private final DataBinder binder = new DataBinder();
+
+    @Test
+    public void substitutesPlaceholdersInTextAndAttributes() {
+        Node root = parser.parse("<document><field label=\"No\">{{invoice.number}}</field><image src=\"{{company.logo}}\"/></document>");
+        Node bound = binder.bind(root, Map.of("invoice", Map.of("number", "SI-1"), "company", Map.of("logo", "/logo.png")));
+        assertEquals("SI-1", bound.children()
+                                  .get(0)
+                                  .text());
+        assertEquals("/logo.png", bound.children()
+                                       .get(1)
+                                       .attributes()
+                                       .get("src"));
+    }
+
+    @Test
+    public void unresolvedPlaceholdersRenderEmpty() {
+        Node root = parser.parse("<document><text>Hi {{missing.path}}!</text></document>");
+        Node bound = binder.bind(root, Map.of());
+        assertEquals("Hi !", bound.children()
+                                  .get(0)
+                                  .text());
+    }
+
+    @Test
+    public void mixedTextAroundPlaceholdersIsPreserved() {
+        Node root = parser.parse("<document><text>Page {{page}} of {{pages}}</text></document>");
+        Node bound = binder.bind(root, Map.of("page", 1, "pages", 3));
+        assertEquals("Page 1 of 3", bound.children()
+                                         .get(0)
+                                         .text());
+    }
+
+    @Test
+    public void tableExpandsOneRowPerSourceElement() {
+        Node root = parser.parse("""
+                <document>
+                    <table source="invoice.items">
+                        <column width="3*">{{description}}</column>
+                        <column width="*" align="right">{{amount}}</column>
+                    </table>
+                </document>
+                """);
+        Node bound = binder.bind(root, Map.of("invoice", Map.of("items",
+                List.of(Map.of("description", "Widget", "amount", "10.00"), Map.of("description", "Gadget", "amount", "20.00")))));
+        TableNode table = (TableNode) bound.children()
+                                           .get(0);
+        // 2 column definitions (templates dropped) + 2 expanded rows
+        assertEquals(4, table.children()
+                             .size());
+        assertTrue(table.children()
+                        .get(0) instanceof ColumnNode);
+        assertEquals("", table.children()
+                              .get(0)
+                              .text());
+        RowNode firstRow = (RowNode) table.children()
+                                          .get(2);
+        assertEquals("Widget", firstRow.children()
+                                       .get(0)
+                                       .text());
+        assertEquals("10.00", firstRow.children()
+                                      .get(1)
+                                      .text());
+        assertEquals("right", firstRow.children()
+                                      .get(1)
+                                      .attributes()
+                                      .get("align"));
+    }
+
+    @Test
+    public void rowScopeFallsBackToTheDocumentScope() {
+        Node root = parser.parse("""
+                <document>
+                    <table source="items">
+                        <column>{{name}} ({{currency}})</column>
+                    </table>
+                </document>
+                """);
+        Node bound = binder.bind(root, Map.of("currency", "EUR", "items", List.of(Map.of("name", "Widget"))));
+        TableNode table = (TableNode) bound.children()
+                                           .get(0);
+        assertEquals("Widget (EUR)", table.children()
+                                          .get(1)
+                                          .children()
+                                          .get(0)
+                                          .text());
+    }
+
+    @Test
+    public void emptyOrMissingTableSourceYieldsNoRows() {
+        Node root = parser.parse("<document><table source=\"missing\"><column>{{x}}</column></table></document>");
+        TableNode table = (TableNode) binder.bind(root, Map.of())
+                                            .children()
+                                            .get(0);
+        assertEquals(1, table.children()
+                             .size());
+    }
+
+    @Test
+    public void forExpandsItsChildrenPerElement() {
+        Node root = parser.parse("""
+                <document>
+                    <for source="transactions">
+                        <text>{{date}}: {{amount}}</text>
+                    </for>
+                </document>
+                """);
+        Node bound = binder.bind(root,
+                Map.of("transactions", List.of(Map.of("date", "01-01", "amount", "5"), Map.of("date", "01-02", "amount", "7"))));
+        assertEquals(2, bound.children()
+                             .size());
+        assertEquals("01-01: 5", bound.children()
+                                      .get(0)
+                                      .text());
+        assertEquals("01-02: 7", bound.children()
+                                      .get(1)
+                                      .text());
+    }
+
+    @Test
+    public void ifKeepsChildrenWhenTruthyAndDropsThemWhenFalsy() {
+        String template = "<document><if source=\"invoice.hasDiscount\"><text>Discount!</text></if></document>";
+        Node kept = binder.bind(parser.parse(template), Map.of("invoice", Map.of("hasDiscount", true)));
+        assertEquals(1, kept.children()
+                            .size());
+        for (Object falsy : new Object[] {false, "", 0, List.of(), Map.of()}) {
+            Node dropped = binder.bind(parser.parse(template), Map.of("invoice", Map.of("hasDiscount", falsy)));
+            assertEquals("Expected no children for " + falsy, 0, dropped.children()
+                                                                        .size());
+        }
+        Node missing = binder.bind(parser.parse(template), Map.of());
+        assertEquals(0, missing.children()
+                               .size());
+    }
+
+    @Test
+    public void nestedStructuresBindRecursively() {
+        Node root = parser.parse("<document><section><row><stack><text>{{a.b}}</text></stack></row></section></document>");
+        Node bound = binder.bind(root, Map.of("a", Map.of("b", "deep")));
+        assertEquals("deep", bound.children()
+                                  .get(0)
+                                  .children()
+                                  .get(0)
+                                  .children()
+                                  .get(0)
+                                  .children()
+                                  .get(0)
+                                  .text());
+    }
+
+    @Test
+    public void bindingIsRepeatableOnTheSameTemplate() {
+        Node root = parser.parse("<document><text>{{n}}</text></document>");
+        assertEquals("1", binder.bind(root, Map.of("n", 1))
+                                .children()
+                                .get(0)
+                                .text());
+        assertEquals("2", binder.bind(root, Map.of("n", 2))
+                                .children()
+                                .get(0)
+                                .text());
+    }
+}

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
@@ -176,6 +176,20 @@ public class DataBinderTest {
     }
 
     @Test
+    public void floatingPointValuesPrintInTheFormMoneyPattern() {
+        Node root = parser.parse("<document><total align=\"right\">{{total}}</total><text>{{qty}} x {{price}}</text></document>");
+        Node bound = binder.bind(root, Map.of("total", 1234567.5d, "qty", 2L, "price", new java.math.BigDecimal("100.00")));
+        // doubles/BigDecimals: space-grouped thousands + two decimals (the generated forms' pattern);
+        // integral numbers stay unformatted
+        assertEquals("1 234 567.50", bound.children()
+                                          .get(0)
+                                          .text());
+        assertEquals("2 x 100.00", bound.children()
+                                        .get(1)
+                                        .text());
+    }
+
+    @Test
     public void bindingIsRepeatableOnTheSameTemplate() {
         Node root = parser.parse("<document><text>{{n}}</text></document>");
         assertEquals("1", binder.bind(root, Map.of("n", 1))

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRendererTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRendererTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.parsers.document.renderer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.parsers.document.Node;
+import org.eclipse.dirigible.parsers.document.binding.DataBinder;
+import org.eclipse.dirigible.parsers.document.parser.DocumentParser;
+import org.junit.Test;
+
+public class XslFoRendererTest {
+
+    private final DocumentParser parser = new DocumentParser();
+    private final DataBinder binder = new DataBinder();
+    private final XslFoRenderer renderer = new XslFoRenderer();
+
+    private String renderTemplate(String template, Map<String, Object> data) {
+        Node bound = binder.bind(parser.parse(template), data);
+        return renderer.renderBound(bound);
+    }
+
+    @Test
+    public void emitsASelfContainedStylesheetWithPageGeometry() {
+        String fo =
+                renderTemplate("<document><page width=\"595\" height=\"842\" padding=\"40\"><text>Hi</text></page></document>", Map.of());
+        assertTrue(fo.startsWith("<?xml version=\"1.0\""));
+        assertTrue(fo.contains("<xsl:template match=\"/\">"));
+        assertTrue(fo.contains("page-width=\"595pt\""));
+        assertTrue(fo.contains("page-height=\"842pt\""));
+        assertTrue(fo.contains("margin=\"40pt\""));
+        assertTrue(fo.contains("<fo:block>Hi</fo:block>"));
+    }
+
+    @Test
+    public void defaultsToA4WithoutAPageNode() {
+        String fo = renderTemplate("<document><text>Hi</text></document>", Map.of());
+        assertTrue(fo.contains("page-width=\"595pt\""));
+        assertTrue(fo.contains("page-height=\"842pt\""));
+    }
+
+    @Test
+    public void rendersTextStylesAndAlignment() {
+        String fo = renderTemplate("<document><text align=\"right\" style=\"title\">Sales Invoice</text></document>", Map.of());
+        assertTrue(fo.contains("text-align=\"right\""));
+        assertTrue(fo.contains("font-size=\"18pt\" font-weight=\"bold\""));
+        assertTrue(fo.contains(">Sales Invoice</fo:block>"));
+    }
+
+    @Test
+    public void rendersFieldsAsLabelValue() {
+        String fo = renderTemplate("<document><field label=\"Invoice No\">{{n}}</field></document>", Map.of("n", "SI-1"));
+        assertTrue(fo.contains("<fo:inline font-weight=\"bold\">Invoice No: </fo:inline>SI-1"));
+    }
+
+    @Test
+    public void rendersDataTableWithHeaderAndProportionalColumns() {
+        String fo = renderTemplate("""
+                <document>
+                    <table source="items">
+                        <column width="3*" label="Description">{{description}}</column>
+                        <column width="*" align="right" label="Amount">{{amount}}</column>
+                    </table>
+                </document>
+                """, Map.of("items", List.of(Map.of("description", "Widget", "amount", "10.00"))));
+        assertTrue(fo.contains("proportional-column-width(3)"));
+        assertTrue(fo.contains("proportional-column-width(1)"));
+        assertTrue(fo.contains("<fo:table-header>"));
+        assertTrue(fo.contains(">Description</fo:block>"));
+        assertTrue(fo.contains(">Widget</fo:block>"));
+        assertTrue(fo.contains("text-align=\"right\">10.00</fo:block>"));
+    }
+
+    @Test
+    public void percentAndPixelColumnWidthsAreEmitted() {
+        String fo = renderTemplate("""
+                <document>
+                    <table source="items">
+                        <column width="45%">{{a}}</column>
+                        <column width="100px">{{b}}</column>
+                    </table>
+                </document>
+                """, Map.of("items", List.of(Map.of("a", "x", "b", "y"))));
+        assertTrue(fo.contains("column-width=\"45%\""));
+        assertTrue(fo.contains("column-width=\"100pt\""));
+    }
+
+    @Test
+    public void tableWithoutRowsIsSkipped() {
+        String fo = renderTemplate("<document><table source=\"missing\"><column label=\"X\">{{x}}</column></table></document>", Map.of());
+        assertFalse(fo.contains("<fo:table "));
+    }
+
+    @Test
+    public void freeStandingRowBecomesASingleRowTable() {
+        String fo = renderTemplate(
+                "<document><row><stack flex=\"2\"><text>L</text></stack><stack flex=\"1\"><text>R</text></stack></row></document>",
+                Map.of());
+        assertTrue(fo.contains("proportional-column-width(2)"));
+        assertTrue(fo.contains("<fo:table-row>"));
+        assertEquals(2, fo.split("<fo:table-cell>", -1).length - 1);
+    }
+
+    @Test
+    public void escapesXmlSpecialCharacters() {
+        String fo = renderTemplate("<document><text>Fruit & Veg &lt;fresh&gt;</text></document>", Map.of());
+        assertTrue(fo.contains("Fruit &amp; Veg &lt;fresh&gt;"));
+    }
+
+    @Test
+    public void rendersLineSpaceTotalAndImage() {
+        String fo = renderTemplate("""
+                <document>
+                    <line/>
+                    <space height="20"/>
+                    <total align="right">{{t}}</total>
+                    <image src="{{logo}}" width="120"/>
+                </document>
+                """, Map.of("t", "302.00", "logo", "/logo.png"));
+        assertTrue(fo.contains("leader-pattern=\"rule\""));
+        assertTrue(fo.contains("space-after=\"20pt\""));
+        assertTrue(fo.contains("font-size=\"12pt\" font-weight=\"bold\" space-before=\"6pt\">302.00</fo:block>"));
+        assertTrue(fo.contains("<fo:external-graphic src=\"/logo.png\" content-width=\"120pt\"/>"));
+    }
+
+    @Test
+    public void salesInvoiceSampleRendersEndToEnd() throws Exception {
+        String template = new String(getClass().getResourceAsStream("/templates/sales-invoice.print")
+                                               .readAllBytes(),
+                java.nio.charset.StandardCharsets.UTF_8);
+        Map<String, Object> data = Map.of("company", Map.of("name", "ACME", "logo", "/logo.png", "address", "Main St 1"), "invoice",
+                Map.of("number", "SI00000001", "date", "2026-07-02", "dueDate", "2026-07-16", "subtotal", "260.00", "vat", "52.00", "total",
+                        "302.00", "hasDiscount", false, "items",
+                        List.of(Map.of("description", "Widget", "quantity", "2", "price", "100.00", "amount", "240.00"))),
+                "customer", Map.of("name", "John Doe", "address", "Elm St 2", "vatNumber", "BG123"), "page", 1, "pages", 1);
+        String fo = renderTemplate(template, data);
+        assertTrue(fo.contains("SI00000001"));
+        assertTrue(fo.contains(">Widget</fo:block>"));
+        assertTrue(fo.contains("302.00"));
+        assertFalse("discount line must be dropped", fo.contains("Discount"));
+        assertFalse("no unresolved placeholders may leak", fo.contains("{{"));
+    }
+}

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -181,6 +181,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-engine-document</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-engine-template</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -324,7 +324,7 @@ class IntentEngineIT extends IntegrationTest {
                                                  .body("written",
                                                          hasItems("orders.edm", "orders.model", "OrderApproval.bpmn", "ApproveOrder.form",
                                                                  "OrdersByCustomer.report", "orders.roles", "orders.glue",
-                                                                 "countries.csvim", "countries.csv"))
+                                                                 "countries.csvim", "countries.csv", "Order.print"))
                                                  .body("scrubbed", hasSize(0))
                                                  // The model-to-code plan the editor replays: one entry per generated model with a
                                                  // recipe in .settings, naming the template + parameters.


### PR DESCRIPTION
## What

The platform arc over the document-template DSL parser (#6118 — **this PR is stacked on that branch**; retarget to master once it merges). End to end: the Intent Editor's Generate emits a standard print template per document entity → publish seeds it into the CMS where business users customize it → the generated Harmonia document view gets a **Print** button that renders the current record to a **PDF**, asking for the language when several template languages exist.

## Pieces

### `dirigible-parsers-document` (library)
- **`DataBinder`** — the data-binding layer the parser deliberately left out: substitutes `{{path}}` in text and attributes from a `Map` context, expands `table`/`for` `source` lists into rows (row scope falls back to the document scope), and resolves `if` truthiness. Unresolved placeholders render empty — a printout never shows raw braces.
- **`XslFoRenderer`** — `DocumentRenderer<String>` producing a self-contained XSLT/XSL-FO stylesheet, the exact input of the existing FOP-based `PDFFacade` (no new PDF dependency). Tables with proportional/percent/px columns and label header rows, fields as label:value, text styles, line/space/total/image. v1 simplifications documented (header/footer in-flow, 1px=1pt, data-less tables skipped).

### `engine-intent`
- **`PrintIntentGenerator`** (@Order(800)) — one `<Entity>.print` per document (header-items) master, derived from the model: title + document-number subtitle, header fields incl. to-one relations (labels resolved client-side), items table with type-aware alignment, totals footer with the `total` field emphasized. `.print` joins `INTENT_OWNED_EXTENSIONS` (scrubbed like the other intent-owned model files). Tests parse-validate the emitted template with the DSL parser.

### `engine-document` (new module)
- **`PrintTemplate`** artefact + **`PrintTemplateSynchronizer`** (multitenant): on publish, seeds `Templates/<Entity>/Print/en/standard.print` into the CMS **create-if-absent** — download/upload customizations through the Documents perspective are never clobbered; deleting the artefact never touches the CMS. Follows the `BaseExportTask` CMS-write pattern; each tenant's CMS is seeded by its own sync.
- **`PrintEndpoint`** — `GET /services/print/{entity}/languages` (CMS language folders with `Locale` display names) and `POST /services/print/{entity}?lang=` (`{document, items}` JSON from the client → parse → bind → XSL-FO → `application/pdf`). The client supplies the data it already loaded, so no server-side entity fetching or auth forwarding.

### Harmonia document view
- **Print button** in the footer toolbar (edit-only): one language prints directly, several open a language dialog ("English" → en, "Bulgarian" → bg). The payload overlays the loaded record with current edits and resolves dropdown FKs to their display labels.

## Testing
- Library: 90 unit tests (21 new for binder + renderer, incl. an end-to-end sales-invoice render asserting no `{{` leaks and the dropped `if` branch).
- engine-intent: 3 generator tests (detection, parseable deterministic output).
- engine-document: 3 pipeline tests.
- `IntentEngineIT` asserts `Order.print` in the generate pass (its fixture is a document master).
- Gates: root `formatter:validate` clean, release-profile javadoc green, full reactor quick-build green.

## Follow-up
Sample-repo (`sample-intent-multi-model`) regeneration + a live print walkthrough after this merges (three-repo ordering), and an HTTP IT for the print service against a published app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)