### PR TITLE
feat(harmonia): honour DIRIGIBLE_BRANDING_* env vars in the Harmonia shells

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/branding.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/branding.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+/*
+ * branding — makes the Harmonia shells honour the SAME instance branding as the AngularJS shell,
+ * driven by the same DIRIGIBLE_BRANDING_* env vars. The platform service
+ * /services/js/platform-branding/branding.js (loaded just before this file) sets the global
+ * top.PlatformBranding = { name, subtitle, brand, brandUrl, icons.favicon, logo, theme, prefix }
+ * from Configurations.get(...). This adapter reads that global (the AngularJS shell reads the same
+ * one via getBrandingInfo()), applies the favicon + document title to the plain HTML head, and
+ * exposes the values as an Alpine `branding` store so the shell markup can bind logo/name/subtitle.
+ *
+ * Opt-in title handling via a <html> attribute (each shell decides, since only the platform launchpad
+ * is "the brand" while a generated app's tab keeps its own name):
+ *   data-brand-title         -> document.title = brand name          (the Applications launchpad)
+ *   data-brand-title-suffix  -> document.title = "<existing> | brand" (a generated app shell)
+ *
+ * The theme value is a BlimpKit theme id (not applicable to Harmonia's own light/dark), and the
+ * localStorage prefix stays the fixed codbex.harmonia.* the Harmonia library itself uses — neither is
+ * consumed here.
+ */
+(() => {
+  const DEFAULTS = {
+    name: 'Dirigible',
+    subtitle: '',
+    brand: 'Eclipse',
+    brandUrl: 'https://www.dirigible.io/',
+    favicon: '/services/web/platform-branding/images/favicon.ico',
+    logo: '/services/web/platform-branding/images/dirigible.svg',
+    prefix: 'dirigible',
+  };
+
+  // The platform branding global is set on `top` (shared across nested same-origin iframes). Fall back
+  // to defaults if it is absent (service not loaded) or unreachable (a cross-origin embedding).
+  const read = () => {
+    let src = null;
+    try {
+      src = window.PlatformBranding || (window.top && window.top.PlatformBranding) || null;
+    } catch (e) {
+      src = null; // cross-origin top — keep defaults
+    }
+    if (!src) return { ...DEFAULTS };
+    return {
+      name: src.name || DEFAULTS.name,
+      subtitle: src.subtitle || '',
+      brand: src.brand || DEFAULTS.brand,
+      brandUrl: src.brandUrl || DEFAULTS.brandUrl,
+      favicon: (src.icons && src.icons.favicon) || DEFAULTS.favicon,
+      logo: src.logo || DEFAULTS.logo,
+      prefix: src.prefix || DEFAULTS.prefix,
+    };
+  };
+
+  const BRANDING = read();
+  window.HarmoniaBranding = BRANDING;
+
+  // Replace the shell's blank placeholder favicon with the instance one.
+  try {
+    if (BRANDING.favicon && typeof document !== 'undefined' && document.head) {
+      let link = document.querySelector('link[rel~="icon"]');
+      if (!link) {
+        link = document.createElement('link');
+        link.setAttribute('rel', 'icon');
+        document.head.appendChild(link);
+      }
+      link.setAttribute('href', BRANDING.favicon);
+    }
+  } catch (e) { /* head not ready — non-fatal, favicon just stays the placeholder */ }
+
+  // Per-shell tab title (opt-in via a <html> attribute; see file header).
+  try {
+    const root = document.documentElement;
+    if (root && root.hasAttribute('data-brand-title')) {
+      document.title = BRANDING.name;
+    } else if (root && root.hasAttribute('data-brand-title-suffix') && BRANDING.name) {
+      const current = (document.title || '').trim();
+      if (current && current.indexOf(BRANDING.name) < 0) {
+        document.title = current + ' | ' + BRANDING.name;
+      } else if (!current) {
+        document.title = BRANDING.name;
+      }
+    }
+  } catch (e) { /* no DOM — non-fatal */ }
+
+  if (typeof document !== 'undefined' && document.addEventListener) {
+    document.addEventListener('alpine:init', () => {
+      Alpine.store('branding', {
+        name: BRANDING.name,
+        subtitle: BRANDING.subtitle,
+        brand: BRANDING.brand,
+        brandUrl: BRANDING.brandUrl,
+        logo: BRANDING.logo,
+        favicon: BRANDING.favicon,
+        prefix: BRANDING.prefix,
+      });
+    }, { once: true });
+  }
+})();

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -21,10 +21,12 @@
   built-in pages (Dashboard/Inbox/Documents/Reports) and aggregates the `application-perspectives`
   extension point for the domain apps, which it hosts in an iframe (their generated SPA, embedded).
 -->
-<html lang="en">
+<!-- data-brand-title: services/branding.js sets the tab title to the instance brand name. -->
+<html lang="en" data-brand-title>
 
   <head>
     <meta charset="UTF-8" />
+    <!-- Placeholder favicon, replaced at runtime by services/branding.js (DIRIGIBLE_BRANDING_FAVICON). -->
     <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Applications</title>
@@ -54,10 +56,15 @@
       <div x-h-split-panel :data-hidden="hiddenPanels.left" data-max="280" data-min="220"
            data-locked="true" data-gutterless="true" x-ref="sidebarPanel">
         <div x-h-sidebar x-ref="sidebar">
+          <!-- Instance brand mark (DIRIGIBLE_BRANDING_LOGO / _NAME / _SUBTITLE via the `branding` store),
+               the Harmonia counterpart of the AngularJS shell header. -->
           <div x-h-sidebar-header>
             <div class="hbox items-center gap-2 p-1">
-              <i role="img" data-lucide="layout-grid" class="size-5 text-primary"></i>
-              <span class="font-bold" x-text="T('application-core:shell.nav.applications', 'Applications')"></span>
+              <img :src="$store.branding.logo" :alt="$store.branding.name" class="size-5" />
+              <div class="vbox gap-0">
+                <span class="font-bold leading-tight" x-text="$store.branding.name"></span>
+                <span x-show="$store.branding.subtitle" class="text-xs text-muted-foreground leading-tight" x-text="$store.branding.subtitle"></span>
+              </div>
             </div>
           </div>
 
@@ -298,6 +305,11 @@
     <script src="/services/web/application-core/shell/js/services/api.js" defer></script>
     <script src="/services/web/application-core/shell/js/services/apiError.js" defer></script>
     <script src="/services/web/application-core/shell/js/services/format.js" defer></script>
+    <!-- Instance branding (same DIRIGIBLE_BRANDING_* env vars as the AngularJS shell): the platform
+         service sets top.PlatformBranding; the adapter applies the favicon/title and exposes it as the
+         Alpine `branding` store. Load the source before the adapter. -->
+    <script src="/services/js/platform-branding/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/branding.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/pages/basePage.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/notifications.js" defer></script>
     <script src="/services/web/application-core/shell/js/stores/processTasks.js" defer></script>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -14,10 +14,13 @@
       served version-less at /webjars/pinecone-router/dist/router.min.js.
   Script load order is load-bearing: plugins -> app code (defer, document order) -> Alpine -> Harmonia -> Lucide.
 -->
-<html lang="en">
+<!-- data-brand-title-suffix: services/branding.js appends " | <brand>" to the app title (like the
+     AngularJS shell's "<perspective> | <name>"); the app keeps its own name + icon as its identity. -->
+<html lang="en" data-brand-title-suffix>
 
   <head>
     <meta charset="UTF-8" />
+    <!-- Placeholder favicon, replaced at runtime by services/branding.js (DIRIGIBLE_BRANDING_FAVICON). -->
     <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${appTitle}</title>
@@ -403,6 +406,11 @@
     <script src="/services/web/application-core/shell/js/services/apiError.js" defer></script>
     <script src="/services/web/application-core/shell/js/services/formValidation.js" defer></script>
     <script src="/services/web/application-core/shell/js/services/format.js" defer></script>
+    <!-- Instance branding (same DIRIGIBLE_BRANDING_* env vars as the AngularJS shell): the platform
+         service sets top.PlatformBranding; the adapter applies the favicon + " | <brand>" title suffix
+         and exposes the Alpine `branding` store. Load the source before the adapter. -->
+    <script src="/services/js/platform-branding/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/branding.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/layout/appShell.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/pages/basePage.js" defer></script>
     <script src="/services/web/application-core/shell/js/components/pages/baseFormPage.js" defer></script>


### PR DESCRIPTION
> Stacked on #6193 (shares the two `index.html` files). Base will be retargeted to `master` once #6193 merges.

## What

Makes the Harmonia shells honour the **same instance branding as the AngularJS shell**, driven by the **same `DIRIGIBLE_BRANDING_*` env vars**. Previously the Harmonia shells ignored branding entirely — a blank placeholder favicon, a hardcoded "Applications" launchpad header, and no consumption of the branding config.

## How

- **`application-core/shell/js/services/branding.js`** (new, shared, self-contained) reads the `top.PlatformBranding` global that the existing `/services/js/platform-branding/branding.js` service sets from `Configurations.get('DIRIGIBLE_BRANDING_*')`. It applies the favicon + tab title to the plain HTML head and exposes the values as an Alpine `branding` store. Falls back to Dirigible defaults if the global is absent.
- **Tab title** is opt-in per shell via a `<html>` attribute: `data-brand-title` (title = brand name) on the Applications launchpad; `data-brand-title-suffix` (title = `"<app> | <brand>"`, mirroring the AngularJS `"<perspective> | <name>"`) on a generated app shell.
- **`resources-application`** (launchpad): sidebar header now renders the instance **brand logo + name (+ subtitle)** instead of the hardcoded `layout-grid` icon.
- **`template shell`** (generated app): keeps its own model title/icon as the app identity, and additionally gets the platform favicon + branded title suffix.

## Why reuse `platform-branding`

Verified it is a **standalone, dependency-free resources module** (empty `<dependencies>`, `project.json` deps `[]`), containing only served JS + images — no AngularJS, no Java. It lives in `group-resources` alongside `application-core` (the Harmonia runtime itself), and the `DIRIGIBLE_BRANDING_*` keys are registered in `Configuration.java`. So it is a **platform-wide branding source both stacks consume**, not an AngularJS artefact — it survives an eventual AngularJS-shell removal. The AngularJS coupling is only in the *consumer* (`platform-core`'s `getBrandingInfo()`), which this does not touch.

The BlimpKit `theme` id and the localStorage `prefix` are intentionally **not** consumed (Harmonia owns its own light/dark and the fixed `codbex.harmonia.*` key prefix used by the vendored Harmonia lib).

## Verification (live)

Booted the freshly-packaged jar with `DIRIGIBLE_BRANDING_NAME="Acme HPA"`, `_SUBTITLE`, `_BRAND="Acme"`:
- `/services/js/platform-branding/branding.js` → serves `name: 'Acme HPA'`, `subtitle`, `brand: 'Acme'` — **env vars flow through**.
- Both shells load the platform service + the adapter; launchpad header binds `$store.branding.{logo,name}`; `<html>` carries the brand-title attributes — all served-current.
- Adapter logic covered by a Node harness (suffix/brand-title modes, favicon application, defaults fallback).
- Brand **logo** (`dirigible.svg`) serves 200 under auth.

## Known caveat (pre-existing, shared with the AngularJS shell)

`.ico` files return **401 under `/services/web`** even authenticated (`.png`/`.svg` serve fine; not a content-type issue — `ContentTypeHelper` knows `image/x-icon`). The default `DIRIGIBLE_BRANDING_FAVICON` points at `favicon.ico`, so the **default favicon does not render in either shell**. Not introduced here — the AngularJS shell reads the same default. Workaround: set `DIRIGIBLE_BRANDING_FAVICON=/services/web/platform-branding/images/favicon-32x32.png`. Suggested follow-up: fix `.ico` serving, or change the platform default to the `.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)