### PR TITLE
test(intent): fix stale rollup body assertions after handler coalescing (#6187 follow-up)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -517,9 +517,8 @@ class IntentEngineIT extends IntegrationTest {
         String rollupCreate = contentOf("gen/events/OrderCustomerRollupOnCreate.java");
         assertTrue(
                 rollupCreate.contains("@Component") && rollupCreate.contains("return \"intent-test-Order-Order\"")
-                        && rollupCreate.contains(
-                                "new OrderRepository().findAll(Criteria.create().eq(\"Customer\", entity.Customer)).size()")
-                        && rollupCreate.contains("parent.OrderCount = count"),
+                        && rollupCreate.contains("new OrderRepository().findAll(Criteria.create().eq(\"Customer\", entity.Customer))")
+                        && rollupCreate.contains("int count = rows.size();") && rollupCreate.contains("parent.OrderCount = count"),
                 "the rollup create-listener should recompute the parent count via Criteria");
         assertTrue(contentOf("gen/events/OrderCustomerRollupOnDelete.java").contains("intent-test-Order-Order-deleted"),
                 "the rollup delete-listener should bind the child's -deleted topic");
@@ -816,8 +815,8 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(onCreate.contains("MemberEntity parent = parents.findById(entity.Member)"),
                 "it should load the parent via the child's FK");
         assertTrue(
-                onCreate.contains("new LoanRepository().findAll(Criteria.create().eq(\"Member\", entity.Member)).size()")
-                        && onCreate.contains("parent.LoanCount = count"),
+                onCreate.contains("new LoanRepository().findAll(Criteria.create().eq(\"Member\", entity.Member))")
+                        && onCreate.contains("int count = rows.size();") && onCreate.contains("parent.LoanCount = count"),
                 "it should recompute the count via a typed Criteria and write it to the parent counter");
 
         String onDelete = contentOf("gen/events/LoanMemberRollupOnDelete.java");


### PR DESCRIPTION
## Problem

The H2 integration-tests leg on `master` is red after #6187 (`fix(intent): coalesce roll-ups sharing a child+parent relation into one handler`). Two `IntentEngineIT` tests fail:

- `rollup_generates_create_and_delete_listeners_that_recompute_the_parent_count`
- `glue_template_generates_the_trigger_and_resolver_handlers`

Both fail on the same assertion — *"recompute the parent count via Criteria" — expected `<true>` but was `<false>`*.

## Root cause

#6187 rewrote `Rollup.java.template` + `renderRollupAggregate()` so a coalesced handler runs the child query **once** into a shared list and computes each aggregate from it:

```java
java.util.List<OrderEntity> rows = new OrderRepository().findAll(Criteria.create().eq("Customer", entity.Customer));
...
int count = rows.size();
if (parent.OrderCount == null || parent.OrderCount.intValue() != count) {
    parent.OrderCount = count;
    ...
}
```

The old inline `findAll(...).size()` one-liner no longer exists. #6187 updated the expected **file names** in the test (per its own commit message) but left the recompute-**body** substrings asserting the old `.size()` call, so the assertion never matched. The generated code is correct — only the test string was stale.

## Fix

Assert the coalesced shape instead (test-only change): the `rows = ...findAll(Criteria...)` query, `int count = rows.size();`, and the `parent.<Counter> = count` write. Substrings verified against `renderRollupAggregate()` / `Rollup.java.template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)