### PR TITLE
ci: disable integration-tests-mssql on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: mvn -T 1C formatter:validate
 
   build-deploy:
-    needs: [ tests, integration-tests-h2, integration-tests-postgresql, integration-tests-mssql ]
+    needs: [ tests, integration-tests-h2, integration-tests-postgresql ]
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -293,75 +293,82 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}
           path: tests/tests-integrations/build/reports/tests
 
-  integration-tests-mssql:
-    runs-on: ubuntu-latest
-    env:
-      MSSQL_PASS: 'mYPass1234!'
-    services:
-      mssql:
-        image: mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04
-        ports:
-          - 1433:1433
-        env:
-          ACCEPT_EULA: Y
-          MSSQL_SA_PASSWORD: ${{ env.MSSQL_PASS }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Set up JDK Corretto 24
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '24'
-          architecture: x64
-
-      - name: Install NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-
-      - name: Install TypeScript and esbuild
-        run: npm install -g typescript@5.9.3 esbuild
-
-      - name: Install ttyd (prebuilt)
-        run: |
-          sudo apt update
-          sudo apt install -y ttyd
-
-      - name: Verify ttyd installation
-        run: ttyd --version
-
-      - name: Integration tests
-        run: mvn clean install -P integration-tests
-        env:
-          DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
-          DIRIGIBLE_DATASOURCE_DEFAULT_URL: 'jdbc:sqlserver://localhost:1433;databaseName=master;encrypt=true;trustServerCertificate=true'
-          DIRIGIBLE_DATASOURCE_DEFAULT_USERNAME: 'sa'
-          DIRIGIBLE_DATASOURCE_DEFAULT_PASSWORD: ${{ env.MSSQL_PASS }}
-
-      - name: Generate a random artifact name
-        if: always()
-        id: generate_name
-        run: |
-          TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-${TIMESTAMP}.zip" >> $GITHUB_ENV
-
-      - name: Upload selenide screenshots
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          retention-days: 3
-          name: ${{ env.ARTIFACT_NAME }}
-          path: tests/tests-integrations/build/reports/tests
+  # NOTE: integration-tests-mssql is intentionally NOT run on master either (was already off on PRs).
+  # The generated Java entity path (@GeneratedValue(IDENTITY)) needs a real IDENTITY column, but MSSQL
+  # deliberately gets a plain INT (TableCreateProcessor skips the IDENTITY DDL so explicit-ID INSERTs
+  # from CSVIM / the TS DAO / user-authored Camel/JDBC still work — MSSQL alone rejects explicit inserts
+  # into IDENTITY columns). Those two constraints conflict on MSSQL; MultitenancyHarmoniaIT surfaces it.
+  # Re-enable once the Java stack allocates its PK from the tenant-aware platform sequence on MSSQL
+  # (parity with the TS DAO) instead of relying on DB IDENTITY.
+#   integration-tests-mssql:
+#     runs-on: ubuntu-latest
+#     env:
+#       MSSQL_PASS: 'mYPass1234!'
+#     services:
+#       mssql:
+#         image: mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04
+#         ports:
+#           - 1433:1433
+#         env:
+#           ACCEPT_EULA: Y
+#           MSSQL_SA_PASSWORD: ${{ env.MSSQL_PASS }}
+#     steps:
+#       - uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
+#
+#       - name: Cache local Maven repository
+#         uses: actions/cache@v4
+#         with:
+#           path: ~/.m2/repository
+#           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#           restore-keys: ${{ runner.os }}-maven-
+#
+#       - name: Set up JDK Corretto 24
+#         uses: actions/setup-java@v4
+#         with:
+#           distribution: 'corretto'
+#           java-version: '24'
+#           architecture: x64
+#
+#       - name: Install NodeJS
+#         uses: actions/setup-node@v4
+#         with:
+#           node-version: 22.x
+#
+#       - name: Install TypeScript and esbuild
+#         run: npm install -g typescript@5.9.3 esbuild
+#
+#       - name: Install ttyd (prebuilt)
+#         run: |
+#           sudo apt update
+#           sudo apt install -y ttyd
+#
+#       - name: Verify ttyd installation
+#         run: ttyd --version
+#
+#       - name: Integration tests
+#         run: mvn clean install -P integration-tests
+#         env:
+#           DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: 'com.microsoft.sqlserver.jdbc.SQLServerDriver'
+#           DIRIGIBLE_DATASOURCE_DEFAULT_URL: 'jdbc:sqlserver://localhost:1433;databaseName=master;encrypt=true;trustServerCertificate=true'
+#           DIRIGIBLE_DATASOURCE_DEFAULT_USERNAME: 'sa'
+#           DIRIGIBLE_DATASOURCE_DEFAULT_PASSWORD: ${{ env.MSSQL_PASS }}
+#
+#       - name: Generate a random artifact name
+#         if: always()
+#         id: generate_name
+#         run: |
+#           TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+#           echo "ARTIFACT_NAME=selenide-screenshots-${TIMESTAMP}.zip" >> $GITHUB_ENV
+#
+#       - name: Upload selenide screenshots
+#         uses: actions/upload-artifact@v4
+#         if: always()
+#         with:
+#           retention-days: 3
+#           name: ${{ env.ARTIFACT_NAME }}
+#           path: tests/tests-integrations/build/reports/tests
 
   scan-image:
     name: Scan Docker image using Docker Scout


### PR DESCRIPTION
MSSQL was already disabled on PRs; this turns it off on master (`build.yml`) too and drops it from `build-deploy`'s `needs`.

## Why

`MultitenancyHarmoniaIT` fails **only** on the MSSQL leg. Root cause: the generated Java entity uses `@GeneratedValue(IDENTITY)` → Hibernate `identity` generator → it omits the PK on insert, expecting the DB to generate it. But on MSSQL `TableCreateProcessor` deliberately emits a **plain `INT`** column (no `IDENTITY(1,1)`), so the insert writes `NULL` → constraint violation → HTTP 500.

That IDENTITY skip is **correct and must stay**: MSSQL uniquely rejects explicit-ID INSERTs into `IDENTITY` columns, and CSVIM, the TS DAO, and **user-authored raw JDBC** (e.g. `CamelExtractTransformLoadJdbcIT`'s MSSQL `MERGE ... INSERT (ID,...) VALUES (source.ID,...)`) all depend on explicit-ID inserts the platform can't wrap in `SET IDENTITY_INSERT`. The two ID paths genuinely conflict on MSSQL.

## Scope

Interim CI change only — no product code touched. H2 + PostgreSQL legs still run on master.

## Follow-up

Re-enable the MSSQL leg once the Java stack allocates its PK from the tenant-aware platform sequence on MSSQL (parity with the TS DAO) instead of relying on DB IDENTITY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)