### PR TITLE
fix(java-lsp): resolve symlinked git-clone project paths to virtual URIs

### DIFF
--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsInstance.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsInstance.java
@@ -24,12 +24,16 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 /**
  * Wraps a single running JDT Language Server OS process and the WebSocket sessions it serves.
@@ -51,6 +55,23 @@ public class JdtLsInstance {
     private final String virtualRoot;
     /** Real filesystem URI root used by JDT.LS, e.g. {@code file:///home/user/.../proj1/}. */
     private final String realRoot;
+    /**
+     * On-disk workspace root ({@code <repo>/root/users/<user>/<workspace>}); its project sub-dirs may
+     * be symlinks.
+     */
+    private final Path workspaceRootPath;
+
+    /**
+     * Canonical (symlink-resolved) real URI prefix → virtual URI prefix, one entry per project whose
+     * workspace directory is a symlink. Dirigible stores git clones under
+     * {@code <repo>/.git/<user>/<workspace>/<clone>/} and symlinks each contained project into the
+     * workspace root, so JDT.LS resolves the symlink and reports the canonical clone path — which the
+     * plain {@link #realRoot} replace cannot map back. Rebuilt on a short TTL so a freshly cloned
+     * project is picked up without restarting JDT.LS.
+     */
+    private volatile Map<String, String> symlinkPrefixes = Collections.emptyMap();
+    private volatile long symlinkPrefixesBuiltAt = 0L;
+    private static final long SYMLINK_MAP_TTL_MS = 5000L;
 
     private final Map<Integer, CompletableFuture<JsonNode>> pendingRequests = new ConcurrentHashMap<>();
     private final AtomicInteger serverRequestCounter = new AtomicInteger(-1);
@@ -70,11 +91,12 @@ public class JdtLsInstance {
      */
     private volatile boolean lspInitialized = false;
 
-    JdtLsInstance(Process process, String virtualRoot, String realRoot) {
+    JdtLsInstance(Process process, String virtualRoot, String realRoot, Path workspaceRootPath) {
         this.process = process;
         this.stdin = process.getOutputStream();
         this.virtualRoot = virtualRoot;
         this.realRoot = realRoot;
+        this.workspaceRootPath = workspaceRootPath;
         startStdoutReader();
         startStderrDrain();
     }
@@ -317,6 +339,65 @@ public class JdtLsInstance {
         return files;
     }
 
+    /**
+     * Translates the real filesystem URIs JDT.LS emits back to the virtual URIs the browser uses.
+     * Applies the plain {@link #realRoot}→{@link #virtualRoot} mapping first (covers regular,
+     * non-symlinked projects), then the per-project symlink mapping (covers git clones stored under
+     * {@code .git/…}).
+     */
+    private String translateToVirtual(String json) {
+        String out = json.replace(realRoot, virtualRoot);
+        for (Map.Entry<String, String> entry : symlinkPrefixes().entrySet()) {
+            if (out.contains(entry.getKey())) {
+                out = out.replace(entry.getKey(), entry.getValue());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Returns the canonical-real→virtual URI prefix map for symlinked project directories, rebuilding
+     * it when the cached copy is older than {@link #SYMLINK_MAP_TTL_MS}. See {@link #symlinkPrefixes}
+     * field.
+     */
+    private Map<String, String> symlinkPrefixes() {
+        long now = System.currentTimeMillis();
+        if (now - symlinkPrefixesBuiltAt < SYMLINK_MAP_TTL_MS) {
+            return symlinkPrefixes;
+        }
+        Map<String, String> map = new HashMap<>();
+        try (Stream<Path> children = Files.list(workspaceRootPath)) {
+            children.filter(Files::isDirectory)
+                    .forEach(child -> addSymlinkPrefix(map, child));
+        } catch (IOException e) {
+            logger.debug("[java-lsp] Could not list workspace root {} for symlink mapping", workspaceRootPath, e);
+        }
+        symlinkPrefixes = map;
+        symlinkPrefixesBuiltAt = now;
+        return map;
+    }
+
+    private void addSymlinkPrefix(Map<String, String> map, Path child) {
+        try {
+            String canonical = withTrailingSlash(child.toRealPath()
+                                                      .toUri()
+                                                      .toString());
+            String nominal = withTrailingSlash(child.toUri()
+                                                    .toString());
+            // Only symlinked (relocated) project dirs need the extra mapping; the plain realRoot replace
+            // already covers a project whose canonical path equals its nominal workspace path.
+            if (!canonical.equals(nominal)) {
+                map.put(canonical, virtualRoot + child.getFileName() + "/");
+            }
+        } catch (IOException e) {
+            logger.debug("[java-lsp] Could not resolve real path of {}", child, e);
+        }
+    }
+
+    private static String withTrailingSlash(String uri) {
+        return uri.endsWith("/") ? uri : uri + "/";
+    }
+
     private void startStdoutReader() {
         Thread t = new Thread(() -> {
             try {
@@ -329,7 +410,7 @@ public class JdtLsInstance {
                     if (body.length == 0)
                         break;
                     String json = new String(body, StandardCharsets.UTF_8);
-                    String translated = json.replace(realRoot, virtualRoot);
+                    String translated = translateToVirtual(json);
                     if (!routeToServerRequest(translated)) {
                         captureDiagnostics(translated);
                         broadcast(translated);

--- a/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
+++ b/components/ide/ide-java-lsp/src/main/java/org/eclipse/dirigible/components/ide/lsp/java/process/JdtLsManager.java
@@ -243,7 +243,7 @@ public class JdtLsManager implements DisposableBean, ApplicationRunner, Applicat
         logger.info("[java-lsp] Starting JDT.LS for {}/{} → {}", sanitize(username), sanitize(workspace), workspaceRootPath);
 
         Process process = new ProcessBuilder(cmd).start();
-        return new JdtLsInstance(process, virtualRoot, realRoot);
+        return new JdtLsInstance(process, virtualRoot, realRoot, workspaceRootPath);
     }
 
     /**

--- a/components/ui/view-java/src/main/resources/META-INF/dirigible/view-java/configs/java-view.js
+++ b/components/ui/view-java/src/main/resources/META-INF/dirigible/view-java/configs/java-view.js
@@ -11,7 +11,7 @@
  */
 const viewData = {
 	id: 'java',
-	label: 'Java',
+	label: 'Hierarchy',
 	lazyLoad: true,
 	autoFocusTab: false,
 	region: 'bottom',

--- a/components/ui/view-java/src/main/resources/META-INF/dirigible/view-java/java.html
+++ b/components/ui/view-java/src/main/resources/META-INF/dirigible/view-java/java.html
@@ -35,7 +35,7 @@
     <body class="bk-vbox" ng-controller="JavaViewController">
         <bk-icon-tab-bar class="bk-fill-parent" side-padding="sm" selected-tab-id="tabs.selected">
             <bk-icon-tab-bar-tablist>
-                <bk-icon-tab-bar-tab label="Hierarchy" tab-id="hierarchy" ng-click="switchTab('hierarchy')"></bk-icon-tab-bar-tab>
+                <bk-icon-tab-bar-tab label="Java" tab-id="hierarchy" ng-click="switchTab('hierarchy')"></bk-icon-tab-bar-tab>
             </bk-icon-tab-bar-tablist>
 
             <bk-icon-tab-bar-panel class="bk-fill-parent" tab-id="hierarchy" ng-show="tabs.selected === 'hierarchy'">


### PR DESCRIPTION
## Problem

Opening a Java problem (Problems → **Java** tab) or a **Hierarchy** node for a project cloned via the Git perspective failed with a 404:

```
GET /services/ide/workspaces/file:/Users/.../target/dirigible/repository/.git/admin/workspace/
    sample-intent-multi-model/countries/gen/countries/api/settings/CityController.java  404
```

The editor received a raw absolute filesystem path instead of a workspace-relative one.

## Root cause

Dirigible stores git clones under `repository/.git/<user>/<workspace>/<clone-repo>/` and **symlinks** each contained project into the workspace root (`root/users/<user>/<workspace>/<project>` → the clone dir). JDT.LS resolves those symlinks and reports the **canonical clone path**.

`JdtLsInstance`'s stdout real→virtual translation only did `json.replace(realRoot, virtualRoot)`, where `realRoot` is `…/root/users/<user>/<workspace>/`. That never matches the canonical `…/.git/…/<clone>/<project>/…` path, so the untranslated real URI leaked to the browser.

A client-side `lastIndexOf('/workspace/')` resolver (like the debugger's) can't fix this — it can't know `<clone-repo>` is a folder to drop, and would produce `/workspace/<clone-repo>/<project>/…`, which still 404s. The mapping is only knowable on the server, where the symlink targets are visible.

## Fix

`JdtLsInstance` now maintains a **canonical-real → virtual URI prefix map**, one entry per project whose workspace directory is a symlink (`child.toRealPath()` ≠ nominal path). It's rebuilt on a 5s TTL so a freshly cloned project is picked up without restarting JDT.LS. `translateToVirtual()` applies the plain `realRoot` replace (regular projects) then the symlink map (git clones), so **diagnostics, call/type hierarchy, and all forwarded LSP messages** get correct virtual URIs.

Because the fix is server-side, the client `toWorkspacePath()` (strip `file:///workspace`) keeps working unchanged for the Problems and Hierarchy views.

Also swaps the `view-java` labels per request: view **"Java" → "Hierarchy"**, inner tab **"Hierarchy" → "Java"** (tab id unchanged).

## Verification

Rebuilt `ide-java-lsp` + `view-java` and the application jar, restarted, and against the cloned `sample-intent-multi-model` project:

- `POST /services/ide/java-lsp/diagnostics` now returns virtual URIs, e.g. `file:///workspace/workspace/countries/gen/countries/api/settings/CountryController.java` (clone prefix gone).
- The exact URL the editor builds — `GET /services/ide/workspaces/workspace/countries/gen/countries/api/settings/CityController.java` — returns **200**.
- `formatter:validate` passes on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)