### PR TITLE
feat: on-demand action buttons in generated Harmonia apps (intent actions DSL)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentGenerationService.java
@@ -47,7 +47,7 @@ public class IntentGenerationService {
      * project root are owned (and scrubbed) by the generation pass.
      */
     private static final Set<String> INTENT_OWNED_EXTENSIONS = Set.of(".edm", ".model", ".bpmn", ".form", ".report", ".roles", ".access",
-            ".dsm", ".schema", ".table", ".view", ".csvim", ".csv", ".glue", ".print");
+            ".dsm", ".schema", ".table", ".view", ".csvim", ".csv", ".glue", ".print", ".extension");
 
     private final List<IntentTargetGenerator> generators;
     private final IRepository repository;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/action/ActionIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/action/ActionIntentGenerator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.action;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.base.helpers.JsonHelper;
+import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
+import org.eclipse.dirigible.components.intent.generator.IntentNaming;
+import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
+import org.eclipse.dirigible.components.intent.model.ActionIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * Materializes each {@code actions} entry into a contribution to the app's
+ * {@code <project>-custom-action} extension point - one {@code <name>-action.extension}
+ * (registering the point + module) plus one {@code <name>-action.js} (a module exporting
+ * {@code getView()} with the action descriptor). The generated Harmonia views load that point
+ * through the shared {@code customActions} store (see the Harmonia UI templates) and render the
+ * button on the entity named by {@code forEntity}, opening the declared {@code page} in the
+ * app-wide dialog. Declaring an action in intent therefore needs no hand-written
+ * {@code .extension}/{@code .js}; external projects may still contribute to the same point.
+ *
+ * <p>
+ * Idempotent: identical input always produces byte-identical output. The {@code .extension} files
+ * are intent-owned (see
+ * {@link org.eclipse.dirigible.components.intent.generator.IntentGenerationService}), so an action
+ * removed from the intent is scrubbed on the next Generate.
+ */
+@Component
+@Order(450)
+public class ActionIntentGenerator implements IntentTargetGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActionIntentGenerator.class);
+
+    @Override
+    public String name() {
+        return "action";
+    }
+
+    @Override
+    public void generate(IntentGenerationContext context) {
+        IntentModel model = context.getModel();
+        if (model.getActions()
+                 .isEmpty()) {
+            return;
+        }
+        String project = context.getProjectName();
+        for (ActionIntent action : model.getActions()) {
+            String name = action.getName();
+            if (name == null || name.isBlank()) {
+                LOGGER.warn("Skipping action with no name");
+                continue;
+            }
+            String fileBase = name + "-action";
+            String modulePath = project + "/" + fileBase + ".js";
+            context.writeModelFile(fileBase + ".extension", buildExtensionJson(project, modulePath, action));
+            context.writeModelFile(fileBase + ".js", buildDescriptorModule(project, action));
+        }
+    }
+
+    private static String buildExtensionJson(String project, String modulePath, ActionIntent action) {
+        Map<String, Object> extension = new LinkedHashMap<>();
+        extension.put("module", modulePath);
+        extension.put("extensionPoint", project + "-custom-action");
+        extension.put("description", "Custom action [" + action.getName() + "] on [" + action.getForEntity() + "]");
+        return JsonHelper.toJson(extension);
+    }
+
+    private static String buildDescriptorModule(String project, ActionIntent action) {
+        Map<String, Object> view = new LinkedHashMap<>();
+        view.put("id", project + "-" + action.getForEntity() + "-" + action.getName());
+        String label = action.getLabel() == null || action.getLabel()
+                                                          .isBlank() ? IntentNaming.humanize(action.getName()) : action.getLabel();
+        view.put("label", label);
+        view.put("path", action.getPage());
+        view.put("view", action.getForEntity());
+        view.put("type", action.getScope());
+        if (action.getIcon() != null && !action.getIcon()
+                                               .isBlank()) {
+            view.put("icon", action.getIcon());
+        }
+        if (action.getOrder() != null) {
+            view.put("order", action.getOrder());
+        }
+        // A CommonJS module exporting getView() - the shape the extension-services endpoint loads.
+        return "const viewData = " + JsonHelper.toJson(view) + ";\n" + "if (typeof exports !== 'undefined') {\n"
+                + "    exports.getView = () => viewData;\n" + "}\n";
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ActionIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ActionIntent.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.model;
+
+/**
+ * On-demand action declaration. Contributes a developer-defined action button onto an entity's
+ * generated Harmonia view via the app's {@code <project>-custom-action} extension point (the same
+ * mechanism external projects use), so the app's own actions and third-party contributions render
+ * through one path (the {@code customActions} store).
+ *
+ * {@link #forEntity} ties the action to an {@link EntityIntent}; {@link #scope} decides where the
+ * button renders: {@code page} (a toolbar action on the whole view) or {@code entity} (a per-record
+ * action that carries the selected record's id to the opened page). {@link #page} is the
+ * same-origin path opened in the app-wide dialog when the button is clicked.
+ */
+public class ActionIntent {
+
+    /** Unique action id within the model; also drives the generated contribution file names. */
+    private String name;
+
+    /** The entity whose generated view shows this action's button. Must be a declared entity. */
+    private String forEntity;
+
+    /** {@code entity} (per-record, default) or {@code page} (whole-view toolbar action). */
+    private String scope = "entity";
+
+    /** Button label; defaults to a humanized {@link #name} when blank. */
+    private String label;
+
+    /** Optional Lucide icon name (informational; carried onto the contribution descriptor). */
+    private String icon;
+
+    /** Optional ordering hint among the contributed actions of a view. */
+    private Integer order;
+
+    /** Same-origin path opened in the app-wide dialog when the action is triggered. */
+    private String page;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getForEntity() {
+        return forEntity;
+    }
+
+    public void setForEntity(String forEntity) {
+        this.forEntity = forEntity;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope == null || scope.isBlank() ? "entity" : scope;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
+    public void setOrder(Integer order) {
+        this.order = order;
+    }
+
+    public String getPage() {
+        return page;
+    }
+
+    public void setPage(String page) {
+        this.page = page;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/IntentModel.java
@@ -57,6 +57,16 @@ public class IntentModel {
     private List<InboundIntent> inbound = new ArrayList<>();
     private List<RollupIntent> rollups = new ArrayList<>();
     private List<SettlementIntent> settlements = new ArrayList<>();
+    /** Developer-declared on-demand action buttons contributed onto entity views. */
+    private List<ActionIntent> actions = new ArrayList<>();
+
+    public List<ActionIntent> getActions() {
+        return actions;
+    }
+
+    public void setActions(List<ActionIntent> actions) {
+        this.actions = actions == null ? new ArrayList<>() : actions;
+    }
 
     public List<SettlementIntent> getSettlements() {
         return settlements;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.dirigible.components.intent.model.ActionIntent;
 import org.eclipse.dirigible.components.intent.model.CustomWidgetIntent;
 import org.eclipse.dirigible.components.intent.model.DependsOnIntent;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
@@ -154,6 +155,7 @@ public final class IntentParser {
         validateOrders(model, issues);
         validateProcesses(model, entityNames, issues);
         validateForms(model, entityNames, issues);
+        validateActions(model, entityNames, issues);
         validateReports(model, entityNames, issues);
         validateWidgets(model, issues);
         validateSeeds(model, entityNames, issues);
@@ -1114,6 +1116,42 @@ public final class IntentParser {
             }
             validateFormRelationFields(form, bound, byName, issues);
             validateFormEditable(form, bound, issues);
+        }
+    }
+
+    /**
+     * Validate the {@code actions} block: each on-demand action needs a unique name, a known
+     * {@code forEntity}, a {@code scope} of {@code entity} or {@code page}, and a same-origin
+     * {@code page} to open. The generator contributes each into the app's
+     * {@code <project>-custom-action} extension point so it renders on the entity's view (see the
+     * ActionIntentGenerator).
+     */
+    private static void validateActions(IntentModel model, Set<String> entityNames, List<String> issues) {
+        Set<String> actionNames = new HashSet<>();
+        for (ActionIntent action : model.getActions()) {
+            if (action.getName() == null || action.getName()
+                                                  .isBlank()) {
+                issues.add("action has no name");
+                continue;
+            }
+            String name = action.getName();
+            if (!actionNames.add(name)) {
+                issues.add("duplicate action [" + name + "]");
+            }
+            if (action.getForEntity() == null || action.getForEntity()
+                                                       .isBlank()) {
+                issues.add("action [" + name + "] has no forEntity");
+            } else if (!entityNames.contains(action.getForEntity())) {
+                issues.add("action [" + name + "] references unknown entity [" + action.getForEntity() + "]");
+            }
+            String scope = action.getScope();
+            if (!"entity".equals(scope) && !"page".equals(scope)) {
+                issues.add("action [" + name + "] has invalid scope [" + scope + "] (expected 'entity' or 'page')");
+            }
+            if (action.getPage() == null || action.getPage()
+                                                  .isBlank()) {
+                issues.add("action [" + name + "] has no page (a same-origin path to open)");
+            }
         }
     }
 

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -404,6 +404,33 @@ paths / relations.
   `decision` that branches on the chosen `action` (e.g. `if: "action == 'approve'"`). For a task that
   just continues linearly, use a **single action** (e.g. `actions: [issue]`) and no decision.
 
+### actions - on-demand action buttons
+
+**Use when:** a generated entity view needs a developer-defined button that opens a custom page - a
+whole-view toolbar action (import, a wizard, a report launcher) or a per-record action (open a portal,
+a related view). This is the UI escape hatch for on-demand actions; it is distinct from a form's task
+`actions` (which complete a BPM user task).
+
+```yaml
+actions:
+  - name: OpenPortal            # unique id; also names the generated contribution files
+    forEntity: Order            # the entity whose generated view shows the button
+    scope: entity               # 'entity' (per-record) or 'page' (whole-view toolbar)
+    label: Open Portal          # button label (defaults to a humanized name)
+    icon: external-link         # optional Lucide icon
+    order: 10                   # optional ordering among a view's actions
+    page: /services/web/myapp/custom/portal.html   # same-origin path opened in the app-wide dialog
+```
+
+**Rules:** unique `name`; `forEntity` must be a declared entity; `scope` is `entity` or `page`
+(default `entity`); `page` is a required same-origin path. Each action generates a contribution to the
+app's `<project>-custom-action` extension point (a `<name>-action.extension` + a `<name>-action.js`
+module), which the generated Harmonia views render through the shared `customActions` store - a
+`page` action becomes a toolbar button, an `entity` action a per-record button that passes the
+selected record's id to the opened page (as `?id=`). External projects may contribute to the same
+point; the app's own declared actions and third-party contributions render through one path. The
+opened page dismisses the dialog by posting `{ type: 'harmonia.form.close' }` to its parent.
+
 ### reports - read-only aggregations
 
 **Use when:** the user needs a read-only view, list, or aggregation across records.
@@ -718,6 +745,7 @@ payment's unallocated balance; entity writes go only through the generated repos
 - "store / manage X" -> **entities**
 - "approval / multi-step / workflow" -> **processes** (+ a **form** for each user task)
 - "a screen to enter / edit X" -> **forms**
+- "a button on X's view that opens a custom page / action" -> **actions**
 - "a list / dashboard / count of X by Y" -> **reports**
 - "who can do what" -> **permissions**
 - "preload these values" -> **seeds**

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/stores/customActions.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+/**
+ * customActions - surfaces developer-contributed, per-view on-demand action buttons in the generated
+ * Harmonia views. It is the Alpine counterpart of the AngularJS templates' `<project>-custom-action`
+ * extension mechanism: any extension contributed to the `<project>-custom-action` extension point (a
+ * view descriptor exporting at least { id, label, path } plus { perspective, view, type, order }) is
+ * fetched once from the shared extension-services endpoint and surfaced on the view it targets.
+ *
+ * A descriptor's `type` decides where its button renders:
+ *   'page' (or omitted) - a toolbar button acting on the whole view
+ *   'entity'            - a per-record button that needs a selected row (its id is passed to the page)
+ *
+ * It is a global Alpine store so every generated view reads it the same way:
+ *   $store.customActions.getActions(perspective, view, 'page')    -> the view's toolbar actions
+ *   $store.customActions.getActions(perspective, view, 'entity')  -> the view's per-record actions
+ *   $store.customActions.trigger(action, id)                      -> open the action page in the
+ *                                                                    app-wide dialog (an entity action
+ *                                                                    passes the record id as ?id=)
+ * The action page opens in the dialog wired in index.html; on its `harmonia.form.close` message (or an
+ * explicit close) the store closes it and raises a `harmonia:action-done` window event, so a view that
+ * a mutating action changed (duplicate / create-from / aggregate) can refresh without a manual reload.
+ */
+document.addEventListener('alpine:init', () => {
+  Alpine.store('customActions', {
+    actions: [],        // the flat list of contributed action descriptors for this app
+    loaded: false,
+    dialogOpen: false,
+    dialogUrl: '',
+    dialogTitle: '',
+    serverUnavailable: false,   // set once the backend is unreachable; stops re-fetching until a reload
+
+    init() {
+      this.load();
+      // An action page (opened in the app-wide dialog) asks its host to close when it is done.
+      window.addEventListener('message', (e) => {
+        if (e && e.data && e.data.type === 'harmonia.form.close' && this.dialogOpen) this.closeDialog();
+      });
+      // Re-read the contributions on navigation so a newly published action shows without a full reload.
+      document.addEventListener('pinecone:end', () => { if (this.loaded) this.load(); });
+    },
+
+    async load() {
+      // Once the server has gone away we stop re-fetching; a browser refresh recreates this store
+      // (serverUnavailable back to false) and resumes.
+      if (this.serverUnavailable) return;
+      const project = (window.App && App.config && App.config.projectName) || '';
+      if (!project) return;
+      const point = project + '-custom-action';
+      try {
+        const data = await App.services.api.get(
+          '/services/js/platform-core/extension-services/views.js?extensionPoints=' + encodeURIComponent(point),
+          { baseUrl: '' });
+        this.actions = Array.isArray(data) ? data : [];
+        this.loaded = true;
+      } catch (e) {
+        // A transport failure (httpStatus 0 -> dead server) or an auth failure (401/403) can't be helped
+        // by retrying; stop until a reload. Other errors just leave the actions empty (buttons hidden).
+        if (e && e.isApiError && (e.httpStatus === 0 || e.httpStatus === 401 || e.httpStatus === 403)) {
+          this.serverUnavailable = true;
+          console.warn('customActions: ' + (e.httpStatus === 0 ? 'server unavailable' : 'not authenticated (' + e.httpStatus + ')')
+            + ' - custom action buttons unavailable until the page is reloaded');
+          return;
+        }
+        this.actions = [];
+        console.error('customActions: unable to load custom actions', e);
+      }
+    },
+
+    refresh() { return this.load(); },
+
+    // The actions targeted at a given view. `view` is the entity name; the app-scoped extension point
+    // (`<project>-custom-action`) already narrows to this app, so entity + type is unambiguous. `type`
+    // is 'page' (a toolbar action on the whole view; matches page or an unset type) or 'entity' (a
+    // per-record action). Contributors set `view`/`type` on the descriptor (a `perspective` field, if
+    // present, stays informational). The list arrives already order-sorted from the endpoint.
+    getActions(view, type) {
+      return (this.actions || []).filter((a) =>
+        a && a.view === view &&
+        (type === 'entity' ? a.type === 'entity'
+                           : (a.type === 'page' || a.type === undefined || a.type === null)));
+    },
+
+    // Open the contributed action page in the app-wide dialog. An entity action carries the selected
+    // record's primary key as `id` (the contributed page reads it from its query string), mirroring the
+    // AngularJS Dialogs.showWindow({ params: { id } }) dispatch. The view knows its own primary key, so
+    // it passes the id value here rather than the whole row.
+    trigger(action, id) {
+      if (!action || !action.path) return;
+      let url = action.path;
+      if (id !== undefined && id !== null && id !== '') {
+        url += (url.indexOf('?') >= 0 ? '&' : '?') + 'id=' + encodeURIComponent(id);
+      }
+      this.dialogUrl = url;
+      this.dialogTitle = action.label || 'Action';
+      this.dialogOpen = true;
+    },
+
+    closeDialog() {
+      this.dialogOpen = false;
+      this.dialogUrl = '';
+      // Let the originating view refresh after a (possibly) mutating action.
+      window.dispatchEvent(new CustomEvent('harmonia:action-done'));
+    },
+  });
+}, { once: true });

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -234,6 +234,22 @@
       </div>
     </div>
 
+    <!-- App-wide dialog for developer-contributed custom actions (driven by the customActions store).
+         The contributed action page is shown in an iframe; it posts harmonia.form.close to dismiss and
+         the store then raises harmonia:action-done so the originating view refreshes. -->
+    <div x-h-dialog-overlay :data-open="$store.customActions.dialogOpen">
+      <div x-h-dialog style="width: 92vw; max-width: 1100px;">
+        <div x-h-dialog-header>
+          <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+        </div>
+        <div x-h-dialog-content>
+          <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"
+                  title="Action" style="width:100%; height:70vh; border:0;"></iframe>
+        </div>
+      </div>
+    </div>
+
     <!-- App-wide transient toasts (raised through Harmonia's notifications magic with this template). -->
     <section x-h-notification-overlay>
       <template id="toast">
@@ -284,6 +300,7 @@
     <script src="/services/web/application-core/shell/js/components/pages/basePage.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/notifications.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/processTasks.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/customActions.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/reports.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/theme.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/locale.js" defer></script>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -157,6 +157,11 @@ document.addEventListener('alpine:init', () => {
 
     apiPath: '/${javaPerspectiveName}/${name}Controller',
 
+    // Entity name used to match developer-contributed custom actions ($store.customActions) targeted
+    // at this document. Set here (not inline in the view) so Velocity substitutes it - a $store.*(...)
+    // call in the template would emit any nested ${...} verbatim.
+    caView: '${name}',
+
     get isEdit() { return this.mode === 'edit'; },
     get isPreview() { return this.mode === 'preview'; },
     get errorCount() { return Object.keys(this.errors).filter(k => this.errors[k]).length; },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -278,6 +278,13 @@
         <span x-show="printBusy" x-h-spinner></span>
         <i role="img" data-lucide="printer" x-show="!printBusy"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
       </button>
+      <!-- Developer-contributed per-record actions for this document (customActions extension point).
+           Shown for an existing document (edit/preview); passes the document id to the action page. -->
+      <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+        <button type="button" x-h-button data-variant="outline" x-show="isEdit || isPreview" @click="$store.customActions.trigger(action, id)">
+          <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+        </button>
+      </template>
       <!-- Preview footer: Close + Edit instead of Cancel + Save. -->
       <button type="button" x-h-button data-variant="transparent" x-show="isPreview" @click="backToList()" x-text="T('$projectName:${tprefix}.defaults.close', 'Close')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="isPreview" @click="goEdit()">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
@@ -26,6 +26,11 @@ document.addEventListener('alpine:init', () => {
     // (the default base api.* prepends): <restBase>/<perspective>/<Entity>Controller.
     apiPath: '/${javaPerspectiveName}/${name}Controller',
 
+    // Entity name used to match developer-contributed custom actions ($store.customActions) targeted
+    // at this view. Set here (not inline in the view) so Velocity substitutes it - a $store.*(...)
+    // call in the template would emit any nested ${...} verbatim.
+    caView: '${name}',
+
     async init() {
       await this.load();
       this.loadLookups();

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
@@ -15,6 +15,12 @@
         <svg x-h-icon.search class="size-4" role="img" aria-label="search"></svg>
       </div>
     </div>
+    <!-- Developer-contributed page actions for this view (customActions extension point). -->
+    <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
+      <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">
+        <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+      </button>
+    </template>
   </div>
 
   <!-- Loading -->
@@ -128,6 +134,16 @@
           </template>
         </div>
 #end
+
+        <!-- Developer-contributed per-record actions for this entity (customActions extension point).
+             Passes the selected record's id to the action page. -->
+        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+            <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
+              <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+            </button>
+          </template>
+        </div>
 
         <!-- Every property of the selected record (the table above shows only the major ones). -->
         <div class="vbox gap-3 p-4">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
@@ -44,6 +44,11 @@ document.addEventListener('alpine:init', () => {
     // (the default base api.* prepends): <restBase>/<perspective>/<Entity>Controller.
     apiPath: '/${javaPerspectiveName}/${name}Controller',
 
+    // Entity name used to match developer-contributed custom actions ($store.customActions) targeted
+    // at this view. Set here (not inline in the view) so Velocity substitutes it - a $store.*(...)
+    // call in the template would emit any nested ${...} verbatim.
+    caView: '${name}',
+
     async init() {
       await this.load();
       this.loadLookups();

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -19,6 +19,12 @@
       <i role="img" data-lucide="plus"></i>
       <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>
     </button>
+    <!-- Developer-contributed page actions for this view (customActions extension point). -->
+    <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
+      <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">
+        <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+      </button>
+    </template>
   </div>
 
   <!-- Loading -->
@@ -177,6 +183,16 @@
           </template>
         </div>
 #end
+
+        <!-- Developer-contributed per-record actions for this entity (customActions extension point).
+             Passes the selected record's id to the action page. -->
+        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+            <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
+              <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+            </button>
+          </template>
+        </div>
 
         <!-- Every property of the selected record (the table above shows only the major ones). A framed
              condensed two-column grid (matches the master-detail pane). -->

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
@@ -17,6 +17,11 @@ document.addEventListener('alpine:init', () => {
     // <restBase>/<perspective>/<Entity>Controller (the master's own controller).
     apiPath: '/${javaPerspectiveName}/${name}Controller',
 
+    // Entity name used to match developer-contributed custom actions ($store.customActions) targeted
+    // at this view. Set here (not inline in the view) so Velocity substitutes it - a $store.*(...)
+    // call in the template would emit any nested ${...} verbatim.
+    caView: '${name}',
+
     state: 'loading',          // loading | error | empty | default
     masters: [],
     page: 1,

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -14,6 +14,12 @@
       <div x-h-input-group-addon data-align="inline-start"><svg x-h-icon.search class="size-4" role="img" aria-label="search"></svg></div>
     </div>
     <button x-h-button data-variant="primary" @click="newMaster()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span></button>
+    <!-- Developer-contributed page actions for this view (customActions extension point). -->
+    <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
+      <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">
+        <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+      </button>
+    </template>
   </div>
 
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
@@ -106,6 +112,15 @@
           </template>
         </div>
 #end
+
+        <!-- Developer-contributed per-record actions for this entity (customActions extension point). -->
+        <div x-show="$store.customActions.getActions(caView, 'entity').length" class="hbox gap-2 flex-wrap">
+          <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">
+            <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action, selectedId)">
+              <span x-text="action.translation &amp;&amp; action.translation.key ? T(action.translation.key, action.label, action.translation.options || {}) : action.label"></span>
+            </button>
+          </template>
+        </div>
 
         <!-- The selected ${name}'s own fields — all properties (the table shows only the major ones). -->
         <div x-h-card>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -260,6 +260,22 @@
       </div>
     </div>
 
+    <!-- App-wide dialog for developer-contributed custom actions (driven by the customActions store).
+         The contributed action page is shown in an iframe; it posts harmonia.form.close to dismiss and
+         the store then raises harmonia:action-done so the originating view refreshes. -->
+    <div x-h-dialog-overlay :data-open="$store.customActions.dialogOpen">
+      <div x-h-dialog style="width: 92vw; max-width: 1100px;">
+        <div x-h-dialog-header>
+          <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+        </div>
+        <div x-h-dialog-content>
+          <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"
+                  title="Action" style="width:100%; height:70vh; border:0;"></iframe>
+        </div>
+      </div>
+    </div>
+
     <!-- App-wide transient toasts. Any component/form/glue raises one through Harmonia's
          notifications magic with the 'toast' template below (data: message + variant). -->
     <section x-h-notification-overlay>
@@ -391,6 +407,7 @@
     <script src="/services/web/application-core/shell/js/components/pages/baseFormPage.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/detailPanel.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/processTasks.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/customActions.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/reports.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/currentUser.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/notifications.js" defer></script>


### PR DESCRIPTION
## On-demand action buttons for generated Harmonia apps

Brings developer-defined **on-demand action buttons** to generated Harmonia views, in two layers. This is the foundation for a set of document capabilities (Duplicate, Create-from, aggregate-generate) that follow on top of it.

### P1 - Harmonia action surface (`053d335597`)
Ports the AngularJS `<project>-custom-action` view-extension mechanism into the Harmonia templates so contributed actions render as buttons and open in the app-wide dialog.

- New shared Alpine store `application-core/shell/js/stores/customActions.js` - fetches the app's `<project>-custom-action` contributions from the existing `extension-services` endpoint, filters by `view` + `type`, dispatches the target page into the app-wide dialog (an entity action passes the record id as `?id=`).
- Wired into both shells (the shared `application/index.html` and the generated standalone `ui/shell/index.html.template`): store script + dialog host.
- Renders page/entity action buttons across all four view kinds (list, manage, master, document). The entity name is carried on a `caView` component property (Velocity emits `${...}` verbatim inside a `$store.*(...)` call, so it must be set in `page.js`, not inline in the view).
- **No platform-core change** - reuses the existing `views.js` extension endpoint.

### P2 - intent `actions:` DSL (`e38b28b581`)
Lets an `.intent` declare actions instead of hand-writing the extension files.

```yaml
actions:
  - name: OpenPortal
    forEntity: Order
    scope: entity        # entity (per-record) | page (whole-view toolbar)
    label: Open Portal
    page: /services/web/myapp/custom/portal.html
```

- `ActionIntent` model + `IntentModel.actions` + `IntentParser.validateActions`.
- `ActionIntentGenerator` (@Order 450) emits a `<name>-action.extension` + `<name>-action.js` descriptor per action; `.extension` is marked intent-owned so a removed action is scrubbed on regenerate.
- Documented in `intent-assistant-guide.md`.

### Verification
Built and exercised end-to-end in a headless browser against a generated app: page and entity actions render on the manage and document views, and clicking dispatches the contributed page into the dialog with the record id. Verified both hand-contributed (P1) and intent-declared (P2) actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
