### PR TITLE
fix(harmonia): read-only master detail panels + form footer below detail panels

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -38,12 +38,18 @@
   <!-- Loading (edit) -->
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
 
-  <!-- Form -->
-  <form x-show="state !== 'loading' && state !== 'load-failure'" @submit.prevent="save()"
+  <!-- Form area: the main column holds the field form, the detail collections and the action footer
+       (in that order, so the Save/Cancel bar is the LAST thing on the page - below the panels, like
+       the document view); the read-only/audit sidebar is the second column of this hbox. -->
+  <div x-show="state !== 'loading' && state !== 'load-failure'"
         class="hbox gap-6 py-6 px-8 w-full items-start">
     <!-- Main content column -->
     <div class="vbox gap-4 grow min-w-0" style="max-width: 42rem;">
 
+    <!-- The header form holds the editable fields only. The Save button lives in the footer below
+         (outside this form, beneath the detail panels) so the footer can sit at the very bottom; it
+         calls save() directly, while @submit.prevent keeps Enter-to-save working inside a field. -->
+    <form @submit.prevent="save()" class="vbox gap-4 w-full">
     <!-- Error summary banner: save failure or unmatched 422 causes -->
     <div x-show="saveFailureMessage || errors.__summary" x-h-alert data-variant="negative" role="alert">
       <svg x-h-icon.circle-error role="img" aria-label="error"></svg>
@@ -169,7 +175,81 @@
 #end
     </div>
     </fieldset>
+    </form>
 
+    <!-- Detail collections (masters only; App.detailsFor returns [] otherwise): the same generic
+         detail panels the master browse view renders, so the record's children are visible and
+         manageable while editing. Rendered INSIDE the main column, above the footer, so the
+         Save/Cancel bar stays at the very bottom of the page. Outside the <form> on purpose (the
+         panel's buttons must not submit it). Add/Edit/Delete route back to THIS page (returnTo
+         override); in preview the panels are read-only. -->
+    <div class="vbox gap-4 w-full"
+         x-show="(isEdit || isPreview) && detailDefs.length && state !== 'loading' && state !== 'load-failure'">
+      <template x-for="d in detailDefs" :key="d.entity + ':' + id">
+        <div x-data="detailPanel({...d, returnTo: '/${name}/' + id + (isPreview ? '/preview' : '/edit')}, id)" x-h-card>
+          <div x-h-card-header>
+            <h3 x-h-card-title x-text="d.label"></h3>
+            <div x-h-card-action x-show="!isPreview">
+              <button type="button" x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
+            </div>
+          </div>
+          <div x-h-card-content>
+            <div x-show="state === 'loading'"><div x-h-spinner></div></div>
+            <div x-show="state === 'error'" x-h-text.muted x-text="error"></div>
+            <div x-show="state === 'empty'" x-h-text.muted x-text="T('$projectName:${tprefix}.messages.noData', 'No records yet.')"></div>
+            <div x-show="state === 'default'" x-h-table-container.scroll style="max-height: 320px">
+              <table x-h-table data-borders="rows">
+                <thead x-h-table-header>
+                  <tr x-h-table-row>
+                    <template x-for="col in def.columns" :key="col.name">
+                      <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label || col.name)"></th>
+                    </template>
+                    <th x-h-table-head scope="col" x-show="!isPreview"></th>
+                  </tr>
+                </thead>
+                <tbody x-h-table-body>
+                  <template x-for="row in rows" :key="row[def.primaryKey]">
+                    <tr x-h-table-row data-hoverable="true">
+                      <template x-for="col in def.columns" :key="col.name">
+                        <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
+                      </template>
+                      <td x-h-table-cell data-row-actions x-show="!isPreview">
+                        <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" data-lucide="ellipsis"></i></button>
+                        <ul x-h-menu data-align="bottom-end">
+                          <li x-h-menu-item @click="previewRow(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
+                          <li x-h-menu-item @click="editRow(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
+                          <li x-h-menu-separator></li>
+                          <li x-h-menu-item data-variant="negative" @click="askDelete(row)" x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></li>
+                        </ul>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <!-- Detail delete confirmation -->
+          <div x-h-dialog-overlay :data-open="deleteOpen">
+            <div x-h-dialog>
+              <div x-h-dialog-header>
+                <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + ' ' + T(def.tkey, def.label)"></h2>
+                <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+              </div>
+              <div x-h-dialog-content><p>Are you sure? This cannot be undone.</p></div>
+              <div x-h-dialog-footer>
+                <button type="button" x-h-button data-variant="outline" @click="deleteOpen = false" :disabled="deleteBusy" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
+                <button type="button" x-h-button data-variant="negative" @click="confirmDelete()" :disabled="deleteBusy"><span x-show="deleteBusy" x-h-spinner></span><span x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></span></button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <!-- Action footer at the very bottom of the main column (below the detail panels), matching the
+         document view. BPM user-task buttons on the LEFT; Cancel + Save/Create on the RIGHT. Save is
+         type=button @click=save() because it lives outside the header <form>. -->
     <div x-h-toolbar.footer>
 #if($hasProcess)
       <!-- Actionable BPM user-task buttons (edit only, hidden in read-only preview), left-aligned. -->
@@ -186,7 +266,7 @@
         <i role="img" data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span>
       </button>
       <button type="button" x-h-button data-variant="transparent" x-show="!isPreview" @click="cancel()" :disabled="state === 'saving'" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
-      <button type="submit" x-h-button data-variant="primary" x-show="!isPreview" :disabled="state === 'saving'">
+      <button type="button" x-h-button data-variant="primary" x-show="!isPreview" :disabled="state === 'saving'" @click="save()">
         <span x-show="state === 'saving'" x-h-spinner></span>
         <i role="img" data-lucide="save" x-show="state !== 'saving'"></i><span x-text="isEdit ? T('$projectName:${tprefix}.defaults.update', 'Save') : T('$projectName:${tprefix}.defaults.create', 'Create')"></span>
       </button>
@@ -223,75 +303,6 @@
       </div>
     </div>
 #end
-  </form>
-
-  <!-- Detail collections (masters only; App.detailsFor returns [] otherwise): the same generic
-       detail panels the master browse view renders, so the record's children are visible and
-       manageable while editing - previously they showed ONLY on the browse view's details pane.
-       Outside the <form> on purpose (the panel's buttons must not submit it). Add/Edit/Delete
-       route back to THIS page (returnTo override); in preview the panels are read-only. -->
-  <div class="vbox gap-4 px-8 pb-6 w-full" style="max-width: 42rem;"
-       x-show="(isEdit || isPreview) && detailDefs.length && state !== 'loading' && state !== 'load-failure'">
-    <template x-for="d in detailDefs" :key="d.entity + ':' + id">
-      <div x-data="detailPanel({...d, returnTo: '/${name}/' + id + (isPreview ? '/preview' : '/edit')}, id)" x-h-card>
-        <div x-h-card-header>
-          <h3 x-h-card-title x-text="d.label"></h3>
-          <div x-h-card-action x-show="!isPreview">
-            <button type="button" x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
-          </div>
-        </div>
-        <div x-h-card-content>
-          <div x-show="state === 'loading'"><div x-h-spinner></div></div>
-          <div x-show="state === 'error'" x-h-text.muted x-text="error"></div>
-          <div x-show="state === 'empty'" x-h-text.muted x-text="T('$projectName:${tprefix}.messages.noData', 'No records yet.')"></div>
-          <div x-show="state === 'default'" x-h-table-container.scroll style="max-height: 320px">
-            <table x-h-table data-borders="rows">
-              <thead x-h-table-header>
-                <tr x-h-table-row>
-                  <template x-for="col in def.columns" :key="col.name">
-                    <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label || col.name)"></th>
-                  </template>
-                  <th x-h-table-head scope="col" x-show="!isPreview"></th>
-                </tr>
-              </thead>
-              <tbody x-h-table-body>
-                <template x-for="row in rows" :key="row[def.primaryKey]">
-                  <tr x-h-table-row data-hoverable="true">
-                    <template x-for="col in def.columns" :key="col.name">
-                      <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
-                    </template>
-                    <td x-h-table-cell data-row-actions x-show="!isPreview">
-                      <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" data-lucide="ellipsis"></i></button>
-                      <ul x-h-menu data-align="bottom-end">
-                        <li x-h-menu-item @click="previewRow(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
-                        <li x-h-menu-item @click="editRow(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
-                        <li x-h-menu-separator></li>
-                        <li x-h-menu-item data-variant="negative" @click="askDelete(row)" x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></li>
-                      </ul>
-                    </td>
-                  </tr>
-                </template>
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        <!-- Detail delete confirmation -->
-        <div x-h-dialog-overlay :data-open="deleteOpen">
-          <div x-h-dialog>
-            <div x-h-dialog-header>
-              <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + ' ' + T(def.tkey, def.label)"></h2>
-              <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
-            </div>
-            <div x-h-dialog-content><p>Are you sure? This cannot be undone.</p></div>
-            <div x-h-dialog-footer>
-              <button type="button" x-h-button data-variant="outline" @click="deleteOpen = false" :disabled="deleteBusy" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
-              <button type="button" x-h-button data-variant="negative" @click="confirmDelete()" :disabled="deleteBusy"><span x-show="deleteBusy" x-h-spinner></span><span x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></span></button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </template>
   </div>
 
 </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -122,7 +122,10 @@
           </template>
         </div>
 
-        <!-- The selected ${name}'s own fields — all properties (the table shows only the major ones). -->
+        <!-- The selected ${name}'s own fields (the table shows only the major ones). Labels are
+             translated like everywhere else; read-only / system fields (audit, uuid, ProcessId,
+             read-only) are shown only when populated - matching the edit form's read-only sidebar -
+             so empty audit columns don't render as blank labelled rows. -->
         <div x-h-card>
           <div x-h-card-header><h3 x-h-card-title x-text="T('$projectName:${tprefix}.defaults.details', 'Details')"></h3></div>
           <div x-h-card-content>
@@ -131,8 +134,12 @@
 #if(!$property.dataAutoIncrement)
 #if($property.widgetLabel)#set($plabel = $property.widgetLabel)#else#set($plabel = $property.name)#end
 #if($property.isDateType)#set($isDate = "true")#else#set($isDate = "false")#end
+#if($property.isReadOnlyProperty == "true" || ($property.auditType && $property.auditType != "NONE"))
+              <div class="vbox gap-0" x-show="selected?.${property.name} !== null && selected?.${property.name} !== undefined && selected?.${property.name} !== ''">
+#else
               <div class="vbox gap-0">
-                <span x-h-text.muted class="text-xs">${plabel}</span>
+#end
+                <span x-h-text.muted class="text-xs" x-text="T('$projectName:${tprefix}.t.${property.dataName}', '${plabel}')"></span>
 #if($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS")
                 <span x-text="lookupText('${property.name}', selected?.${property.name})"></span>
 #elseif($property.isFloatType)
@@ -154,9 +161,6 @@
           <div x-data="detailPanel(d, selectedId)" x-h-card>
             <div x-h-card-header>
               <h3 x-h-card-title x-text="d.label"></h3>
-              <div x-h-card-action>
-                <button x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
-              </div>
             </div>
             <div x-h-card-content>
               <div x-show="state === 'loading'"><div x-h-spinner></div></div>
@@ -178,40 +182,22 @@
                         <template x-for="col in def.columns" :key="col.name">
                           <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
                         </template>
+                        <!-- Read-only browse pane: children are added/edited/deleted from the record's
+                             Edit form (where these same panels are editable), NOT here. Only the
+                             actionable user tasks (e.g. a triggered review) and a read-only Preview
+                             remain. -->
                         <td x-h-table-cell data-row-actions>
-                          <!-- This detail record's actionable user tasks (e.g. a triggered review), one button each. -->
                           <template x-for="task in $store.processTasks.getTasks(row)" :key="task.id">
                             <button x-h-button data-variant="primary" data-size="sm" @click="$store.processTasks.openTask(task)">
                               <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
                             </button>
                           </template>
-                          <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" data-lucide="ellipsis"></i></button>
-                          <ul x-h-menu data-align="bottom-end">
-                            <li x-h-menu-item @click="previewRow(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
-                            <li x-h-menu-item @click="editRow(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
-                            <li x-h-menu-separator></li>
-                            <li x-h-menu-item data-variant="negative" @click="askDelete(row)" x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></li>
-                          </ul>
+                          <button x-h-button data-variant="transparent" data-size="sm" aria-label="Preview" @click="previewRow(row)"><i role="img" data-lucide="eye"></i></button>
                         </td>
                       </tr>
                     </template>
                   </tbody>
                 </table>
-              </div>
-            </div>
-
-            <!-- Detail delete confirmation -->
-            <div x-h-dialog-overlay :data-open="deleteOpen">
-              <div x-h-dialog>
-                <div x-h-dialog-header>
-                  <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + ' ' + T(def.tkey, def.label)"></h2>
-                  <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
-                </div>
-                <div x-h-dialog-content><p>Are you sure? This cannot be undone.</p></div>
-                <div x-h-dialog-footer>
-                  <button x-h-button data-variant="outline" @click="deleteOpen = false" :disabled="deleteBusy" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
-                  <button x-h-button data-variant="negative" @click="confirmDelete()" :disabled="deleteBusy"><span x-show="deleteBusy" x-h-spinner></span><span x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></span></button>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What

Two fixes to the **Harmonia Java UI templates** (`template-application-ui-harmonia-java`), found while reviewing a generated *Master*-function entity (a Project with `ProjectTask` / `EmployeeProjectAssignment` composition children).

### 1. Master browse pane is now read-only (`master/master-view.html.template`)
The master-detail right pane is a **read-only preview** of the selected record — its toolbar already carries Edit/Delete and its own fields render as a read-only card — but the child detail panels still exposed **Add** and per-row **Edit/Delete**. Children are now added/edited/deleted only from the record's **Edit form**, where the same panels remain fully editable.
- Removed the Add button and the Edit/Delete row menu.
- Kept a read-only **Preview** button and the actionable BPM user-task buttons.
- Removed the now-unreachable detail delete-confirmation dialog.

### 2. Read-only "Details" card cleaned up (`master/master-view.html.template`)
The card previously rendered **every** property — including the null system/audit columns (`uuid`, `CreatedAt/By`, `UpdatedAt/By`) — with **raw untranslated labels**. Now read-only/audit fields are shown **only when populated** and **all labels go through `T(...)`**, matching the edit form's read-only sidebar convention.

### 3. Form footer moved below the detail panels (`manage/form-view.html.template`)
The Save/Cancel footer sat **between** the fields and the detail collection panels. It now sits at the **very bottom** of the main column, below the panels — mirroring the document view. Save became `type="button" @click="save()"` (it lives outside the header `<form>`); the inner form keeps `@submit.prevent` so Enter-to-save still works.

## Scope
Pure template (HTML/Velocity) changes — no Java. These fix **every** entity generated by these templates, not just the one that surfaced them.

## Verification
Applied the same transformations to a generated app's served `gen/` views and confirmed against a running instance: master pane has no `addRow()` / Edit / Delete (Preview + tasks only), audit fields gated + translated; form has no `type="submit"`, Save is `type=button @click=save()`, and the footer renders after the detail panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)