### PR TITLE
fix(tests): EdmView.regenerate waits for generated sources, not the transient toast

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/ide/EdmView.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/ide/EdmView.java
@@ -9,6 +9,11 @@
  */
 package org.eclipse.dirigible.tests.framework.ide;
 
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.tests.framework.browser.Browser;
 import org.eclipse.dirigible.tests.framework.browser.HtmlAttribute;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
@@ -21,10 +26,12 @@ public class EdmView {
 
     private final Browser browser;
     private final WorkbenchFactory workbenchFactory;
+    private final IRepository repository;
 
-    public EdmView(Browser browser, WorkbenchFactory workbenchFactory) {
+    public EdmView(Browser browser, WorkbenchFactory workbenchFactory, IRepository repository) {
         this.browser = browser;
         this.workbenchFactory = workbenchFactory;
+        this.repository = repository;
     }
 
     public void regenerate(String projectName, String edmFileName) {
@@ -32,7 +39,16 @@ public class EdmView {
         workbench.openFile(projectName, edmFileName);
 
         browser.clickOnElementByAttributePattern(HtmlElementType.BUTTON, HtmlAttribute.TITLE, "Regenerate");
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Generated from model");
+        // Wait for the DURABLE effect of the regeneration - the generated sources landing in the
+        // project's gen folder - not the transient "Generated from model" toast. On slow CI runners
+        // the cross-frame text sweep can outlast the toast, and the sweep's timeout fallback reloads
+        // the page, destroying it for good (failure screenshots showed the toast on screen and the
+        // gen folder already created while the assertion still failed - the recurring DependsOnIT
+        // flake that also hit master).
+        String genPath = IRepositoryStructure.PATH_USERS + "/admin/workspace/" + projectName + "/gen";
+        Awaitility.await()
+                  .atMost(120, TimeUnit.SECONDS)
+                  .pollInterval(1, TimeUnit.SECONDS)
+                  .until(() -> repository.hasCollection(genPath));
     }
 }
-


### PR DESCRIPTION
## What

`DependsOnIT` has been failing flakily on CI — including on **master** (the `fix(pdf)` merge run) — while the generation it tests actually succeeds.

**Evidence from the failure screenshots**: the status bar shows *"Generated from model 'edm.model'"* and the `gen` folder is already in the project tree — the exact text the assertion looks for is on screen. The cross-frame text sweep times out anyway (a runner-side Selenium *"Failed to establish BiDi connection"* error accompanies the failures), and the sweep's timeout fallback **reloads the page**, destroying the transient toast so the retry can never succeed.

## Fix

`EdmView.regenerate` now waits for the **durable effect** — the generated sources landing in the workspace project's `gen` folder, polled through `IRepository` with Awaitility (the same approach `IntentEditorLoadsIT` uses) — instead of the transient toast.

Verified locally: `DependsOnIT` passes in 69s with the change.

Merging this unblocks the failing `integration-tests-*` jobs on master, #6125 and #6126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)