### PR TITLE
feat(intent-editor): add a Refresh button to re-parse/re-validate on demand

### DIFF
--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/editor.html
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/editor.html
@@ -154,6 +154,8 @@
         <bk-toolbar compact="true" has-title="false">
             <span>Intent</span>
             <bk-toolbar-spacer></bk-toolbar-spacer>
+            <bk-button state="transparent" glyph="sap-icon--refresh" title="Refresh — re-parse and re-validate (e.g. after generating a dependency project)" aria-label="Refresh" ng-click="refresh()" ng-disabled="state.isBusy"></bk-button>
+            <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="transparent" glyph="sap-icon--save" title="Save" aria-label="Save" ng-click="save()" ng-disabled="!changed || state.isBusy"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="emphasized" glyph="sap-icon--generate-shortcut" label="Generate" title="Generate the model files into the project" aria-label="Generate" ng-click="generate()" ng-disabled="state.isBusy || issues.length"></bk-button>

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -229,7 +229,7 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
     };
 
     const refreshPreview = () => {
-        $http.post(PARSE_URL, $scope.text || '', { headers: { 'Content-Type': 'text/plain' } }).then((response) => {
+        return $http.post(PARSE_URL, $scope.text || '', { headers: { 'Content-Type': 'text/plain' } }).then((response) => {
             $scope.issues = [];
             $scope.model = normalize(response.data);
             render();
@@ -242,6 +242,17 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
                     console.error(response);
                 }
             });
+        });
+    };
+
+    // Re-parse and re-validate the current buffer on demand. Generate resolves cross-model
+    // dependencies against other projects' already-generated .model files; when one is missing it
+    // fails with issues that stay pinned (blocking Generate) until the buffer is re-parsed. After
+    // generating the dependency project, Refresh clears those stale issues and re-renders — no browser
+    // reload needed.
+    $scope.refresh = () => {
+        refreshPreview().then(() => {
+            statusBarHub.showMessage('Re-validated the intent');
         });
     };
 


### PR DESCRIPTION
## What

Adds a **Refresh** button to the Intent Editor toolbar, before Save (order: `Refresh · Save · Generate · AI`).

## Why

Generate resolves cross-model dependencies against other projects' already-generated `.model` files. When a dependency is missing, Generate fails and sets `$scope.issues`, which stay pinned and keep the Generate button disabled (`ng-disabled="state.isBusy || issues.length"`). Previously, after generating the missing dependency project elsewhere, the **only** way to clear those stale issues and re-enable Generate was a full browser reload.

## How

- `editor.html`: new `bk-button` (`sap-icon--refresh`) before Save, `ng-click="refresh()"`, disabled only while busy.
- `editor.js`: `$scope.refresh()` re-runs the existing `refreshPreview()` (re-POSTs the buffer to the parse endpoint), which clears `$scope.issues`, re-renders the mxGraph diagram, and re-enables Generate; then shows a "Re-validated the intent" status message. `refreshPreview()` now returns its promise so Refresh can chain the status message.

No new endpoints, no behavior change to parse/generate — just an on-demand trigger of the existing live-preview validation.

## Verification

`node --check` on `editor.js`, correct toolbar order, clean module build with the button present in the packaged HTML. Not yet driven in a live browser (IDE UI resources don't hot-reload; needs a rebuild + restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)