### PR TITLE
fix(harmonia): clear the report sidebar highlight when navigating away

### DIFF
--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -119,7 +119,7 @@
                 <ul x-h-sidebar-menu>
                   <template x-for="r in $store.reports.items" :key="r.url">
                     <li x-h-sidebar-menu-item>
-                      <button x-h-sidebar-menu-button :data-active="$store.reports.selected && $store.reports.selected.url === r.url" @click="openReport(r)">
+                      <button x-h-sidebar-menu-button :data-active="isReportActive(r)" @click="openReport(r)">
                         <i role="img" data-lucide="bar-chart-3"></i><span x-text="$store.reports.displayLabel(r)"></span>
                       </button>
                     </li>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -380,6 +380,12 @@ document.addEventListener('alpine:init', () => {
 
     isBuiltinActive(route) { return !this.hostedUrl && this.currentPath === route; },
     isAppActive(item) { return this.hostedId === item.id; },
+    // A report entry is active only while a report route is showing it — keying off the current route
+    // (not just $store.reports.selected) so navigating to an entity/inbox/documents clears its highlight.
+    isReportActive(report) {
+      const selected = Alpine.store('reports').selected;
+      return !this.hostedUrl && this.currentPath.indexOf('/reports') === 0 && selected && selected.url === report.url;
+    },
     isSvgIcon(icon) { return !!icon && /\.svg(\?|#|$)/i.test(icon); },
     isImageIcon(icon) { return !!icon && !this.isSvgIcon(icon) && (icon.indexOf('/') !== -1 || icon.indexOf('.') !== -1 || icon.indexOf('http') === 0); },
 


### PR DESCRIPTION
## Bug

In the shared application shell sidebar, clicking a **report** entry highlights it (blue), and clicking another report moves the highlight — but clicking an **entity / Inbox / Documents** left the report entry highlighted. Only report entries had this; the others clear correctly.

## Cause

The report entry's active state was bound to `$store.reports.selected && $store.reports.selected.url === r.url`. Navigating to a non-report page doesn't touch `$store.reports.selected`, so the highlight persisted — unlike the built-in / app entries, which key off `currentPath` / `hostedId`.

## Fix

Add `isReportActive(r)` and bind the report entry to it. It returns true only when a `/reports` route is currently showing that report (and no app is hosted):

```js
isReportActive(report) {
  const selected = Alpine.store('reports').selected;
  return !this.hostedUrl && this.currentPath.indexOf('/reports') === 0 && selected && selected.url === report.url;
}
```

Now leaving the reports page drops the highlight, consistent with `isBuiltinActive` / `isAppActive`.

Verified live on the running instance's served shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)