### PR TITLE
feat(harmonia): KPI description + deep-linkable report routing (shared shell dashboard)

### DIFF
--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -119,7 +119,7 @@
                 <ul x-h-sidebar-menu>
                   <template x-for="r in $store.reports.items" :key="r.url">
                     <li x-h-sidebar-menu-item>
-                      <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/reports') && $store.reports.selected && $store.reports.selected.url === r.url" @click="$store.reports.selected = r; navigate('/reports')">
+                      <button x-h-sidebar-menu-button :data-active="$store.reports.selected && $store.reports.selected.url === r.url" @click="openReport(r)">
                         <i role="img" data-lucide="bar-chart-3"></i><span x-text="r.label"></span>
                       </button>
                     </li>
@@ -261,6 +261,8 @@
     <template x-route="/inbox" x-template.target.app="/services/web/application-core/shell/views/_inbox.html"></template>
     <template x-route="/documents" x-template.target.app="/services/web/application-core/shell/views/_documents.html"></template>
     <template x-route="/reports" x-template.target.app="/services/web/application-core/shell/views/_reports.html"></template>
+    <!-- /reports/<name> deep-links a specific report (restored on refresh); applyRoute resolves the store selection. -->
+    <template x-route="/reports/:name" x-template.target.app="/services/web/application-core/shell/views/_reports.html"></template>
     <!-- Settings: list (/settings) or a selected entity (/settings/<perspective-id>). The master-detail
          fragment renders into #app (visible) so its split lays out correctly. -->
     <template x-route="/settings" x-template.target.app="./views/_settings.html"></template>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -160,6 +160,17 @@ document.addEventListener('alpine:init', () => {
         this.$watch('language', (v) => locale.set(v));
       }
 
+      // Reports are discovered asynchronously (the store walks the registry). Once its items arrive,
+      // re-resolve a deep-linked /reports/<name> so a refresh on that URL lands on the right report
+      // instead of the "Select a report" empty state.
+      this.$watch('$store.reports.loaded', () => {
+        if (this.currentPath === '/reports' || this.currentPath.indexOf('/reports/') === 0) {
+          this.selectReportByName(this.currentPath.indexOf('/reports/') === 0
+                  ? decodeURIComponent(this.currentPath.slice('/reports/'.length))
+                  : '');
+        }
+      });
+
       // Resolve shell state from the current route. Hosted domain apps are addressable as
       // /app/<perspective-id>[/<inner-route>]; everything else is a built-in page rendered into #app.
       // The inner route is the iframe app's own hash route (e.g. /SalesInvoice/42/edit), so the top
@@ -203,6 +214,12 @@ document.addEventListener('alpine:init', () => {
           } else {
             this.hostedId = '';
             this.hostedUrl = '';
+            // Reports deep-link: /reports/<name> selects that report so a browser refresh restores it.
+            // The store may still be loading (its items arrive asynchronously) - the `$store.reports.loaded`
+            // watcher below re-resolves once they do.
+            if (p === '/reports' || p.indexOf('/reports/') === 0) {
+              this.selectReportByName(p.indexOf('/reports/') === 0 ? decodeURIComponent(p.slice('/reports/'.length)) : '');
+            }
           }
         }
         this.refreshIcons();
@@ -231,6 +248,23 @@ document.addEventListener('alpine:init', () => {
       this.settingsMode = false;
       window.PineconeRouter.navigate(route);
       this.closeSideNav();
+    },
+
+    /** Open a discovered report deep-linkably: the report name goes in the URL (/reports/<name>) so a
+     *  refresh restores it. applyRoute (and the reports-loaded watcher) resolve the store selection. */
+    openReport(report) {
+      this.navigate('/reports/' + encodeURIComponent(report.name));
+    },
+
+    /** Select the discovered report with this name (from the shared reports store) for the Reports page.
+     *  A blank name (bare /reports) clears the selection so the empty state shows; an unknown name (the
+     *  store not loaded yet) leaves it null until the loaded watcher re-resolves. */
+    selectReportByName(name) {
+      const store = Alpine.store('reports');
+      if (!store) {
+        return;
+      }
+      store.selected = name ? (store.items || []).find(r => r.name === name) || null : null;
     },
 
     /** Host a domain app (a perspective) in the iframe. Swap the iframe synchronously on click (do not

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
@@ -43,6 +43,7 @@
                   <template x-if="!$store.reports.widgetState(r).loaded"><div x-h-skeleton class="w-1/2 h-9"></div></template>
                   <p x-show="$store.reports.widgetState(r).loaded && !$store.reports.widgetState(r).error" class="text-3xl font-bold" x-text="$store.reports.widgetValueText(r)"></p>
                   <p x-show="$store.reports.widgetState(r).error" x-h-text.muted class="text-3xl font-bold">—</p>
+                  <p x-show="r.description" x-h-text.muted class="text-xs" x-text="r.description"></p>
                 </div>
               </template>
               <template x-if="r.widget.kind === 'list'">

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
@@ -30,8 +30,8 @@
         <template x-for="r in $store.reports.kpiReports()" :key="r.name">
           <div x-h-card role="button" tabindex="0" class="cursor-pointer"
                :class="r.widget.kind === 'list' ? 'sm:col-span-2' : ''"
-               @click="$store.reports.selected = r; navigate('/reports')"
-               @keydown.enter.prevent="$store.reports.selected = r; navigate('/reports')">
+               @click="openReport(r)"
+               @keydown.enter.prevent="openReport(r)">
             <div x-h-card-header>
               <div class="hbox items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
                 <i role="img" :data-lucide="r.widget.icon" class="size-4"></i><span x-text="$store.reports.widgetLabel(r)"></span>
@@ -88,12 +88,12 @@
           <div x-h-card>
             <div x-h-card-header>
               <h3 x-h-card-title class="hbox items-center gap-2 cursor-pointer"
-                  @click="$store.reports.selected = r; navigate('/reports')">
+                  @click="openReport(r)">
                 <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="r.label"></span>
               </h3>
               <div x-h-card-action>
                 <button x-h-button data-variant="transparent" data-size="icon-sm"
-                        @click="$store.reports.selected = r; navigate('/reports')" aria-label="Open report">
+                        @click="openReport(r)" aria-label="Open report">
                   <i role="img" data-lucide="arrow-up-right"></i>
                 </button>
               </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/dashboard.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/dashboard.html.template
@@ -45,6 +45,7 @@
                   <template x-if="!kpiState(r).loaded"><div x-h-skeleton class="w-1/2 h-9"></div></template>
                   <p x-show="kpiState(r).loaded && !kpiState(r).error" class="text-3xl font-bold" x-text="kpiValueText(r)"></p>
                   <p x-show="kpiState(r).error" x-h-text.muted class="text-3xl font-bold">—</p>
+                  <p x-show="r.description" x-h-text.muted class="text-xs" x-text="r.description"></p>
                 </div>
               </template>
               <template x-if="r.widget.kind === 'list'">


### PR DESCRIPTION
Two small shared-shell dashboard / reports UX fixes (they overlap `_dashboard.html`, hence one PR).

## 1. Report description under a KPI number tile
A count/value report KPI tile showed only the number. Render the report's `description` (already on the reports-store item — the same field the preview tiles and custom widgets use) as a muted line under the number. Applied to the shared application shell dashboard and the generated per-app dashboard for parity. List-kind tiles unchanged.

## 2. Deep-linkable report selection
Selecting a report set `$store.reports.selected` **in memory** and navigated to the bare `/reports`, so the URL never reflected the chosen report — a browser refresh on `#/reports` landed on the "Select a report" empty state.

- Encode the report in the URL as **`/reports/<name>`** (mirrors the existing `/settings/:id` deep-link): a new `/reports/:name` route + `openReport(r)` navigates there.
- `applyRoute` resolves the store item by name into `$store.reports.selected`.
- The reports store loads **asynchronously** (it walks the registry), so a `$store.reports.loaded` watcher re-resolves once its items arrive — a refresh on `/reports/<name>` restores the report.
- The sidebar entry (+ its active state) and the dashboard KPI / preview tiles all route through `openReport` now.

## Verification
Both applied to the running instance's served copies and confirmed: the KPI tiles show their description, clicking a report puts `/reports/<name>` in the URL, and refreshing that URL restores the report (no more empty state). Per the UI-only workflow, the jar rebuild is left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)