### PR TITLE
test(it): DependsOnScenarios expects humanized 'Sales Order' sidebar label

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnScenariosTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnScenariosTestProject.java
@@ -53,7 +53,7 @@ class DependsOnScenariosTestProject extends BaseTestProject {
 
     private void verifyPaymentAmount() {
         browser.openPath(VERIFICATION_URI);
-        browser.clickOnElementWithText(HtmlElementType.SPAN, "SalesOrder");
+        browser.clickOnElementWithText(HtmlElementType.SPAN, "Sales Order");
 
         browser.clickOnElementWithText(HtmlElementType.DIV, "Customer A");
 
@@ -76,7 +76,7 @@ class DependsOnScenariosTestProject extends BaseTestProject {
 
     private void verifyCustomerPayment() {
         browser.openPath(VERIFICATION_URI);
-        browser.clickOnElementWithText(HtmlElementType.SPAN, "SalesOrder");
+        browser.clickOnElementWithText(HtmlElementType.SPAN, "Sales Order");
 
         browser.clickOnElementWithText(HtmlElementType.DIV, "Customer A");
 
@@ -111,7 +111,7 @@ class DependsOnScenariosTestProject extends BaseTestProject {
 
     private void verifyOrderCustomer() {
         browser.openPath(VERIFICATION_URI);
-        browser.clickOnElementWithText(HtmlElementType.SPAN, "SalesOrder");
+        browser.clickOnElementWithText(HtmlElementType.SPAN, "Sales Order");
 
         browser.clickOnElementWithText(HtmlElementType.DIV, "Customer A");
 
@@ -126,7 +126,7 @@ class DependsOnScenariosTestProject extends BaseTestProject {
 
     private void verifyProductPrice() {
         browser.openPath(VERIFICATION_URI);
-        browser.clickOnElementWithText(HtmlElementType.SPAN, "SalesOrder");
+        browser.clickOnElementWithText(HtmlElementType.SPAN, "Sales Order");
 
         browser.clickOnElementWithText(HtmlElementType.DIV, "Customer A");
 
@@ -145,7 +145,7 @@ class DependsOnScenariosTestProject extends BaseTestProject {
 
     private void verifyProductUom() {
         browser.openPath(VERIFICATION_URI);
-        browser.clickOnElementWithText(HtmlElementType.SPAN, "SalesOrder");
+        browser.clickOnElementWithText(HtmlElementType.SPAN, "Sales Order");
 
         browser.clickOnElementWithText(HtmlElementType.DIV, "Customer A");
 


### PR DESCRIPTION
## Why

PR #6132 (merged) humanizes the **singular** entity label in the shared generation catalog — `t.<dataName>` went from the raw name to a humanized one (`"SalesOrder"` → `"Sales Order"`). The generated app's sidebar binds that key, so `DependsOnScenariosIT`'s exact-text sidebar clicks fail on master now.

## Change

Updates the 5 exact-text clicks in `DependsOnScenariosTestProject` to the humanized label. Scope check:
- Single-word labels (`Customer`, `Product`, `Orders`, `Country`, `City`) humanize to themselves — unchanged.
- `SalesOrderItem` / `SalesOrderPayment` are clicked **by id**, not text — unchanged.
- Search placeholders use the **property** dataName (not humanized) — unchanged.

This is the AngularJS parity test; the naming change is a Harmonia-facing feature, but the catalog is shared, so the parity test's expectation is updated to match. (Full IT→Harmonia migration is a separate effort as AngularJS is deprecated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)