### PR TITLE
feat(intent): capacity guard on balance roll-ups (reject over-capacity child writes)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -33,6 +33,7 @@ import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
+import org.eclipse.dirigible.components.intent.model.RollupIntent;
 import org.eclipse.dirigible.components.intent.model.UsesIntent;
 import org.eclipse.dirigible.components.intent.parser.IntentValidationException;
 import org.slf4j.Logger;
@@ -152,6 +153,11 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         // "Item" (SalesInvoice -> SalesInvoiceItem) renders as a document - header form, inline items
         // table, totals footer - rather than the default master-detail. Maps master -> its items entity.
         Map<String, String> documentItems = documentMasters(entities, compositionParents);
+        // Capacity guard: a child of a capacity-bearing (balance-pattern) roll-up rejects a create/update
+        // that would drive the parent's balance negative. Stamp the guard metadata onto the child so its
+        // generated DAO enforces it synchronously (the DAO is generated from this .model, which otherwise
+        // does not see the roll-ups - those live in the .glue).
+        Map<String, Map<String, Object>> rollupGuards = buildRollupGuards(model, byName, compositionParents);
         int perspectiveOrder = 1;
 
         for (EntityIntent entity : entities) {
@@ -171,6 +177,9 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             // application shell (the standalone shell is unaffected). Defaults to empty (top-level).
             if (notBlank(entity.getGroup())) {
                 entityMap.put("perspectiveNavId", entity.getGroup());
+            }
+            if (rollupGuards.containsKey(name)) {
+                entityMap.put("rollupGuard", rollupGuards.get(name));
             }
             // A document master keeps its own perspective/nav but swaps the master-detail layout for the
             // document layout; it names its line-items entity so the document page renders that child as
@@ -347,6 +356,40 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * The perspective an entity (or relation target) lives under: the global {@code Settings}
      * perspective for a setting entity, otherwise its composition-resolved perspective.
      */
+    /**
+     * Build the capacity-guard metadata per child entity from the model's roll-ups. A guard applies to
+     * a child of a capacity-bearing sum roll-up (one carrying {@code capacity} + {@code of}); it
+     * rejects a create/update that would push the parent's balance below zero. Keyed by child entity
+     * name; the DAO template ({@code #rollupGuardCheck}) reads {@code rollupGuard} off the entity.
+     */
+    private static Map<String, Map<String, Object>> buildRollupGuards(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents) {
+        Map<String, Map<String, Object>> guards = new HashMap<>();
+        for (RollupIntent rollup : model.getRollups()) {
+            if (!"sum".equals(rollup.getOp()) || rollup.getCapacity() == null || rollup.getCapacity()
+                                                                                       .isBlank()
+                    || rollup.getOf() == null || rollup.getOf()
+                                                       .isBlank()) {
+                continue;
+            }
+            EntityIntent child = byName.get(rollup.getEntity());
+            RelationIntent via = child == null ? null : toOneRelationByName(child, rollup.getVia());
+            EntityIntent parent = via == null ? null : byName.get(via.getTo());
+            if (parent == null || guards.containsKey(rollup.getEntity())) {
+                continue;
+            }
+            Map<String, Object> guard = new LinkedHashMap<>();
+            guard.put("parentEntity", parent.getName());
+            guard.put("parentPerspective", resolvePerspective(parent.getName(), compositionParents));
+            guard.put("fkProperty", IntentNaming.pascalCase(rollup.getVia()));
+            guard.put("capacityField", IntentNaming.pascalCase(rollup.getCapacity()));
+            guard.put("ofField", IntentNaming.pascalCase(rollup.getOf()));
+            guard.put("childIdField", "Id");
+            guards.put(rollup.getEntity(), guard);
+        }
+        return guards;
+    }
+
     private static String perspectiveFor(String entityName, Map<String, String> compositionParents, Set<String> settingEntities) {
         if (settingEntities.contains(entityName)) {
             return SETTINGS_PERSPECTIVE;

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -42,6 +42,33 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
 #macro(actionAssign $property $action)
         entity.${property.name} = Beans.get(${action}.class).calculate(entity);
 #end
+## Capacity guard: reject a create/update that would drive the parent's balance negative. Derived from a
+## capacity-bearing roll-up (child -> parent via FK; parent.capacity vs sum of the children's `of` field).
+## Recomputed synchronously from the store (not the async-maintained balance field), excluding this row.
+#macro(rollupGuardCheck)
+#if($rollupGuard)
+        if (entity.${rollupGuard.fkProperty} != null) {
+            ${rollupGuard.parentEntity}Entity guardParent = new ${rollupGuard.parentEntity}Repository().findById(entity.${rollupGuard.fkProperty});
+            if (guardParent != null && guardParent.${rollupGuard.capacityField} != null) {
+                java.math.BigDecimal guardConsumed = java.math.BigDecimal.ZERO;
+                for (${name}Entity guardRow : findAll(Criteria.create().eq("${rollupGuard.fkProperty}", entity.${rollupGuard.fkProperty}))) {
+                    if (entity.${rollupGuard.childIdField} != null && entity.${rollupGuard.childIdField}.equals(guardRow.${rollupGuard.childIdField})) {
+                        continue;
+                    }
+                    if (guardRow.${rollupGuard.ofField} != null) {
+                        guardConsumed = guardConsumed.add(guardRow.${rollupGuard.ofField});
+                    }
+                }
+                java.math.BigDecimal guardIncoming = entity.${rollupGuard.ofField} == null ? java.math.BigDecimal.ZERO : entity.${rollupGuard.ofField};
+                if (guardConsumed.add(guardIncoming).compareTo(guardParent.${rollupGuard.capacityField}) > 0) {
+                    throw new IllegalStateException("${rollupGuard.parentEntity} capacity exceeded (id " + entity.${rollupGuard.fkProperty}
+                            + "): capacity " + guardParent.${rollupGuard.capacityField} + ", already consumed " + guardConsumed
+                            + ", requested " + guardIncoming);
+                }
+            }
+        }
+#end
+#end
 import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
 import org.eclipse.dirigible.sdk.component.Repository;
 import org.eclipse.dirigible.sdk.messaging.Producer;
@@ -67,6 +94,13 @@ import java.math.BigDecimal;
 import gen.${javaGenFolderName}.data.${documentMaster.javaChildPerspective}.${documentMaster.childEntity}Entity;
 import gen.${javaGenFolderName}.data.${documentMaster.javaChildPerspective}.${documentMaster.childEntity}Repository;
 #end
+#if($rollupGuard)
+#if(!$documentMaster && $multilingual != "true")
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
+#end
+import gen.${javaGenFolderName}.data.${rollupGuard.parentPerspective}.${rollupGuard.parentEntity}Entity;
+import gen.${javaGenFolderName}.data.${rollupGuard.parentPerspective}.${rollupGuard.parentEntity}Repository;
+#end
 #if($documentItem)
 import gen.${javaGenFolderName}.data.${documentItem.javaParentPerspective}.${documentItem.parentEntity}Repository;
 #end
@@ -84,6 +118,7 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 
     @Override
     public ${name}Entity save(${name}Entity entity) {
+#rollupGuardCheck()
 #if($haveCalculatedPropertyOnCreate)
 #foreach ($property in $properties)
 #if($property.isCalculatedProperty && $property.calculatedActionOnCreate)
@@ -108,6 +143,7 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 
     @Override
     public ${name}Entity update(${name}Entity entity) {
+#rollupGuardCheck()
 #if($haveCalculatedPropertyOnUpdate)
 #foreach ($property in $properties)
 #if($property.isCalculatedProperty && $property.calculatedActionOnUpdate)

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -209,6 +209,7 @@ export function generateFiles(model, parameters, templateSources) {
     const apiModels = model.entities.filter(e => e.type !== "PROJECTION");
     const daoModels = model.entities.filter(e => e.type !== "PROJECTION");
     annotateDocumentModels(model.entities);
+    annotateGuardedRollups(model.entities);
     // A human-readable singular label for every entity. The intent generator (EdmIntentGenerator)
     // bakes `entityLabel`; a hand-authored .edm carries none, so derive it the same way the i18n
     // catalog does. Without this the templates' `${entityLabel}` fallback renders literally (e.g. the
@@ -965,6 +966,19 @@ function getGenerationEngine(template) {
  * package, the FK column, the master PK, and the aggregate fields the child also carries by name; the
  * child gets `documentItem` = its parent entity, package and FK. The DAO template reads these.
  */
+// Capacity guard: EdmIntentGenerator stamps `rollupGuard` (parent/FK/capacity/of) onto a child of a
+// capacity-bearing (balance-pattern) roll-up. The child's parent perspective arrives as the raw
+// perspective name; sanitize it to the Java data-folder segment the DAO template imports from
+// (gen.<genFolder>.data.<parentPerspective>.<parentEntity>). Repository.java.template's #rollupGuardCheck
+// reads it and rejects a create/update that would drive the parent's balance negative.
+function annotateGuardedRollups(entities) {
+    for (const e of entities) {
+        if (e.rollupGuard && e.rollupGuard.parentPerspective) {
+            e.rollupGuard.parentPerspective = sanitizeJavaIdentifier(e.rollupGuard.parentPerspective);
+        }
+    }
+}
+
 function annotateDocumentModels(entities) {
     const byName = {};
     for (const e of entities) {


### PR DESCRIPTION
## What

Add an opt-in-by-shape **capacity guard** to balance roll-ups: a capacity-bearing sum roll-up (one that declares `capacity` + `of`, i.e. the sales-order balance pattern) now makes its **child** reject a create/update that would drive the parent's balance **negative** — synchronously, at the data layer, independent of any workflow.

Today a balance roll-up (`SalesInvoice.paid/balance/Status`, a vacation entitlement's consumed/balance/EXHAUSTED, …) tracks the balance but nothing *prevents* over-allocation beyond `capacity`; only bespoke workflow logic can. This makes "never exceed the declared capacity" a property of the model.

## How

- **`EdmIntentGenerator`** — for each entity that is the child of a capacity roll-up, stamp `rollupGuard` (parent entity/perspective, FK, capacity field, `of` field) onto the child's `.model`. The DAO is generated from the `.model`, which otherwise does not see the roll-ups (those live in the `.glue`), so the metadata has to travel on the entity — mirroring how `documentItemsEntity` already does.
- **`Repository.java.template`** — `save()` and `update()` run a `#rollupGuardCheck`: load the parent, sum the siblings' `of` field (excluding this row) plus the incoming value, and throw if it exceeds the parent's capacity. Recomputed from the store, so it does not depend on the async-maintained balance field.
- **`generateUtils.js`** — sanitizes the parent perspective to the Java data-folder segment the DAO imports from.

Pure additions (guarded by `#if($rollupGuard)`), so roll-ups without `capacity` are unaffected; existing modules regenerate byte-identically unless they carry a capacity roll-up.

## Verification

On a capacity-2 entitlement with day-items summed by a capacity roll-up:
- create a 3-unit child (0 + 3 > 2) → **rejected**
- create a 2-unit child (0 + 2 = 2) → **accepted**
- create a 1-unit child (2 + 1 > 2) → **rejected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
