### PR TITLE
fix(bpm): enforce tenant isolation on getTasksCount and deleteTasks(reason)

### DIFF
--- a/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskServiceImpl.java
+++ b/components/engine/engine-bpm-flowable/src/main/java/org/eclipse/dirigible/components/engine/bpm/flowable/config/TaskServiceImpl.java
@@ -55,6 +55,7 @@ class TaskServiceImpl implements TaskService {
     @Override
     public long getTasksCount() {
         return flowableTaskService.createTaskQuery()
+                                  .taskTenantId(getTenantId())
                                   .count();
     }
 
@@ -153,6 +154,8 @@ class TaskServiceImpl implements TaskService {
 
     @Override
     public void deleteTasks(Collection<String> taskIds, String deleteReason) {
+        flowableArtefactsValidator.validateTasks(taskIds);
+
         flowableTaskService.deleteTasks(taskIds, deleteReason);
     }
 


### PR DESCRIPTION
Two methods in `TaskServiceImpl` bypassed the tenant checks the rest of the class applies consistently. Flowable stores all tenants' data in the shared `SystemDB` and isolates purely by the native `tenantId` column, so every task access must filter/validate by the current tenant — these two were the outliers.

## Fixes

- **`getTasksCount()`** ran a bare `createTaskQuery().count()` → counted tasks across **all tenants**. Added `.taskTenantId(getTenantId())`. (Info leak — count only.)
- **`deleteTasks(Collection<String>, String deleteReason)`** was the **only** delete overload skipping `flowableArtefactsValidator.validateTasks(...)` (its siblings all validate) → a caller in tenant A could delete tenant B's tasks by id via `BpmFacade.getEngine().getTaskService()`. Added the validation.

## Scope

Two-line change, no behavior change for same-tenant callers. `mvn compile` + `formatter:format` clean on `engine-bpm-flowable`.

## Follow-up (not in this PR)

A cross-tenant IT (assert task ops on another tenant's id throw) would lock this down — happy to add on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)