### PR TITLE
feat(harmonia): report preview tile shows the most recent rows

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
@@ -115,8 +115,18 @@ document.addEventListener('alpine:init', () => {
       this.state = 'loading';
       this.error = null;
       try {
-        const offset = (this.page - 1) * this.limit;
         const conditions = this.conditions();
+        // Fetch the total first so preview mode (the dashboard tile) can window to the LAST rows -
+        // the most recent records in the report's natural order - rather than the first ones.
+        try {
+          const c = conditions.length
+            ? await reportHttp.post(this.apiBase + '/count', { conditions })
+            : await reportHttp.get(this.apiBase + '/count');
+          this.count = (c && c.count != null) ? c.count : 0;
+        } catch (e) { this.count = 0; }
+        const offset = this.preview
+          ? Math.max(0, this.count - this.limit)
+          : (this.page - 1) * this.limit;
         let rows;
         if (conditions.length) {
           rows = await reportHttp.post(this.apiBase + '/search', { ${dollar}limit: this.limit, ${dollar}offset: offset, conditions });
@@ -128,12 +138,7 @@ document.addEventListener('alpine:init', () => {
         // falling back to the generation-time metadata when a filter empties the page.
         if (this.rows.length) this.columns = Object.keys(this.rows[0]);
         else if (!this.columns.length && this.reportColumns.length) this.columns = this.reportColumns.map(c => c.key);
-        try {
-          const c = conditions.length
-            ? await reportHttp.post(this.apiBase + '/count', { conditions })
-            : await reportHttp.get(this.apiBase + '/count');
-          this.count = (c && c.count != null) ? c.count : this.rows.length;
-        } catch (e) { this.count = this.rows.length; }
+        if (!this.count) this.count = this.rows.length;
         this.state = this.rows.length ? 'default' : 'empty';
       } catch (e) {
         this.error = (e && e.message) || 'Could not run the ${name} report.';


### PR DESCRIPTION
## What

A dashboard report **preview tile** embeds the report page in `?preview=1` mode, which showed the **first** 5 rows. For a time-bucketed report (e.g. `MonthlyRevenue`) that's the *oldest* months — the tile showed 2025-07…2025-11 instead of the recent months.

Window preview mode to the **last** rows instead, keeping the report's natural (ascending) order — so `MonthlyRevenue` shows 2026-03…2026-07 (01…05 order, bottom 5).

## How

In `report.js.template` `load()`: fetch the count first, then in preview mode offset to `max(0, count - limit)` (the tail) rather than page 1. A full report view is unchanged (pagination still starts at page 1).

```js
const offset = this.preview ? Math.max(0, this.count - this.limit) : (this.page - 1) * this.limit;
```

## Verification

Applied to the running instance's served per-report `report.js` copies and confirmed via the report controller: the preview window now returns `202603…202607` (recent 5, ascending) instead of `202507…202511`.

Note: the ordering is the report's DB-natural order (GROUP BY on the month bucket returns ascending on H2/PostgreSQL); no `ORDER BY` was added, matching the requested "natural order, bottom 5" behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)