### PR TITLE
feat(intent): duplicable documents - built-in Duplicate action

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -183,6 +183,11 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 // the line-items' humanized + pluralized label ("Sales Invoice Items").
                 entityMap.put("documentLabel", IntentNaming.humanize(name));
                 entityMap.put("documentItemsLabel", IntentNaming.pluralize(IntentNaming.humanize(itemsEntity)));
+                // duplicable: the document view offers a built-in Duplicate action that clones the
+                // current document (header + line items) into a new draft (see the document template).
+                if (entity.isDuplicable()) {
+                    entityMap.put("duplicable", "true");
+                }
             }
             // A plain PRIMARY entity with NO composition children of its own is standalone, not a
             // master-detail. Give it the fuller MANAGE list layout (search / sort / per-column filter,

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -67,6 +67,14 @@ public class EntityIntent {
      */
     private Boolean multilingual;
     /**
+     * Marks a document entity as <b>duplicable</b>: its generated document view shows a built-in
+     * Duplicate action that clones the current record (header + composition line items) into a new
+     * draft and opens it. The clone creates through the normal REST create path, so the number
+     * ({@code calculatedActionOnCreate}), the initial status ({@code init}) and calculated fields are
+     * reassigned by the server. Absent (the default) → no Duplicate action.
+     */
+    private Boolean duplicable;
+    /**
      * Optional explicit ordering of the generated UI controls (form inputs, list columns, detail rows)
      * by property name - fields and to-one relations interleaved, in the given order. Names match the
      * authored field / relation names (case-insensitive). Any property not listed keeps its default
@@ -181,5 +189,21 @@ public class EntityIntent {
 
     public void setMultilingual(Boolean multilingual) {
         this.multilingual = multilingual;
+    }
+
+    /**
+     * Whether this entity's document view offers the built-in Duplicate action
+     * ({@code duplicable: true}).
+     */
+    public boolean isDuplicable() {
+        return Boolean.TRUE.equals(duplicable);
+    }
+
+    public Boolean getDuplicable() {
+        return duplicable;
+    }
+
+    public void setDuplicable(Boolean duplicable) {
+        this.duplicable = duplicable;
     }
 }

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -157,6 +157,14 @@ composition is opt-in.
 **Audit columns:** `audit: true` on an entity adds the four standard audit columns (`CreatedAt`,
 `CreatedBy`, `UpdatedAt`, `UpdatedBy`), populated by the platform's audit annotations.
 
+**Duplicate action (`duplicable: true`):** on a **document** entity (a master owning a composition
+child whose name ends in `Item`) this adds a built-in **Duplicate** button to the document view. It
+clones the current document - header plus its line items - into a new draft and opens it, cloning
+through the normal create path so the number (`calculatedActionOnCreate`), the initial status
+(`init`), the audit columns and all calculated/aggregate fields are reassigned by the server (only the
+source's identity/system/status fields are dropped). Use it for documents users routinely copy
+(invoices, orders). It has no effect on non-document entities.
+
 **Control order (`order:`):** by default the generated UI controls (form inputs, list columns, detail
 rows) follow the declaration order - all fields first, then the to-one relations, so relations end up
 last. Give an entity an `order:` list of property names to sequence them explicitly, interleaving

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -100,6 +100,14 @@ function harmoniaCalcEval(expr, vars, scale) {
   return roundHalfUp(isFinite(result) ? result : 0, scale == null ? 2 : scale);
 }
 
+## Document-role properties (the number/title field and the status FK), derived once here so they are
+## available to duplicate()'s clone-strip list below (which runs before the status-pill #set further down).
+#set($docNumberProp = "")
+#set($docStatusProp = "")
+#foreach($property in $properties)
+#if($property.widgetType == "DOCUMENT_NUMBER")#set($docNumberProp = $property.name)#end
+#if($property.widgetType == "DOCUMENT_STATUS")#set($docStatusProp = $property.name)#end
+#end
 document.addEventListener('alpine:init', () => {
   Alpine.data('${name}DocumentPage', () => ({
     ...baseFormPage(),
@@ -468,6 +476,55 @@ document.addEventListener('alpine:init', () => {
 #end
       return payload;
     },
+
+#if($duplicable)
+    // Duplicate this document (header + line items) into a new draft and open it. Clones through the
+    // normal create path, so the number (calculatedActionOnCreate), the initial status (init default),
+    // audit columns and calculated/aggregate fields are reassigned by the server; the source's
+    // identity/system/status fields are dropped from the cloned header.
+    async duplicate() {
+      if (this.id == null) return;
+      this.state = 'saving';
+      try {
+        const src = await App.services.api.get(this.apiPath + '/' + encodeURIComponent(this.id));
+        const header = { ...src };
+        [
+          '${primaryKeysString}', 'ProcessId', 'CreatedAt', 'CreatedBy', 'UpdatedAt', 'UpdatedBy', 'Uuid',
+#foreach($property in $properties)
+#if($property.isReadOnlyProperty == "true" || $property.aggregate == "true")
+          '${property.name}',
+#end
+#end
+#if($docStatusProp != "")
+          '${docStatusProp}',
+#end
+#if($docNumberProp != "")
+          '${docNumberProp}',
+#end
+        ].forEach(f => { delete header[f]; });
+        const created = await App.services.api.post(this.apiPath, header);
+        const newId = created && (created.${primaryKeysString} !== undefined ? created.${primaryKeysString} : created.id);
+        if (newId == null) throw new Error('No id returned for the duplicated document.');
+        // Clone the line items, repointed at the new header (editable inputs only; calculated item
+        // fields are recomputed by the server on create).
+        if (this.itemsDef) {
+          const q = '?' + encodeURIComponent(this.itemsDef.masterEntityId) + '=' + encodeURIComponent(this.id);
+          const items = (await App.services.api.getAll(this.itemsDef.apiPath + q)) || [];
+          for (const it of items) {
+            const body = {};
+            this.editColumns.forEach(c => { if (!c.readonly && it[c.name] !== undefined) body[c.name] = it[c.name]; });
+            body[this.itemsDef.masterEntityId] = newId;
+            await App.services.api.post(this.itemsDef.apiPath, body);
+          }
+        }
+        window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(newId) + '/edit');
+      } catch (e) {
+        this.applyApiError(e, { fallbackMessage: 'Could not duplicate the document.' });
+      } finally {
+        this.state = 'ready';
+      }
+    },
+#end
 
     // ----- Items (read-only table + add/edit dialog, server-side) --------------------------------
     get editColumns() { return (this.itemsDef && this.itemsDef.editColumns) || []; },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -278,6 +278,12 @@
         <span x-show="printBusy" x-h-spinner></span>
         <i role="img" data-lucide="printer" x-show="!printBusy"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
       </button>
+#if($duplicable)
+      <!-- Built-in Duplicate action: clones this document (header + items) into a new draft and opens it. -->
+      <button type="button" x-h-button data-variant="outline" x-show="isEdit || isPreview" :disabled="state === 'saving'" @click="duplicate()">
+        <i role="img" data-lucide="copy"></i><span x-text="T('$projectName:${tprefix}.defaults.duplicate', 'Duplicate')"></span>
+      </button>
+#end
       <!-- Developer-contributed per-record actions for this document (customActions extension point).
            Shown for an existing document (edit/preview); passes the document id to the action page. -->
       <template x-for="action in $store.customActions.getActions(caView, 'entity')" :key="action.id">


### PR DESCRIPTION
## Built-in Duplicate action for documents (`duplicable: true`)

Stacked on #6151 (on-demand actions). Adds `duplicable: true` on a **document** entity (a master owning a composition child whose name ends in `Item`, e.g. `SalesInvoice`/`SalesInvoiceItem`). The generated document view gains a built-in **Duplicate** button that clones the current document - header plus its line items - into a new draft and opens it.

- `EntityIntent.duplicable` + `isDuplicable()`; `EdmIntentGenerator` emits `duplicable` onto the document entity's `.model` (rides the entity map like `multilingual` - no `service-generate` change).
- `document-view`: native Duplicate button in the footer (edit/preview), behind `#if($duplicable)`.
- `document-page`: a generated `duplicate()` that clones the header through the normal REST **create** path - dropping the PK, system/audit columns, the `documentStatus` FK (so `init` reapplies → DRAFT) and the `documentTitle`/number (so the number generator reassigns) - then clones the line items repointed at the new draft and navigates to it. The document-role props (`docNumberProp`/`docStatusProp`) are derived at the top of the component so the clone's strip list resolves them.
- Documented `duplicable: true` in `intent-assistant-guide.md`.

### Verification
End-to-end (browser + REST): cloning a **CONFIRMED** document (`ORD-0001`) produced a new **DRAFT** with the number blanked, the status reset via `init`, the copied totals, and both line items copied and repointed to the new draft; the UI navigated to the new draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
