### PR TITLE
fix(intent): text pane blank in editors restored in a hidden tab

### DIFF
--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -185,7 +185,32 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
                 });
             });
             themingHub.onThemeChange((theme) => monaco.editor.setTheme(monacoThemeFor(theme)));
+            recoverWhenRevealed(container);
         });
+    };
+
+    // After a browser refresh every open editor iframe bootstraps at once, but only the focused tab
+    // is visible - the rest sit in `display:none` tab panels (the layout toggles them with ng-show).
+    // Monaco created inside a hidden, zero-size container measures a zero-width font and lays out to
+    // nothing, and unlike the geometry-driven mxGraph diagrams it does not repaint on its own when the
+    // tab is finally revealed: the text pane shows up blank. `automaticLayout` re-runs layout on the
+    // size change but keeps the stale zero font metrics, so the glyphs stay invisible. Watch for the
+    // container gaining real size (the tab being shown) and, once, remeasure the fonts and relayout so
+    // the source appears. A no-op for the focused editor, which is already sized when Monaco is created.
+    let revealObserver = null;
+    const recoverWhenRevealed = (container) => {
+        if (typeof ResizeObserver === 'undefined') return;
+        if (container.clientWidth > 0 && container.clientHeight > 0) return; // already visible at creation
+        revealObserver = new ResizeObserver(() => {
+            if (container.clientWidth > 0 && container.clientHeight > 0) {
+                revealObserver.disconnect();
+                revealObserver = null;
+                if (!monacoEditor) return;
+                if (monacoApi) monacoApi.editor.remeasureFonts();
+                monacoEditor.layout();
+            }
+        });
+        revealObserver.observe(container);
     };
 
     // ----- Live preview --------------------------------------------------------
@@ -711,6 +736,10 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
     $scope.$on('$destroy', () => {
         teardown();
         disposeDiff();
+        if (revealObserver) {
+            revealObserver.disconnect();
+            revealObserver = null;
+        }
         if (monacoEditor) {
             monacoEditor.dispose();
             monacoEditor = null;


### PR DESCRIPTION
## Problem

When multiple Intent Editors are open and the browser is refreshed, only the **focused** tab renders correctly. The others load with the **text (Monaco) pane blank** - switching to such a tab shows only the diagram pane; the source pane never appears.

## Root cause

Inactive editor tabs stay in the DOM but hidden: the layout renders each panel with `ng-show="pane.selectedTab === tab.id"` (`splitted-tabs.html`), i.e. `display:none`. On refresh every editor iframe bootstraps at once, so the non-focused ones create **Monaco inside a zero-size, hidden container**. Monaco then measures a zero-width font and lays out to nothing. Unlike the mxGraph diagrams - which lay out from geometry and an explicit container height, so they render fine while hidden - Monaco does not repaint when the tab is later revealed: `automaticLayout` re-runs layout on the size change but keeps the stale zero font metrics, so the glyphs stay invisible.

This regressed when the source pane moved from a `<textarea>` (visibility-agnostic) to Monaco.

The existing `IntentEditorLoadsIT` only opens a single, focused editor, so it never exercised the hidden-tab path.

## Fix

After Monaco is created, if the container is hidden (zero size), a one-shot `ResizeObserver` waits for it to gain real size (the tab being revealed) and then calls `monaco.editor.remeasureFonts()` + `editor.layout()` so the source appears. It's a no-op for the focused editor (already sized at creation), disconnects after firing, and is cleaned up on `$destroy`.

## Verification

`node --check` passes. **Not yet runtime-verified in a browser** - reproducing needs the full IDE with 2+ intent editors open and a refresh. Draft pending an end-to-end check and, ideally, a multi-tab regression IT (deliberately omitted here to avoid landing an unvalidated Selenide test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)