### PR TITLE
test(framework): raise GreenMail startup timeout to cut IT flakiness

### DIFF
--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/mail/GreenMailConfig.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/mail/GreenMailConfig.java
@@ -31,9 +31,21 @@ public class GreenMailConfig {
     private static final String MAIL_PASSWORD = "mailPassword";
     private static final int MAIL_PORT = PortUtil.getFreeRandomPort();
 
+    /**
+     * GreenMail's default server-startup timeout is 2000ms - the socket must be confirmed up within it
+     * or {@link GreenMail#start()} throws, failing this bean and (because Spring caches context-load
+     * failures with a threshold of 1) cascading an {@code ApplicationContext} load failure across the
+     * UI ITs that share the context. On a loaded CI runner the 2s window is intermittently missed,
+     * which is the single largest source of integration-test flakiness. Give startup generous headroom;
+     * it only ever waits this long on failure - a healthy server returns as soon as the socket is
+     * listening.
+     */
+    private static final long SERVER_STARTUP_TIMEOUT_MS = 30_000L;
+
     @Bean
     GreenMail provideGreenMailServer() {
         ServerSetup serverSetup = new ServerSetup(MAIL_PORT, "localhost", "smtp");
+        serverSetup.setServerStartupTimeout(SERVER_STARTUP_TIMEOUT_MS);
         GreenMail greenMail = new GreenMail(serverSetup);
         greenMail.start();
         greenMail.setUser(MAIL_USER, MAIL_PASSWORD);


### PR DESCRIPTION
## Problem

The integration-test jobs (`integration-tests-h2`, `-postgresql`) fail intermittently with **`Failed to load ApplicationContext`** on UI Selenide ITs — never an assertion failure, and passing on re-run / on the other DB job. Tracing the actual cause:

```
BeanCreationException: Error creating bean 'provideGreenMailServer' ...
Could not start mail server smtp:localhost:NNNNN, try to set server startup
timeout > 2000 via ServerSetup.setServerStartupTimeout(...) or -Dgreenmail.startup.timeout
```

Every `@SpringBootTest` UI IT boots the whole app, which includes the GreenMail embedded SMTP server. GreenMail's default **startup timeout is 2000 ms**; on a loaded CI runner the socket isn't always confirmed up within it, so `start()` throws → the `provideGreenMailServer` bean fails → the `ApplicationContext` fails to load. Spring caches context-load failures with a **threshold of 1**, so a single miss cascades: every later UI IT sharing the context is errored (`ApplicationContext failure threshold (1) exceeded`), turning one flaky boot into 3–4 red tests.

This is the dominant source of the IT flakiness (why it looks worse than it is — the threshold amplifies one miss into several reds; and the app boot has grown heavier over time — Java LSP, `tsc` watch, Flowable, synchronizers all initialize at context startup, so the 2 s window is missed more often).

## Fix

Set the GreenMail server-startup timeout to **30 s** via `ServerSetup.setServerStartupTimeout(...)` — exactly what the failure message recommends. It only ever *waits* this long on failure; a healthy server returns as soon as the socket is listening, so the happy path is unchanged.

A deeper follow-up (out of scope here) would be to reuse the Spring context across UI ITs instead of rebooting the whole app per test.

## Verification

`tests-framework` compiles with the new `ServerSetup.setServerStartupTimeout` call. The race is load-dependent and not reliably reproducible locally; the real proof is the context-load flake rate dropping across subsequent CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)