### PR TITLE
fix(harmonia): FK "Add new" must use the target app's raw gen folder (cross/self-model 404)

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/app.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/app.js
@@ -18,18 +18,23 @@ window.App = {
   services: {},
   routes: {},
   utils: {
-    // Derive a related entity's embedded create-page URL from its REST controller URL, so an FK
-    // combobox's "Add" button can open the target's OWN generated create form in an iframe dialog -
-    // even when the target lives in another project (cross-model association). Example:
-    //   /services/java/customers/gen/customers/api/customer/CustomerController , "Customer"
-    //   -> /services/web/customers/gen/customers/index.html?embedded=1#/Customer/create?embedded=1
-    // `embedded` is set in BOTH the search (the shell hides its chrome) and the hash query (the form
-    // posts a "created" message instead of navigating away).
-    relatedCreateUrl(controllerUrl, entity) {
-      if (!controllerUrl || !entity) return '';
-      const i = controllerUrl.indexOf('/api/');
-      const base = (i >= 0 ? controllerUrl.substring(0, i) : controllerUrl).replace('/services/java/', '/services/web/');
-      return base + '/index.html?embedded=1#/' + entity + '/create?embedded=1&dialog=1';
+    // Build the embedded create-page URL for a related entity, so an FK combobox's "Add" button can
+    // open the target's OWN generated create form in an iframe dialog - even when the target lives in
+    // another project (cross-model association). `embedded` is set in BOTH the search (the shell hides
+    // its chrome) and the hash query (the form posts a "created" message instead of navigating away).
+    //   appUrl "/services/web/customer-payments/gen/customer-payments/index.html", "CustomerPayment"
+    //   -> "/services/web/customer-payments/gen/customer-payments/index.html?embedded=1#/CustomerPayment/create?embedded=1&dialog=1"
+    // The generator passes the target app's index.html at its RAW gen folder. Legacy fallback: apps
+    // generated before that arg existed pass a Java controller URL - rewrite it (this keeps the
+    // sanitized gen folder, which only matters for hyphenated project names, but preserves behaviour).
+    relatedCreateUrl(appUrl, entity) {
+      if (!appUrl || !entity) return '';
+      let base = appUrl;
+      const apiIdx = appUrl.indexOf('/api/');
+      if (apiIdx >= 0) {
+        base = appUrl.substring(0, apiIdx).replace('/services/java/', '/services/web/') + '/index.html';
+      }
+      return base + '?embedded=1#/' + entity + '/create?embedded=1&dialog=1';
     },
   },
   config: {},

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -155,10 +155,12 @@ document.addEventListener('alpine:init', () => {
       return found ? found.text : value;
     },
 
-    // "Add new <related>" from a non-setting FK combobox: open the target's own create page in the
-    // shared related-create iframe dialog; on save, reload that field's options and select the new id.
-    addRelated(field, controllerUrl, entity) {
-      Alpine.store('related').create(App.utils.relatedCreateUrl(controllerUrl, entity), 'New ' + entity, async (id) => {
+    // "Add new <related>" from a non-setting FK combobox: open the target's own create page (its
+    // Harmonia SPA, which may live in another project) in the shared related-create iframe dialog;
+    // on save, reload that field's options and select the new id. appUrl is the target app's raw
+    // web index.html (the generator resolves the correct - unsanitized - gen folder).
+    addRelated(field, appUrl, entity) {
+      Alpine.store('related').create(App.utils.relatedCreateUrl(appUrl, entity), 'New ' + entity, async (id) => {
         await this.loadOptions();
         if (id != null) this.form[field] = String(id);
       });

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -103,7 +103,7 @@
               </template>
             </div>
           </div>
-          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>&nbsp;<span x-text="T('$projectName:${tprefix}.t.${property.relationshipEntityName}', '${property.relationshipEntityName}')"></span></button>
+          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownAppUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>&nbsp;<span x-text="T('$projectName:${tprefix}.t.${property.relationshipEntityName}', '${property.relationshipEntityName}')"></span></button>
           <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
@@ -171,6 +171,11 @@ export function process(model, parameters) {
                     const javaUrl = `/services/java/${targetProject}/gen/${javaGen}/api/${javaPerspective}/${p.relationshipEntityName}Controller`;
                     p.widgetDropdownUrl = javaUrl;
                     p.widgetDropdownControllerUrl = javaUrl;
+                    // The target's own Harmonia SPA (for the FK "Add new" iframe dialog). The web assets
+                    // live under the RAW genFolderName, while the Java controllers use the sanitized one
+                    // - so this must be derived from targetGenFolder directly, NOT by rewriting the
+                    // controller URL (that keeps the sanitized folder and 404s for hyphenated names).
+                    p.widgetDropdownAppUrl = `/services/web/${targetProject}/gen/${targetGenFolder}/index.html`;
                 } else {
                     p.widgetDropdownUrl = `/services/ts/${targetProject}/gen/${targetGenFolder}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Service.ts`;
                     p.widgetDropdownControllerUrl = `/services/ts/${targetProject}/gen/${targetGenFolder}/api/${p.relationshipEntityPerspectiveName}/${p.relationshipEntityName}Controller.ts`;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnScenariosHarmoniaTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnScenariosHarmoniaTestProject.java
@@ -61,6 +61,22 @@ class DependsOnScenariosHarmoniaTestProject extends BaseTestProject {
         verifyCountryCityCascade();
         verifyProductUomAndPrice();
         verifyCustomerPaymentAndAmount();
+        verifyRelatedCreateOpens();
+    }
+
+    /**
+     * The FK "Add new" on a non-setting association must open the target entity's own create form in
+     * the iframe dialog. Regression guard for the cross/self-model create URL: it was derived from the
+     * Java controller URL and kept the Java-sanitized gen folder, so it 404'd for any hyphenated model
+     * name (here {@code sales-order} -> {@code sales_order}). UoM is a non-setting association on
+     * SalesOrderItem; clicking its "New UoM" opens the UoM create form (its "Name" field label proves
+     * the form loaded rather than a 404 page). "UoM" matches only that button - the sidebar entry is
+     * the humanized "Uo M".
+     */
+    private void verifyRelatedCreateOpens() {
+        browser.openPath(BASE_URI + "/SalesOrderItem/create");
+        browser.clickOnElementContainingText(HtmlElementType.BUTTON, "UoM");
+        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Name");
     }
 
     /**


### PR DESCRIPTION
## Symptom

Clicking an FK **"Add new"** on a Harmonia form (e.g. *New CustomerPayment* on the `SalesInvoiceCustomerPayment` bridge) opened a **Page Not Found**. Console:

```
GET /services/web/customer-payments/gen/customer_payments/index.html?embedded=1  → 404
```

## Cause

`relatedCreateUrl` (shared runtime, `application-core/.../app.js`) built the target app's **web** URL from its **Java** controller URL by swapping only `/services/java/` → `/services/web/`. But the Harmonia web assets live under the **raw** `genFolderName`, while the Java controllers use the **sanitized** one — so the derived URL kept the sanitized folder (`customer_payments`) and 404'd for any hyphenated project/model name. (`customer-payments` → web is `gen/customer-payments/`, not `gen/customer_payments/`.) The raw folder can't be recovered from the sanitized one, so the derivation was lossy.

## Fix

- **`parameterUtils.js`** (generator): also emits `widgetDropdownAppUrl = /services/web/<project>/gen/<rawGenFolder>/index.html`, resolved from the raw `targetGenFolder` directly.
- **`form-view.html.template`** / **`form-page.js.template`**: the "Add" button passes that app URL through `addRelated`.
- **`app.js`** (`relatedCreateUrl`): uses the app URL as-is; keeps a legacy `/api/` fallback so apps generated before this arg still work (unchanged behaviour).

## Verification (headless, green)

`DependsOnScenariosHarmoniaIT` gains a regression step: on the `SalesOrderItem` create form (model `sales-order` → sanitizes to `sales_order`, reproducing the mismatch) it clicks **"New UoM"** and asserts the UoM create form loads (its `Name` field label) instead of a 404 page. Full IT green.

Follows up #6145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)