### PR TITLE
feat(intent): scheduled record generation - a schedule can create a record per matching row

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -85,7 +85,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> writers = buildWriters(model, settings);
         List<Map<String, Object>> setters = buildSetters(model, settings);
         List<Map<String, Object>> notifications = buildNotifications(model, byName, compositionParents, settings);
-        List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings);
+        List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
         List<Map<String, Object>> inbound = buildInbound(model, byName, compositionParents, settings);
         List<Map<String, Object>> rollups = buildRollups(model, byName, compositionParents, settings);
@@ -667,7 +667,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     }
 
     private static List<Map<String, Object>> buildSchedules(IntentModel model, Map<String, EntityIntent> byName,
-            Map<String, String> compositionParents, IntentSettings settings) {
+            Map<String, String> compositionParents, IntentSettings settings, IntentGenerationContext context) {
         List<Map<String, Object>> schedules = new ArrayList<>();
         for (ScheduleIntent schedule : model.getSchedules()) {
             if (schedule.getName() == null || schedule.getName()
@@ -675,36 +675,77 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 continue;
             }
             String entity = schedule.getEntity();
-            if (entity == null || !byName.containsKey(entity) || schedule.getNotify() == null) {
+            if (entity == null || !byName.containsKey(entity)) {
                 continue;
+            }
+            boolean generates = schedule.getGenerate() != null;
+            if (!generates && schedule.getNotify() == null) {
+                continue; // parser already reported "no notify/generate action"
             }
             if (!settings.shouldGenerate("schedules", schedule.getName())) {
                 LOGGER.info("Settings opt-out: keeping existing job for schedule [{}] (not generated)", schedule.getName());
                 continue;
             }
-            // The per-row action reuses the notification machinery against the queried row entity.
-            NotificationSupport.Plan plan = NotificationSupport.plan(schedule.getNotify(), byName.get(entity), byName, compositionParents);
-            if (plan == null) {
-                LOGGER.warn("Schedule [{}] notify recipient [{}] is not a resolvable field or relation.field of [{}] - skipping",
-                        schedule.getName(), schedule.getNotify()
-                                                    .getTo(),
-                        entity);
-                continue;
-            }
+
             Map<String, Object> entry = new LinkedHashMap<>();
             entry.put("name", schedule.getName());
-            entry.put("className", IntentNaming.pascalCase(schedule.getName()));
+            // pascalIdentifier (not pascalCase) so a hyphenated schedule name yields a valid Java class.
+            entry.put("className", IntentNaming.pascalIdentifier(schedule.getName()));
             entry.put("cron", schedule.getCron());
             entry.put("entity", entity);
             entry.put("perspective", IntentEntities.resolvePerspective(entity, compositionParents));
             entry.put("criteriaExpression", ScheduleSupport.criteriaExpression(schedule));
-            entry.put("relationLoads", relationLoads(plan));
-            entry.put("toExpression", plan.toExpression());
-            entry.put("subjectExpression", plan.subjectExpression());
-            entry.put("bodyExpression", plan.bodyExpression());
+
+            if (generates) {
+                // Scheduled record generation: the queried row is the source, so its create-from maps the
+                // loop variable (named "entity" in the job template) onto a fresh target and saves through
+                // the target's repository. Item cloning is out of scope here (see parser validation).
+                GeneratesIntent g = schedule.getGenerate();
+                g.setFrom(entity);
+                boolean crossModel = g.getUses() != null && !g.getUses()
+                                                              .isBlank();
+                UsesIntent uses = crossModel ? findUses(model, g.getUses()) : null;
+                CrossModelSupport.TargetInfo target = uses == null ? null : CrossModelSupport.resolve(context, uses, g.getTo());
+                String toPerspective =
+                        target != null ? target.perspectiveName() : IntentEntities.resolvePerspective(g.getTo(), compositionParents);
+                String toPk = target != null ? target.keyField() : IntentEntities.keyFieldName(byName.get(g.getTo()));
+                entry.put("action", "generate");
+                entry.put("genCrossModel", crossModel);
+                entry.put("genToEntity", g.getTo());
+                entry.put("genToModel", crossModel ? g.getUses() : "");
+                entry.put("genToPerspective", toPerspective);
+                entry.put("genToPk", toPk);
+                entry.put("genFieldAssignments", assignments(g.getMap(), g.getDefaults(), "entity"));
+            } else {
+                // The per-row action reuses the notification machinery against the queried row entity.
+                NotificationSupport.Plan plan =
+                        NotificationSupport.plan(schedule.getNotify(), byName.get(entity), byName, compositionParents);
+                if (plan == null) {
+                    LOGGER.warn("Schedule [{}] notify recipient [{}] is not a resolvable field or relation.field of [{}] - skipping",
+                            schedule.getName(), schedule.getNotify()
+                                                        .getTo(),
+                            entity);
+                    continue;
+                }
+                entry.put("action", "notify");
+                entry.put("relationLoads", relationLoads(plan));
+                entry.put("toExpression", plan.toExpression());
+                entry.put("subjectExpression", plan.subjectExpression());
+                entry.put("bodyExpression", plan.bodyExpression());
+            }
             schedules.add(entry);
         }
         return schedules;
+    }
+
+    /**
+     * Test hook: build the {@code schedules} glue collection without a repository (a null context makes
+     * a cross-model generate target fall back to naming-convention defaults, enough to assert the
+     * mapping and action shape).
+     */
+    static List<Map<String, Object>> buildSchedulesForTest(IntentModel model) {
+        return buildSchedules(model, IntentEntities.byName(model), IntentEntities.compositionParents(model), IntentSettings.parse("{}"),
+                null);
     }
 
     private static List<Map<String, Object>> relationLoads(NotificationSupport.Plan plan) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/ScheduleIntent.java
@@ -18,9 +18,19 @@ import java.util.List;
  *
  * <p>
  * Generates a client-Java {@code @Scheduled} {@code JobHandler} that queries {@link #entity} with a
- * typed {@code Criteria} built from {@link #where} and, for each row, performs {@link #notify}
- * (reusing the notification machinery against the row entity). The notify's {@code event}/
- * {@code channel} are unused here - the cron + {@code where} are the trigger and filter.
+ * typed {@code Criteria} built from {@link #where} and, for each matching row, performs exactly one
+ * action:
+ * <ul>
+ * <li>{@link #notify} - send a mail per row (reusing the notification machinery against the row
+ * entity); the notify's {@code event}/{@code channel} are unused here - the cron + {@code where}
+ * are the trigger and filter; or</li>
+ * <li>{@link #generate} - create a new record per row ("scheduled record generation"): map the row
+ * onto a fresh target entity and save through the target's generated repository, so its create-time
+ * logic (document numbering, status init, calculated fields) fires. The row is the source, so the
+ * reused {@link GeneratesIntent#getFrom()} is the schedule's {@link #entity}; item cloning is out
+ * of scope here (use an on-demand {@code generates} action for document-to-document cloning).</li>
+ * </ul>
+ * Exactly one of {@code notify} / {@code generate} must be set.
  */
 public class ScheduleIntent {
 
@@ -29,6 +39,7 @@ public class ScheduleIntent {
     private String entity;
     private List<ScheduleConditionIntent> where = new ArrayList<>();
     private NotificationIntent notify;
+    private GeneratesIntent generate;
 
     public String getName() {
         return name;
@@ -68,5 +79,13 @@ public class ScheduleIntent {
 
     public void setNotify(NotificationIntent notify) {
         this.notify = notify;
+    }
+
+    public GeneratesIntent getGenerate() {
+        return generate;
+    }
+
+    public void setGenerate(GeneratesIntent generate) {
+        this.generate = generate;
     }
 }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -164,7 +164,7 @@ public final class IntentParser {
         validateSeeds(model, entityNames, issues);
         validateLanguages(model, issues);
         validateNotifications(model, entityNames, issues);
-        validateSchedules(model, entityNames, issues);
+        validateSchedules(model, entityNames, usesAliases, issues);
         validateIntegrations(model, entityNames, issues);
         validateInbound(model, entityNames, issues);
         validateRollups(model, issues);
@@ -311,7 +311,13 @@ public final class IntentParser {
      * Each schedule must have a unique name, a cron expression, an entity to query, supported
      * {@code where} operators, and a notify action with a valid recipient.
      */
-    private static void validateSchedules(IntentModel model, Set<String> entityNames, List<String> issues) {
+    private static void validateSchedules(IntentModel model, Set<String> entityNames, Set<String> usesAliases, List<String> issues) {
+        Map<String, EntityIntent> byName = new HashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() != null) {
+                byName.put(entity.getName(), entity);
+            }
+        }
         Set<String> names = new HashSet<>();
         for (ScheduleIntent schedule : model.getSchedules()) {
             String name = schedule.getName();
@@ -326,8 +332,11 @@ public final class IntentParser {
                                                       .isBlank()) {
                 issues.add("schedule [" + name + "] has no cron expression");
             }
+            EntityIntent source = null;
             if (schedule.getEntity() == null || !entityNames.contains(schedule.getEntity())) {
                 issues.add("schedule [" + name + "] queries unknown entity [" + schedule.getEntity() + "]");
+            } else {
+                source = byName.get(schedule.getEntity());
             }
             for (ScheduleConditionIntent condition : schedule.getWhere()) {
                 if (condition.getField() == null || condition.getField()
@@ -339,9 +348,14 @@ public final class IntentParser {
                             + "] (supported: eq/ne/gt/ge/lt/le/like)");
                 }
             }
-            if (schedule.getNotify() == null) {
-                issues.add("schedule [" + name + "] has no notify action");
-            } else {
+            // A schedule performs exactly one per-row action: notify (mail) or generate (create-from).
+            boolean hasNotify = schedule.getNotify() != null;
+            boolean hasGenerate = schedule.getGenerate() != null;
+            if (hasNotify && hasGenerate) {
+                issues.add("schedule [" + name + "] has both notify and generate - a schedule performs exactly one per-row action");
+            } else if (!hasNotify && !hasGenerate) {
+                issues.add("schedule [" + name + "] has no action (add a notify or a generate)");
+            } else if (hasNotify) {
                 String to = schedule.getNotify()
                                     .getTo();
                 if (to == null || to.isBlank()) {
@@ -351,7 +365,44 @@ public final class IntentParser {
                                                   .count() >= 2) {
                     issues.add("schedule [" + name + "] notify recipient [" + to + "] uses a multi-hop path, which is not supported");
                 }
+            } else {
+                validateScheduleGenerate(schedule, source, entityNames, usesAliases, issues);
             }
+        }
+    }
+
+    /**
+     * A schedule's {@code generate} action creates one target record per matching row. The row is the
+     * source, so {@code from} is implicit (the schedule's {@code entity}); the author declares
+     * {@code to} (this model, or another via {@code uses:}), a {@code map} (target property -> a field
+     * or to-one relation of the row) and {@code defaults}. Composition-item cloning is out of scope
+     * here - it needs a selected document, so it belongs to an on-demand {@code generates} action.
+     */
+    private static void validateScheduleGenerate(ScheduleIntent schedule, EntityIntent source, Set<String> entityNames,
+            Set<String> usesAliases, List<String> issues) {
+        String name = schedule.getName();
+        GeneratesIntent g = schedule.getGenerate();
+        if (g.getTo() == null || g.getTo()
+                                  .isBlank()) {
+            issues.add("schedule [" + name + "] generate has no to entity");
+        }
+        boolean crossModel = g.getUses() != null && !g.getUses()
+                                                      .isBlank();
+        if (crossModel) {
+            if (!usesAliases.contains(g.getUses())) {
+                issues.add("schedule [" + name + "] generate uses unknown model alias [" + g.getUses()
+                        + "] (declare it under the model's uses:)");
+            }
+        } else if (g.getTo() != null && !g.getTo()
+                                          .isBlank()
+                && !entityNames.contains(g.getTo())) {
+            issues.add("schedule [" + name + "] generate to references unknown entity [" + g.getTo()
+                    + "] (add a uses: alias if the target lives in another model)");
+        }
+        validateMapSource(source, g.getMap(), "schedule [" + name + "]", "generate map", issues);
+        if (g.getItems() != null) {
+            issues.add("schedule [" + name + "] generate declares items - item cloning is not supported for a scheduled generation;"
+                    + " use an on-demand generates action for document-to-document cloning");
         }
     }
 
@@ -1221,7 +1272,7 @@ public final class IntentParser {
             if (!"entity".equals(scope) && !"page".equals(scope)) {
                 issues.add("generates [" + name + "] has invalid scope [" + scope + "] (expected 'entity' or 'page')");
             }
-            validateMapSource(source, g.getMap(), name, "map", issues);
+            validateMapSource(source, g.getMap(), "generates [" + name + "]", "map", issues);
             if (g.getItems() != null) {
                 GeneratesItemsIntent items = g.getItems();
                 EntityIntent itemSource = null;
@@ -1237,7 +1288,7 @@ public final class IntentParser {
                                                   .isBlank()) {
                     issues.add("generates [" + name + "] items has no to entity");
                 }
-                validateMapSource(itemSource, items.getMap(), name, "items map", issues);
+                validateMapSource(itemSource, items.getMap(), "generates [" + name + "]", "items map", issues);
             }
         }
     }
@@ -1247,24 +1298,24 @@ public final class IntentParser {
      * {@code relation.field} path is rejected (not yet supported). Skipped when the source is unknown -
      * that error is already reported.
      */
-    private static void validateMapSource(EntityIntent source, Map<String, String> map, String name, String role, List<String> issues) {
+    private static void validateMapSource(EntityIntent source, Map<String, String> map, String subject, String role, List<String> issues) {
         if (source == null || map == null) {
             return;
         }
         for (Map.Entry<String, String> entry : map.entrySet()) {
             String sourceProp = entry.getValue();
             if (sourceProp == null || sourceProp.isBlank()) {
-                issues.add("generates [" + name + "] " + role + " [" + entry.getKey() + "] has no source property");
+                issues.add(subject + " " + role + " [" + entry.getKey() + "] has no source property");
                 continue;
             }
             if (sourceProp.indexOf('.') >= 0) {
-                issues.add("generates [" + name + "] " + role + " [" + entry.getKey() + "] maps a relation.field path [" + sourceProp
+                issues.add(subject + " " + role + " [" + entry.getKey() + "] maps a relation.field path [" + sourceProp
                         + "] which is not yet supported - map a direct field or to-one relation of [" + source.getName() + "]");
                 continue;
             }
             if (fieldByName(source, sourceProp) == null && toOneRelationByName(source, sourceProp) == null) {
-                issues.add("generates [" + name + "] " + role + " source [" + sourceProp + "] is not a field or to-one relation of ["
-                        + source.getName() + "]");
+                issues.add(subject + " " + role + " source [" + sourceProp + "] is not a field or to-one relation of [" + source.getName()
+                        + "]");
             }
         }
     }

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -665,10 +665,12 @@ notifications:
 **Rules:** exactly one event referencing a declared entity; `channel` is `email`; `to` follows the
 recipient rule (literal / field / one-hop `relation.field`).
 
-### schedules - run on a cron and notify
+### schedules - run on a cron and notify or generate records
 
-**Use when:** something must run **on a schedule** (cron), find records matching conditions, and
-notify about them (e.g. "every morning, email members with overdue loans").
+**Use when:** something must run **on a schedule** (cron), find records matching conditions, and, per
+matching row, perform **exactly one** per-row action: `notify` (email) or `generate` (create a record).
+
+**notify** - e.g. "every morning, email members with overdue loans":
 
 ```yaml
 schedules:
@@ -684,8 +686,32 @@ schedules:
       body: "Your loan is overdue, please return the book."
 ```
 
-**Rules:** unique name, a `cron`, a declared `entity`, `where` operators from the allowed list, and a
-`notify` block with a valid recipient.
+**generate** (scheduled record generation) - e.g. "on the 1st of every month, create an
+EmployeeTimesheet for each active employee". Per matching row, a new target record is created and
+saved through the target's generated repository, so its create-time logic (document numbering, status
+init, calculated fields) fires. The **row is the source**, so `from` is implicit (the schedule's
+`entity`); `map` copies a field or to-one relation of the row onto a target property, `defaults` sets
+`now` or a literal. The target may live in another model via `uses:` (same as `generates`).
+
+```yaml
+schedules:
+  - name: monthlyTimesheets
+    cron: "0 0 1 1 * ?"                  # Spring cron: 00:00 on day 1 of every month
+    entity: Employee
+    where:
+      - { field: status, op: eq, value: ACTIVE }
+    generate:
+      to: EmployeeTimesheet             # add `uses: <alias>` if the target is in another model
+      map:
+        Employee: id                    # target.Employee = the employee row's id (FK back-reference)
+      defaults:
+        Period: now
+```
+
+**Rules:** unique name, a `cron`, a declared `entity`, `where` operators from the allowed list, and
+**exactly one** of `notify` (valid recipient) / `generate` (a declared/cross-model `to`, a `map` over
+the row's fields/to-one relations). Composition-item cloning is **not** available on a schedule (it
+needs a selected document) - use an on-demand `generates` action for document-to-document cloning.
 
 ### integrations - outbound HTTP on a data change
 
@@ -813,12 +839,13 @@ payment's unallocated balance; entity writes go only through the generated repos
 - "approval / multi-step / workflow" -> **processes** (+ a **form** for each user task)
 - "a screen to enter / edit X" -> **forms**
 - "a button on X's view that opens a custom page / action" -> **actions**
-- "create a Y from an X / generate an invoice from a timesheet / turn a quote into an order" -> **generates**
+- "create a Y from an X / generate an invoice from a timesheet / turn a quote into an order" (on a button, per selected record) -> **generates**
 - "a list / dashboard / count of X by Y" -> **reports**
 - "who can do what" -> **permissions**
 - "preload these values" -> **seeds**
 - "email someone when X is created/updated/deleted" -> **notifications**
-- "every day/hour, check X and notify" -> **schedules**
+- "every day/hour, check X and notify" -> **schedules** (`notify`)
+- "on a schedule / every month, create a Y for each X / recurring invoices / auto-generate timesheets" -> **schedules** (`generate`)
 - "call an external API when X changes" -> **integrations**
 - "let an external system create X" -> **inbound**
 - "keep a running count of children on the parent" -> **rollups**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code schedules} entries the {@link GlueIntentGenerator} emits for the two per-row
+ * actions: a {@code generate} schedule (scheduled record generation) carries the create-from target
+ * and the pre-rendered field assignments against the loop row ({@code entity.<Prop>}); a
+ * {@code notify} schedule keeps the mail plan. The hyphenated schedule name becomes a valid Java
+ * class identifier.
+ */
+class GlueSchedulesTest {
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void generateScheduleEmitsCreateFromTargetAndRowAssignments() {
+        String yaml = """
+                name: hr
+                entities:
+                  - name: Employee
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                      - { name: status, type: string }
+                  - name: EmployeeTimesheet
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: period, type: date }
+                    relations:
+                      - { name: Employee, kind: manyToOne, to: Employee }
+                schedules:
+                  - name: monthly-timesheets
+                    cron: "0 0 1 1 * ?"
+                    entity: Employee
+                    where:
+                      - { field: status, op: eq, value: ACTIVE }
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                      defaults:
+                        Period: now
+                """;
+        IntentModel model = IntentParser.parse(yaml);
+        List<Map<String, Object>> schedules = GlueIntentGenerator.buildSchedulesForTest(model);
+        assertEquals(1, schedules.size());
+        Map<String, Object> s = schedules.get(0);
+
+        assertEquals("generate", s.get("action"));
+        // pascalIdentifier keeps a hyphenated name a legal Java class.
+        assertEquals("MonthlyTimesheets", s.get("className"));
+        assertEquals("Employee", s.get("entity"));
+        assertEquals("EmployeeTimesheet", s.get("genToEntity"));
+        assertEquals(false, s.get("genCrossModel"));
+        assertTrue(((String) s.get("criteriaExpression")).contains(".eq(\"Status\", \"ACTIVE\")"),
+                "criteria: " + s.get("criteriaExpression"));
+
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) s.get("genFieldAssignments");
+        // The loop variable in the job template is "entity"; map copies the row, defaults render
+        // now/literal.
+        assertTrue(fields.contains(Map.of("targetProp", "Employee", "expr", "entity.Id")), "fields: " + fields);
+        assertTrue(fields.contains(Map.of("targetProp", "Period", "expr", "java.time.LocalDate.now()")), "fields: " + fields);
+    }
+
+    @Test
+    void generateScheduleResolvesCrossModelTarget() {
+        String yaml = """
+                name: hr
+                uses:
+                  - { model: billing }
+                entities:
+                  - name: Subscription
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: status, type: string }
+                schedules:
+                  - name: recurring-invoices
+                    cron: "0 0 1 1 * ?"
+                    entity: Subscription
+                    generate:
+                      to: SalesInvoice
+                      uses: billing
+                      map:
+                        Subscription: id
+                """;
+        IntentModel model = IntentParser.parse(yaml);
+        Map<String, Object> s = GlueIntentGenerator.buildSchedulesForTest(model)
+                                                   .get(0);
+        assertEquals("generate", s.get("action"));
+        assertEquals(true, s.get("genCrossModel"));
+        assertEquals("billing", s.get("genToModel"));
+        // With no repository, the cross-model perspective falls back to the entity name (convention).
+        assertEquals("SalesInvoice", s.get("genToPerspective"));
+    }
+
+    @Test
+    void notifyScheduleStillEmitsMailPlan() {
+        String yaml = """
+                name: hr
+                entities:
+                  - name: Invoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: dueOn, type: date }
+                      - { name: contactEmail, type: string }
+                schedules:
+                  - name: overdue-reminders
+                    cron: "0 0 8 * * ?"
+                    entity: Invoice
+                    where:
+                      - { field: dueOn, op: lt, value: CURRENT_DATE }
+                    notify:
+                      to: contactEmail
+                      subject: "Overdue"
+                      body: "Your invoice is overdue"
+                """;
+        IntentModel model = IntentParser.parse(yaml);
+        Map<String, Object> s = GlueIntentGenerator.buildSchedulesForTest(model)
+                                                   .get(0);
+        assertEquals("notify", s.get("action"));
+        assertEquals("OverdueReminders", s.get("className"));
+        assertTrue(s.containsKey("toExpression"));
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -564,4 +564,110 @@ class IntentParserTest {
                      .anyMatch(i -> i.contains("has unknown kind [chart]")),
                 "expected an unknown-kind issue, got: " + ex.getIssues());
     }
+
+    private static final String SCHEDULE_GEN_HEAD = """
+            name: hr
+            entities:
+              - name: Employee
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: status, type: string }
+              - name: EmployeeTimesheet
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                relations:
+                  - { name: Employee, kind: manyToOne, to: Employee }
+            schedules:
+              - name: monthly-timesheets
+                cron: "0 0 1 1 * ?"
+                entity: Employee
+            """;
+
+    @Test
+    void scheduleGenerateParsesWithoutIssues() {
+        String yaml = SCHEDULE_GEN_HEAD + """
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                """;
+        // A well-formed scheduled generation validates cleanly (no exception).
+        IntentParser.parse(yaml);
+    }
+
+    @Test
+    void scheduleWithBothNotifyAndGenerateIsRejected() {
+        String yaml = SCHEDULE_GEN_HEAD + """
+                    notify:
+                      to: status
+                      subject: "x"
+                      body: "y"
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("has both notify and generate")),
+                "expected a both-actions issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void scheduleWithNoActionIsRejected() {
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(SCHEDULE_GEN_HEAD));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("has no action")),
+                "expected a no-action issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void scheduleGenerateWithUnknownTargetIsRejected() {
+        String yaml = SCHEDULE_GEN_HEAD + """
+                    generate:
+                      to: Nonexistent
+                      map:
+                        Employee: id
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("generate to references unknown entity [Nonexistent]")),
+                "expected an unknown-target issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void scheduleGenerateWithItemsIsRejected() {
+        String yaml = SCHEDULE_GEN_HEAD + """
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                      items:
+                        from: Employee
+                        to: EmployeeTimesheet
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("item cloning is not supported for a scheduled generation")),
+                "expected an items-not-supported issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void scheduleGenerateWithBadMapSourceIsRejected() {
+        String yaml = SCHEDULE_GEN_HEAD + """
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: nonexistentField
+                """;
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(yaml));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("generate map source [nonexistentField] is not a field or to-one relation of [Employee]")),
+                "expected a bad-map-source issue, got: " + ex.getIssues());
+    }
 }

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Job.java.template
@@ -1,14 +1,18 @@
 package gen.events;
 
-import java.util.HashMap;
 import java.util.List;
+#if($action != "generate")
+import java.util.HashMap;
 import java.util.Map;
+#end
 
 import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
 import org.eclipse.dirigible.sdk.component.Component;
+#if($action != "generate")
 import org.eclipse.dirigible.sdk.core.Configurations;
-import org.eclipse.dirigible.sdk.job.JobHandler;
 import org.eclipse.dirigible.sdk.mail.Mail;
+#end
+import org.eclipse.dirigible.sdk.job.JobHandler;
 
 import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Entity;
 import gen.${javaGenFolderName}.data.${javaPerspective}.${entity}Repository;
@@ -18,10 +22,13 @@ import gen.${javaGenFolderName}.data.${load.javaTargetPerspective}.${load.target
 #end
 
 /**
- * Runs the ${name} schedule: on each cron tick, query ${entity} and notify per matching row.
+ * Runs the ${name} schedule: on each cron tick, query ${entity} and, per matching row, either notify
+ * (mail) or generate a target record (create-from, saved through the target's generated repository so
+ * its numbering / status init / calculated fields fire).
  *
  * Generated from the intent schedules block - do not edit; it is re-generated with the application.
- * The sender address comes from the DIRIGIBLE_MAIL_SENDER configuration.
+ * Entity access goes ONLY through the generated repositories. The mail sender comes from the
+ * DIRIGIBLE_MAIL_SENDER configuration.
  */
 @Component
 public class ${className}Job implements JobHandler {
@@ -35,6 +42,14 @@ public class ${className}Job implements JobHandler {
     public void run() {
         List<${entity}Entity> rows = new ${entity}Repository().findAll(${criteriaExpression});
         for (${entity}Entity entity : rows) {
+#if($action == "generate")
+            gen.${genToGenFolder}.data.${genToJavaPerspective}.${genToEntity}Entity target =
+                    new gen.${genToGenFolder}.data.${genToJavaPerspective}.${genToEntity}Entity();
+#foreach($a in $genFieldAssignments)
+            target.${a.targetProp} = ${a.expr};
+#end
+            new gen.${genToGenFolder}.data.${genToJavaPerspective}.${genToEntity}Repository().save(target);
+#else
 #foreach($load in $relationLoads)
             ${load.targetEntity}Entity ${load.local} = entity.${load.fkProperty} == null ? null : new ${load.targetEntity}Repository().findById(entity.${load.fkProperty});
 #end
@@ -54,6 +69,7 @@ public class ${className}Job implements JobHandler {
             } catch (Exception ex) {
                 throw new RuntimeException("Failed to send schedule ${name}", ex);
             }
+#end
         }
     }
 }

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -541,25 +541,38 @@ export function generateFiles(model, parameters, templateSources) {
                     break;
                 case "schedules":
                     // Schedules (intent layer): one @Scheduled JobHandler per schedule - query the entity
-                    // via a typed Criteria and notify per matching row. Not entity-shaped, own loop.
+                    // via a typed Criteria and, per matching row, either notify (mail) or generate a
+                    // target record (create-from). Not entity-shaped, own loop. The generate branch's
+                    // target gen folder / perspective are lowercased (sanitized) like the create-from
+                    // controller; the field assignment expressions are pre-rendered by the glue generator.
                     if (model.schedules) {
                         for (let s = 0; s < model.schedules.length; s++) {
+                            const sc = model.schedules[s];
+                            const isGenerate = sc.action === "generate";
                             const scheduleParameters = {
                                 ...parameters,
-                                name: model.schedules[s].name,
-                                className: model.schedules[s].className,
-                                cron: model.schedules[s].cron,
-                                entity: model.schedules[s].entity,
-                                perspective: model.schedules[s].perspective,
-                                javaPerspective: sanitizeJavaIdentifier(model.schedules[s].perspective),
-                                criteriaExpression: model.schedules[s].criteriaExpression,
-                                relationLoads: (model.schedules[s].relationLoads || []).map(load => ({
+                                name: sc.name,
+                                className: sc.className,
+                                cron: sc.cron,
+                                entity: sc.entity,
+                                perspective: sc.perspective,
+                                javaPerspective: sanitizeJavaIdentifier(sc.perspective),
+                                criteriaExpression: sc.criteriaExpression,
+                                action: sc.action || "notify",
+                                relationLoads: (sc.relationLoads || []).map(load => ({
                                     ...load,
                                     javaTargetPerspective: sanitizeJavaIdentifier(load.targetPerspective)
                                 })),
-                                toExpression: model.schedules[s].toExpression,
-                                subjectExpression: model.schedules[s].subjectExpression,
-                                bodyExpression: model.schedules[s].bodyExpression
+                                toExpression: sc.toExpression,
+                                subjectExpression: sc.subjectExpression,
+                                bodyExpression: sc.bodyExpression,
+                                genToEntity: sc.genToEntity,
+                                genToPk: sc.genToPk,
+                                genFieldAssignments: sc.genFieldAssignments,
+                                genToGenFolder: isGenerate
+                                    ? (sc.genCrossModel ? sanitizeJavaIdentifier(sc.genToModel) : parameters.javaGenFolderName)
+                                    : "",
+                                genToJavaPerspective: isGenerate ? sanitizeJavaIdentifier(sc.genToPerspective) : ""
                             };
                             const cleanScheduleParameters = cleanData(scheduleParameters);
                             generatedFiles.push({

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -676,6 +676,60 @@ class IntentEngineIT extends IntegrationTest {
     }
 
     @Test
+    void scheduled_generation_emits_a_create_from_job_not_a_mail_notification() {
+        // A schedule with a `generate` action (scheduled record generation) runs the create-from mapping
+        // per matching row on the cron tick: it builds a fresh target through the target's repository (so
+        // numbering / status init / calculated fields fire), rather than sending mail. The queried row is
+        // the source, so map/defaults render against the job's loop variable "entity".
+        String yaml = """
+                name: hr
+                entities:
+                  - name: Employee
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: name,   type: string }
+                      - { name: status, type: string }
+                  - name: EmployeeTimesheet
+                    fields:
+                      - { name: id,     type: integer, primaryKey: true, generated: true }
+                      - { name: period, type: date }
+                    relations:
+                      - { name: Employee, kind: manyToOne, to: Employee }
+                schedules:
+                  - name: monthly-timesheets
+                    cron: "0 0 1 1 * ?"
+                    entity: Employee
+                    where:
+                      - { field: status, op: eq, value: ACTIVE }
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                      defaults:
+                        Period: now
+                """;
+        writeIntent(yaml);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        generateFromModel("template-application-events-java/template/template.js", "hr.glue");
+
+        String job = contentOf("gen/events/MonthlyTimesheetsJob.java");
+        assertTrue(job.contains("class MonthlyTimesheetsJob implements JobHandler"),
+                "a hyphenated schedule name should still yield a valid Java class (pascalIdentifier)");
+        assertTrue(job.contains("new EmployeeRepository().findAll("), "the job should query the source rows");
+        assertTrue(job.contains(".eq(\"Status\", \"ACTIVE\")"), "the where filter should render as a typed criteria");
+        assertTrue(job.contains("for (EmployeeEntity entity : rows)"), "the job should loop the matching rows");
+        assertTrue(job.contains(".EmployeeTimesheetEntity target ="), "the job should build a fresh target per row");
+        assertTrue(job.contains("target.Employee = entity.Id;"), "map copies the row's field onto the target property");
+        assertTrue(job.contains("target.Period = java.time.LocalDate.now();"), "a `now` default renders as today's date");
+        assertTrue(job.contains(".EmployeeTimesheetRepository().save(target);"),
+                "the target is saved through its generated repository so create-time logic fires");
+        assertFalse(job.contains("Mail.send"), "a generate schedule must not emit the notify (mail) path");
+    }
+
+    @Test
     void process_trigger_on_update_with_a_guard_generates_a_suffixed_guarded_listener() {
         String yaml = """
                 name: shipping


### PR DESCRIPTION
## What

The next capability in the intent series (**P6**). A `schedules:` block already runs a `@Scheduled` `JobHandler` that queries an entity by a typed `Criteria` and **notifies** per matching row. This adds a second per-row action, **`generate`**, that **creates a target record per row** - recurring invoices, monthly timesheets, period-open documents - by reusing the create-from mapping of `generates`.

The queried row is the source, so `from` is implicit (the schedule's `entity`). A schedule performs **exactly one** action: `notify` or `generate`.

```yaml
schedules:
  - name: monthlyTimesheets
    cron: "0 0 1 1 * ?"                 # 00:00 on day 1 of every month
    entity: Employee
    where:
      - { field: status, op: eq, value: ACTIVE }
    generate:
      to: EmployeeTimesheet             # add `uses: <alias>` for a cross-model target
      map:
        Employee: id                    # target.Employee = the row's id
      defaults:
        Period: now
```

## How

- **`ScheduleIntent`** gains an optional `generate` (reuses `GeneratesIntent`; `from` is set to the schedule's `entity`).
- **`GlueIntentGenerator.buildSchedules`** branches on the action, tags the glue entry with `action`, resolves the create-from target (cross-model aware), and pre-renders the field assignments against the job's loop variable (`entity`) via the shared `assignments()` helper. `className` now uses `pascalIdentifier` so a hyphenated schedule name yields a valid Java class.
- **`generateUtils.js`** passes `action` + the target java gen-folder / perspective / field assignments through to the template.
- **`Job.java.template`** branches: a generate schedule builds a fresh target per row and saves through the target's generated repository (so numbering / status init / calculated fields fire); the notify (mail) path is unchanged. Notify-only imports are guarded so a generate job carries no unused `Mail` import.
- **`IntentParser`**: exactly-one-of `notify`/`generate`; validates the target (declared or `uses:` alias) and the `map` over the row's fields/to-one relations; rejects `items` (composition-item cloning needs a selected document - use an on-demand `generates` action).
- **Docs**: `intent-assistant-guide` schedules section + request-mapping heuristics.

## Tests

- `GlueSchedulesTest` - the generate / notify / cross-model glue entry shape and the pre-rendered `entity.<Prop>` assignments.
- `IntentParserTest` - exactly-one-of, unknown target, `items` rejection, bad map source, and a clean parse.
- `IntentEngineIT#scheduled_generation_emits_a_create_from_job_not_a_mail_notification` - end-to-end: generates `MonthlyTimesheetsJob.java` and asserts the create-from loop (target build, row-field map, `now` default, repository save, typed criteria) with **no** mail path. Verified green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)