### PR TITLE
feat(intent): transitive (chained) roll-ups across composition levels

### DIFF
--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -740,6 +740,20 @@ rollups:
       capacity: total, balance: balance, status: Status, statusWhenFull: 7, statusWhenPartial: 6 }
 ```
 
+**Transitive (chained) roll-ups.** Roll-ups compose across a multi-level composition: if the parent of
+one roll-up is itself the child of another, a change flows all the way up. Declare one roll-up per
+level and the chain maintains itself - e.g. a 3-level timesheet:
+```yaml
+rollups:
+  # day allocations -> employee timesheet -> project timesheet (both totals stay live)
+  - { name: allocationTotals, entity: EmployeeDayAllocation, via: EmployeeTimesheet, field: total, op: sum, of: total }
+  - { name: timesheetTotals,  entity: EmployeeTimesheet,     via: ProjectTimesheet,  field: total, op: sum, of: total }
+```
+Editing a leaf allocation recomputes its `EmployeeTimesheet.total`, which in turn recomputes the
+`ProjectTimesheet.total`. Recomputation is skipped when a rolled-up value does not actually change, so
+the cascade stops at rest and never loops (composition is an acyclic tree). No UI is needed beyond the
+standard per-level master-detail: each level is its own record with its own detail rows.
+
 **Rules:** `via` must be a to-one (`manyToOne` / `oneToOne`) relation of the child entity; `field`
 must be an existing field on the parent (**integer** for `count`, **numeric** for `sum`). For the sum
 extras: `capacity`/`balance` are numeric parent fields, `status` a to-one relation of the parent, and

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
@@ -52,6 +52,12 @@ public class ${className} implements MessageHandler {
                 sum = sum.add(row.${sumField});
             }
         }
+        // Skip when the rolled-up total has not moved: no redundant write, and - crucially - no event.
+        // This bounds the roll-up cascade (a parent whose total is unchanged raises nothing further) so
+        // transitive roll-ups over an acyclic composition tree always terminate.
+        if (parent.${countField} != null && parent.${countField}.compareTo(sum) == 0) {
+            return;
+        }
         parent.${countField} = sum;
 #if($capacityField != "")
         BigDecimal capacity = parent.${capacityField} == null ? BigDecimal.ZERO : parent.${capacityField};
@@ -66,10 +72,17 @@ public class ${className} implements MessageHandler {
         }
 #end
 #end
-        // System-managed denormalization - persist without re-publishing the parent "-updated" event.
-        parents.updateWithoutEvent(parent);
+        // A change to a rolled-up total is a real change to the parent - publish the normal update event
+        // so a higher-level roll-up (and any other update listener) sees it. This is what makes roll-ups
+        // transitive across a composition chain: grandchild -> child -> parent (e.g. day allocations ->
+        // employee timesheet -> project timesheet). The change-guard above stops the cascade at rest.
+        parents.update(parent);
 #else
         int count = new ${childEntity}Repository().findAll(${criteriaExpression}).size();
+        // Same change-guard on the count path: only persist + emit when the count actually moved.
+        if (parent.${countField} != null && parent.${countField} == count) {
+            return;
+        }
         parent.${countField} = count;
         parents.update(parent);
 #end


### PR DESCRIPTION
## What

Makes intent roll-ups **transitive**: when the parent of one roll-up is itself the child of another, a change flows all the way up the composition chain. The motivating case is a 3-level timesheet:

```
ProjectTimesheet
  └─ EmployeeTimesheet        (roll-up: sum of its allocations)
        └─ EmployeeDayAllocation
```
```yaml
rollups:
  - { name: allocationTotals, entity: EmployeeDayAllocation, via: EmployeeTimesheet, field: total, op: sum, of: total }
  - { name: timesheetTotals,  entity: EmployeeTimesheet,     via: ProjectTimesheet,  field: total, op: sum, of: total }
```
Editing a leaf `EmployeeDayAllocation` now recomputes `EmployeeTimesheet.total` **and** `ProjectTimesheet.total`.

## Why it didn't work before

The **sum** roll-up handler persisted the parent with `updateWithoutEvent(parent)`, deliberately suppressing the parent's `-updated` event — so a higher-level roll-up listening on it never fired and the top total went stale whenever only a leaf changed. (The **count** path already used `update`, so count roll-ups chained — the asymmetry is the tell that the sum silence was over-caution, not a real constraint.)

`updateWithoutEvent` exists for the **Trigger** case, where a listener writes `ProcessId` back onto the *same* entity that fired it — a genuine self-loop. A roll-up writes the **parent**, not itself, so there's no self-loop; a changed total is simply a real change to the parent, no different from editing its number.

## Fix

`Rollup.java.template` only:
- Persist rolled-up values with the normal **event-firing `update`** so higher-level roll-ups (and any other update listener) see the change.
- Guard both the sum and count paths with an **"only when the value actually changed"** check. This bounds the cascade — a parent whose total didn't move raises no further event — so it terminates at rest and cannot loop over the acyclic composition tree.

No DSL / glue / generator changes; existing `via` / `op: sum` roll-ups start chaining automatically. Docs: a "Transitive (chained) roll-ups" note added to the intent assistant guide.

## Verification

Generated + ran a 3-level `ProjectTimesheet` / `EmployeeTimesheet` / `EmployeeDayAllocation` model and drove it over REST:

| step | EmployeeTimesheet.Total | ProjectTimesheet.Total |
|---|---|---|
| add allocation 80 | 80 | **80** |
| add allocation +50 | 130 | **130** |

The **project** total tracks a **leaf** allocation change — exactly what the old `updateWithoutEvent` blocked. Generated listeners confirmed to use `parents.update(parent)` (0 `updateWithoutEvent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)