### PR TITLE
fix(harmonia): translate report names + descriptions in the shell (sidebar/dashboard)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/report/ReportIntentGenerator.java
@@ -206,11 +206,14 @@ public class ReportIntentGenerator implements IntentTargetGenerator {
         document.put("name", report.getName());
         document.put("alias", baseAlias);
         document.put("table", baseTable);
-        document.put("tId", translationId(report.getName()));
+        String tId = translationId(report.getName());
+        document.put("tId", tId);
         document.put("label", humanize(report.getName()));
         if (report.getDescription() != null && !report.getDescription()
                                                       .isBlank()) {
             document.put("description", report.getDescription());
+            // Externalize the description as its own catalog key so it localizes alongside the label.
+            document.put("descriptionTId", tId + "Description");
         }
         // dashboard: false excludes the report's tile from the home dashboard (it still shows in the
         // sidebar). Carried on the .report; the Harmonia reports store reads it.

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/reports.js
@@ -98,6 +98,7 @@ document.addEventListener('alpine:init', () => {
           if (def.description) it.description = def.description;
           if (def.dashboard === false) it.dashboard = false;
           if (def.tId) it.tId = def.tId;
+          if (def.descriptionTId) it.descriptionTId = def.descriptionTId;
           // A report-attached KPI widget: the dashboard shows a compact KPI tile (count / single
           // aggregate value / top-N list) instead of the report's iframe preview tile.
           if (def.widget) {
@@ -185,6 +186,9 @@ document.addEventListener('alpine:init', () => {
     tkey(it, tId) { return it.project + ':' + it.name + '-report.t.' + tId; },
     displayLabel(it) {
       return (window.T && it.tId) ? T(this.tkey(it, it.tId), it.label) : it.label;
+    },
+    displayDescription(it) {
+      return (window.T && it.descriptionTId) ? T(this.tkey(it, it.descriptionTId), it.description) : it.description;
     },
     widgetLabel(it) {
       const w = it.widget || {};

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -120,7 +120,7 @@
                   <template x-for="r in $store.reports.items" :key="r.url">
                     <li x-h-sidebar-menu-item>
                       <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/reports') && $store.reports.selected && $store.reports.selected.url === r.url" @click="$store.reports.selected = r; navigate('/reports')">
-                        <i role="img" data-lucide="bar-chart-3"></i><span x-text="r.label"></span>
+                        <i role="img" data-lucide="bar-chart-3"></i><span x-text="$store.reports.displayLabel(r)"></span>
                       </button>
                     </li>
                   </template>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
@@ -98,7 +98,7 @@
               </div>
             </div>
             <div x-h-card-content class="vbox gap-2">
-              <p x-show="r.description" x-h-text.muted class="text-sm" x-text="r.description"></p>
+              <p x-show="r.description" x-h-text.muted class="text-sm" x-text="$store.reports.displayDescription(r)"></p>
               <iframe :src="r.url + '?preview=1'" title="Report preview" loading="lazy"
                       style="width:100%; height:220px; border:0;"></iframe>
             </div>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
@@ -88,7 +88,7 @@
             <div x-h-card-header>
               <h3 x-h-card-title class="hbox items-center gap-2 cursor-pointer"
                   @click="$store.reports.selected = r; navigate('/reports')">
-                <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="r.label"></span>
+                <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="$store.reports.displayLabel(r)"></span>
               </h3>
               <div x-h-card-action>
                 <button x-h-button data-variant="transparent" data-size="icon-sm"

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -79,6 +79,10 @@ function getTranslations(model) {
 function getReportTranslations(report) {
     let translations = {};
     translations[report.tId] = report.label;
+    // The report's description is externalized under its own key so translators localize it too.
+    if (report.descriptionTId && report.description) {
+        translations[report.descriptionTId] = report.description;
+    }
     for (let i = 0; i < report.columns.length; i++) {
         translations[report.columns[i]['tId']] = report.columns[i]['label'];
     }


### PR DESCRIPTION
## Problem

With a language set (e.g. `bg`), entity names translate in the shell but **report names and descriptions stay English**:
1. The sidebar report entries and dashboard report-preview tiles bind the raw `r.label`.
2. The report **description** was carried on the `.report` but never externalized into the translation catalog, so it had no key to localize.

## Fix

**Names** — render via the reports store's translation-aware `displayLabel(r)` (`T('<project>:<Name>-report.t.<tId>', label)`) in `application/index.html` (sidebar) and `application/views/_dashboard.html` (preview tile). Same path the KPI widget tiles already use.

**Descriptions** — externalize as translatable end-to-end:
- `ReportIntentGenerator` emits `descriptionTId` (`<tId>Description`) onto the `.report` (only when a description exists).
- `getReportTranslations` puts the description under that key in the generated catalog.
- The reports store reads `def.descriptionTId` and gains `displayDescription(r)`; the dashboard binds it.

In the default language `T()` returns the baked English text, so no change there.

## Verify

- `ReportIntentGeneratorTest` green (JDK 21, offline); `generateUtils.js`/`reports.js` pass `node --check`.
- Publish a project with a `bg-BG` report catalog and switch to Bulgarian: report **names and descriptions** in the sidebar/dashboard render translated (e.g. `MonthlyRevenue` → "Месечни приходи").

🤖 Generated with [Claude Code](https://claude.com/claude-code)