### PR TITLE
feat(harmonia): Phase 2 - dark-mode cleanup + Lucide x-h-lucide adoption

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/layout/appShell.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/layout/appShell.js
@@ -148,10 +148,8 @@ document.addEventListener('alpine:init', () => {
       if (window.matchMedia('(max-width: 1024px)').matches) this.isOpen = false;
     },
 
-    refreshIcons() {
-      if (window.lucide && typeof window.lucide.createIcons === 'function') {
-        window.lucide.createIcons();
-      }
-    },
+    // No-op: Lucide icons now render via the x-h-lucide directive (harmonia-lucide bundle), which
+    // upgrades icons on init and inside dynamically loaded views - no manual createIcons scan needed.
+    refreshIcons() {},
   }));
 }, { once: true });

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -22,13 +22,9 @@
  */
 function basePage() {
   return {
-    refreshIcons() {
-      this.$nextTick(() => {
-        if (window.lucide && typeof window.lucide.createIcons === 'function') {
-          window.lucide.createIcons();
-        }
-      });
-    },
+    // No-op: Lucide icons now render via the x-h-lucide directive (harmonia-lucide bundle), which
+    // upgrades icons on init and inside dynamically loaded views - no manual createIcons scan needed.
+    refreshIcons() {},
 
     /**
      * Format a floating-point value for display: decimals from the field's DecimalFormat pattern, the

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_documents.html
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_documents.html
@@ -19,9 +19,9 @@
 <div x-data="documentsPage" class="vbox size-full">
 
   <div x-h-toolbar data-variant="transparent">
-    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!hasBack()" @click="goBack()" aria-label="Back"><i role="img" data-lucide="arrow-left"></i></button>
-    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!hasForward()" @click="goForward()" aria-label="Forward"><i role="img" data-lucide="arrow-right"></i></button>
-    <button x-h-button data-variant="transparent" data-size="icon-sm" @click="refresh()" aria-label="Refresh"><i role="img" data-lucide="refresh-cw"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!hasBack()" @click="goBack()" aria-label="Back"><i role="img" x-h-lucide data-lucide="arrow-left"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!hasForward()" @click="goForward()" aria-label="Forward"><i role="img" x-h-lucide data-lucide="arrow-right"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" @click="refresh()" aria-label="Refresh"><i role="img" x-h-lucide data-lucide="refresh-cw"></i></button>
     <nav x-h-breadcrumb data-overflow="scroll" class="px-1">
       <ol x-h-breadcrumb-list>
         <template x-for="(c, i) in breadcrumbs" :key="c.path + ':' + i">
@@ -33,11 +33,11 @@
       </ol>
     </nav>
     <div x-h-toolbar-spacer></div>
-    <button x-h-button data-variant="transparent" data-size="icon-sm" :aria-pressed="search.show" @click="toggleSearch()" aria-label="Find item"><i role="img" data-lucide="search"></i></button>
-    <button x-h-button data-variant="transparent" data-size="icon-sm" @click="askNewFolder()" aria-label="New folder"><i role="img" data-lucide="folder-plus"></i></button>
-    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!anySelected()" @click="askDeleteSelected()" aria-label="Delete selected"><i role="img" data-lucide="trash-2"></i></button>
-    <a x-h-button data-variant="transparent" data-size="icon-sm" :href="zipUrl()" target="_blank" aria-label="Download folder as zip"><i role="img" data-lucide="folder-down"></i></a>
-    <button x-h-menu-trigger.dropdown x-h-button data-variant="transparent" data-size="icon-sm" aria-label="Upload"><i role="img" data-lucide="upload"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" :aria-pressed="search.show" @click="toggleSearch()" aria-label="Find item"><i role="img" x-h-lucide data-lucide="search"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" @click="askNewFolder()" aria-label="New folder"><i role="img" x-h-lucide data-lucide="folder-plus"></i></button>
+    <button x-h-button data-variant="transparent" data-size="icon-sm" :disabled="!anySelected()" @click="askDeleteSelected()" aria-label="Delete selected"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
+    <a x-h-button data-variant="transparent" data-size="icon-sm" :href="zipUrl()" target="_blank" aria-label="Download folder as zip"><i role="img" x-h-lucide data-lucide="folder-down"></i></a>
+    <button x-h-menu-trigger.dropdown x-h-button data-variant="transparent" data-size="icon-sm" aria-label="Upload"><i role="img" x-h-lucide data-lucide="upload"></i></button>
     <ul x-h-menu data-align="bottom-end">
       <li x-h-menu-item @click="triggerUpload(false)" x-text="T('application-core:shell.documents.uploadFiles', 'Upload files')"></li>
       <li x-h-menu-item @click="triggerUpload(true)" x-text="T('application-core:shell.documents.uploadZip', 'Upload zip contents')"></li>
@@ -91,11 +91,11 @@
                   </td>
                   <th x-h-table-head scope="row">
                     <button x-h-button data-variant="link" class="justify-start" @click="onRowClick(item)">
-                      <i role="img" :data-lucide="fileIcon(item)"></i><span x-text="item.name"></span>
+                      <i role="img" x-h-lucide :data-lucide="fileIcon(item)"></i><span x-text="item.name"></span>
                     </button>
                   </th>
                   <td x-h-table-cell data-row-actions>
-                    <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Item actions"><i role="img" data-lucide="ellipsis"></i></button>
+                    <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Item actions"><i role="img" x-h-lucide data-lucide="ellipsis"></i></button>
                     <ul x-h-menu data-align="bottom-end">
                       <li x-show="isDocument(item)" x-h-menu-item @click="copyLink(item)" x-text="T('application-core:shell.documents.copyLink', 'Copy link')"></li>
                       <li x-h-menu-item @click="askRename(item)" x-text="T('application-core:shell.documents.rename', 'Rename')"></li>
@@ -140,7 +140,7 @@
         <!-- Empty / not previewable -->
         <div x-show="!selectedFile || !canPreview" x-h-info-page class="p-4">
           <div x-h-info-page-header>
-            <div x-h-info-page-media.icon><i data-lucide="eye" role="img" aria-label="preview"></i></div>
+            <div x-h-info-page-media.icon><i x-h-lucide data-lucide="eye" role="img" aria-label="preview"></i></div>
             <div x-h-info-page-title x-text="T('application-core:shell.documents.filePreview', 'File Preview')"></div>
             <div x-h-info-page-description x-text="(selectedFile && !canPreview) ? 'This file cannot be previewed.' : 'Click on a file to see its preview.'"></div>
           </div>

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_inbox.html
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_inbox.html
@@ -22,9 +22,10 @@
     <span x-show="lastUpdated" x-h-text.muted x-text="'Updated ' + fmtTime(lastUpdated)"></span>
     <button x-h-button data-variant="transparent" data-size="icon-sm" :aria-pressed="autoRefresh"
             @click="toggleAuto()" :aria-label="autoRefresh ? 'Pause auto-refresh' : 'Resume auto-refresh'">
-      <i role="img" :data-lucide="autoRefresh ? 'pause' : 'play'"></i>
+      <svg x-h-lucide role="img" data-lucide="pause" x-show="autoRefresh"></svg>
+      <svg x-h-lucide role="img" data-lucide="play" x-show="!autoRefresh"></svg>
     </button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="refresh()"><i role="img" data-lucide="refresh-cw"></i><span x-text="T('application-core:shell.inbox.refresh', 'Refresh')"></span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="refresh()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span x-text="T('application-core:shell.inbox.refresh', 'Refresh')"></span></button>
   </div>
 
   <div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
@@ -41,7 +42,7 @@
 
         <div x-show="filtered.length === 0" x-h-info-page class="p-4">
           <div x-h-info-page-header>
-            <div x-h-info-page-media.icon><i data-lucide="inbox" role="img" aria-label="inbox"></i></div>
+            <div x-h-info-page-media.icon><i x-h-lucide data-lucide="inbox" role="img" aria-label="inbox"></i></div>
             <div x-h-info-page-title x-text="T('application-core:shell.inbox.noTasks', 'No tasks')"></div>
             <div x-h-info-page-description x-text="T('application-core:shell.inbox.noTasksHint', 'You have no pending tasks.')"></div>
           </div>
@@ -92,12 +93,12 @@
         <div x-show="selected && !selected.mine" class="vbox gap-3 items-start p-4">
           <div x-h-info-page>
             <div x-h-info-page-header>
-              <div x-h-info-page-media.icon><i data-lucide="inbox" role="img" aria-label="inbox"></i></div>
+              <div x-h-info-page-media.icon><i x-h-lucide data-lucide="inbox" role="img" aria-label="inbox"></i></div>
               <div x-h-info-page-title x-text="T('application-core:shell.inbox.claimTask', 'Claim this task')"></div>
               <div x-h-info-page-description x-text="T('application-core:shell.inbox.claimHint', 'This task is available to your group. Claim it to open and complete its form.')"></div>
             </div>
           </div>
-          <button x-h-button data-variant="primary" :disabled="busy" @click="claim(selected)"><i role="img" data-lucide="hand"></i><span x-text="T('application-core:shell.inbox.claimOpen', 'Claim & open')"></span></button>
+          <button x-h-button data-variant="primary" :disabled="busy" @click="claim(selected)"><i role="img" x-h-lucide data-lucide="hand"></i><span x-text="T('application-core:shell.inbox.claimOpen', 'Claim & open')"></span></button>
         </div>
 
         <!-- Claimed + has a form: render the standalone form inline. -->

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -76,17 +76,17 @@
                 <ul x-h-sidebar-menu>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/dashboard')" @click="navigate('/dashboard')">
-                      <i role="img" data-lucide="layout-dashboard"></i><span x-text="T('application-core:shell.nav.dashboard', 'Dashboard')"></span>
+                      <i role="img" x-h-lucide data-lucide="layout-dashboard"></i><span x-text="T('application-core:shell.nav.dashboard', 'Dashboard')"></span>
                     </button>
                   </li>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/inbox')" @click="navigate('/inbox')">
-                      <i role="img" data-lucide="inbox"></i><span x-text="T('application-core:shell.nav.inbox', 'Inbox')"></span>
+                      <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="T('application-core:shell.nav.inbox', 'Inbox')"></span>
                     </button>
                   </li>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/documents')" @click="navigate('/documents')">
-                      <i role="img" data-lucide="folder"></i><span x-text="T('application-core:shell.nav.documents', 'Documents')"></span>
+                      <i role="img" x-h-lucide data-lucide="folder"></i><span x-text="T('application-core:shell.nav.documents', 'Documents')"></span>
                     </button>
                   </li>
                 </ul>
@@ -108,7 +108,7 @@
                         <button x-h-sidebar-menu-button :data-active="isAppActive(item)" @click="openApp(item)">
                           <template x-if="isSvgIcon(item.icon)"><svg x-h-icon :data-link="item.icon" class="size-4" role="presentation"></svg></template>
                           <template x-if="isImageIcon(item.icon)"><img :src="item.icon" alt="" class="size-4" /></template>
-                          <template x-if="!isSvgIcon(item.icon) && !isImageIcon(item.icon)"><i role="img" :data-lucide="item.icon || 'box'"></i></template>
+                          <template x-if="!isSvgIcon(item.icon) && !isImageIcon(item.icon)"><i role="img" x-h-lucide :data-lucide="item.icon || 'box'"></i></template>
                           <span x-text="item.tkey ? T(item.tkey, item.label) : item.label"></span>
                         </button>
                       </li>
@@ -127,7 +127,7 @@
                   <template x-for="r in $store.reports.items" :key="r.url">
                     <li x-h-sidebar-menu-item>
                       <button x-h-sidebar-menu-button :data-active="isReportActive(r)" @click="openReport(r)">
-                        <i role="img" data-lucide="bar-chart-3"></i><span x-text="$store.reports.displayLabel(r)"></span>
+                        <i role="img" x-h-lucide data-lucide="bar-chart-3"></i><span x-text="$store.reports.displayLabel(r)"></span>
                       </button>
                     </li>
                   </template>
@@ -141,7 +141,7 @@
             <ul x-h-sidebar-menu>
               <li x-h-sidebar-menu-item x-show="settingsItems.length > 0">
                 <button x-h-sidebar-menu-button :data-active="settingsMode" @click="openSettings()">
-                  <i role="img" data-lucide="settings"></i><span x-text="T('application-core:shell.nav.settings', 'Settings')"></span>
+                  <i role="img" x-h-lucide data-lucide="settings"></i><span x-text="T('application-core:shell.nav.settings', 'Settings')"></span>
                 </button>
               </li>
             </ul>
@@ -155,19 +155,19 @@
           <div x-h-toolbar data-variant="transparent" x-cloak>
             <button x-show="hiddenPanels.left" x-h-button data-variant="transparent"
                     aria-label="Navigation" @click="openSideNav()" data-size="icon">
-              <i role="img" data-lucide="menu"></i>
+              <i role="img" x-h-lucide data-lucide="menu"></i>
             </button>
             <span x-h-toolbar-title x-text="T('application-core:shell.nav.applications', 'Applications')"></span>
             <div x-h-toolbar-spacer></div>
             <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.theme.toggle()"
                     :aria-label="$store.theme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'" title="Toggle theme">
-              <i x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></i>
-              <i x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></i>
+              <svg x-h-lucide x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></svg>
+              <svg x-h-lucide x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></svg>
             </button>
 
             <!-- Notifications: the bell shows the unread count; the popover lists them. -->
             <button x-h-button x-h-popover-trigger data-variant="transparent" data-size="icon-sm" aria-label="Notifications" class="relative">
-              <i role="img" data-lucide="bell"></i>
+              <i role="img" x-h-lucide data-lucide="bell"></i>
               <span x-show="$store.notifications.unreadCount > 0" class="absolute" x-text="$store.notifications.unreadCount"
                     style="right:-2px; bottom:-2px; min-width:15px; height:15px; padding:0 3px; border-radius:9999px; background:#e01b24; color:#fff; font-size:9px; line-height:15px; text-align:center; font-weight:700;"></span>
             </button>
@@ -176,7 +176,7 @@
                 <span x-h-toolbar-title class="shrink-0" x-text="T('application-core:shell.notifications.title', 'Notifications') + ' (' + $store.notifications.unreadCount + ')'"></span>
                 <div x-h-toolbar-spacer></div>
                 <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.notifications.markAllRead()"
-                        title="Mark all as read" aria-label="Mark all as read"><i role="img" data-lucide="check-check"></i></button>
+                        title="Mark all as read" aria-label="Mark all as read"><i role="img" x-h-lucide data-lucide="check-check"></i></button>
               </div>
               <div x-show="$store.notifications.items.length === 0" x-h-text.muted class="p-3 text-sm" x-text="T('application-core:shell.notifications.caughtUp', 'You\u2019re all caught up.')"></div>
               <ol x-show="$store.notifications.items.length" x-h-notification-list>
@@ -196,18 +196,18 @@
             <!-- Logged-in user: avatar; the dropdown shows the user name and Log out. -->
             <button x-h-button x-h-menu-trigger.dropdown data-variant="transparent" data-size="icon-sm"
                     :aria-label="$store.currentUser.name || 'Account'">
-              <i role="img" data-lucide="circle-user"></i>
+              <i role="img" x-h-lucide data-lucide="circle-user"></i>
             </button>
             <ul x-h-menu aria-label="User menu" data-align="bottom-end">
               <div x-h-tile class="mb-1">
-                <div x-h-tile-media><i role="img" data-lucide="circle-user" class="size-6"></i></div>
+                <div x-h-tile-media><i role="img" x-h-lucide data-lucide="circle-user" class="size-6"></i></div>
                 <div x-h-tile-content>
                   <div x-h-tile-title x-text="$store.currentUser.name || T('application-core:shell.user.user', 'User')"></div>
                 </div>
               </div>
               <div x-h-menu-separator></div>
               <li x-h-menu-item data-variant="negative" @click="$store.currentUser.logout()">
-                <i role="img" data-lucide="log-out"></i> <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
+                <i role="img" x-h-lucide data-lucide="log-out"></i> <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
               </li>
             </ul>
           </div>
@@ -328,10 +328,10 @@
 
     <!-- 4. Lucide icons -->
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
-    <script>
-      document.addEventListener('alpine:initialized', () => { if (window.lucide) window.lucide.createIcons(); }, { once: true });
-      document.addEventListener('pinecone:end', () => { if (window.lucide) window.lucide.createIcons(); });
-    </script>
+    <!-- opt-in Harmonia Lucide plugin: registers x-h-lucide (renders Lucide icons + keeps them in sync); needs window.lucide (above). -->
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
+    <!-- Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle above): it upgrades
+         icons on init and inside router-swapped views, so no manual createIcons scan is needed. -->
   </body>
 
 </html>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -391,6 +391,6 @@ document.addEventListener('alpine:init', () => {
 
     openSideNav() { this.isOpen = true; },
     closeSideNav() { if (window.matchMedia('(max-width: 1024px)').matches) this.isOpen = false; },
-    refreshIcons() { if (window.lucide && typeof window.lucide.createIcons === 'function') window.lucide.createIcons(); },
+    refreshIcons() {}, // no-op: Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle)
   }));
 }, { once: true });

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_dashboard.html
@@ -7,7 +7,7 @@
   x-data="app" scope, so it reads `navigate` / `refreshIcons` and the `reports` store directly.
   KPI-tile style mirrors the standalone per-app dashboard.
 -->
-<div class="vbox size-full overflow-auto" x-init="$nextTick(() => { if (window.lucide) window.lucide.createIcons(); })">
+<div class="vbox size-full overflow-auto">
   <div class="vbox gap-6 p-6">
     <div class="vbox gap-1">
       <h1 class="text-2xl font-bold" x-text="T('application-core:shell.nav.dashboard', 'Dashboard')"></h1>
@@ -21,10 +21,9 @@
     <!-- Key Indicators: report-attached KPI widgets (reports[].widget) aggregated from every published
          app. A count/value widget is a compact number tile; a list widget is a top-N mini table.
          Clicking a tile opens the full report. Values come from the shared reports store. -->
-    <div class="vbox gap-3" x-show="$store.reports.kpiReports().length > 0" x-cloak
-         x-effect="$store.reports.kpiReports().length; $nextTick(() => refreshIcons())">
+    <div class="vbox gap-3" x-show="$store.reports.kpiReports().length > 0" x-cloak>
       <div class="hbox items-center gap-2 text-xs font-bold uppercase text-muted-foreground">
-        <i role="img" data-lucide="gauge" class="size-4"></i><span x-text="T('application-core:shell.dashboard.kpis', 'Key Indicators')"></span>
+        <i role="img" x-h-lucide data-lucide="gauge" class="size-4"></i><span x-text="T('application-core:shell.dashboard.kpis', 'Key Indicators')"></span>
       </div>
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <template x-for="r in $store.reports.kpiReports()" :key="r.name">
@@ -34,7 +33,7 @@
                @keydown.enter.prevent="openReport(r)">
             <div x-h-card-header>
               <div class="hbox items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
-                <i role="img" :data-lucide="r.widget.icon" class="size-4"></i><span x-text="$store.reports.widgetLabel(r)"></span>
+                <i role="img" x-h-lucide :data-lucide="r.widget.icon" class="size-4"></i><span x-text="$store.reports.widgetLabel(r)"></span>
               </div>
             </div>
             <div x-h-card-content>
@@ -81,7 +80,7 @@
          above; the sidebar Reports section still lists them all). -->
     <div class="vbox gap-3" x-show="$store.reports.previewReports().length > 0" x-cloak>
       <div class="hbox items-center gap-2 text-xs font-bold uppercase text-muted-foreground">
-        <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="T('application-core:shell.nav.reports', 'Reports')"></span>
+        <i role="img" x-h-lucide data-lucide="bar-chart-3" class="size-4"></i><span x-text="T('application-core:shell.nav.reports', 'Reports')"></span>
       </div>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <template x-for="r in $store.reports.previewReports()" :key="r.url">
@@ -89,12 +88,12 @@
             <div x-h-card-header>
               <h3 x-h-card-title class="hbox items-center gap-2 cursor-pointer"
                   @click="openReport(r)">
-                <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="$store.reports.displayLabel(r)"></span>
+                <i role="img" x-h-lucide data-lucide="bar-chart-3" class="size-4"></i><span x-text="$store.reports.displayLabel(r)"></span>
               </h3>
               <div x-h-card-action>
                 <button x-h-button data-variant="transparent" data-size="icon-sm"
                         @click="openReport(r)" aria-label="Open report">
-                  <i role="img" data-lucide="arrow-up-right"></i>
+                  <i role="img" x-h-lucide data-lucide="arrow-up-right"></i>
                 </button>
               </div>
             </div>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
@@ -15,13 +15,13 @@
       <button x-h-button data-variant="outline" class="justify-start"
               :data-state="isSettingActive({ id: 'region-language' }) ? 'selected' : ''"
               @click="selectSetting({ id: 'region-language' })">
-        <i role="img" data-lucide="globe"></i>
+        <i role="img" x-h-lucide data-lucide="globe"></i>
         <span x-text="T('application-core:shell.settings.regionLanguage', 'Region & Language')"></span>
       </button>
       <template x-for="item in settingsItems" :key="item.id">
         <button x-h-button data-variant="outline" class="justify-start"
                 :data-state="isSettingActive(item) ? 'selected' : ''" @click="selectSetting(item)">
-          <i role="img" data-lucide="settings"></i>
+          <i role="img" x-h-lucide data-lucide="settings"></i>
           <span x-text="item.tkey ? T(item.tkey, item.label) : item.label"></span>
         </button>
       </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -103,8 +103,8 @@
               </template>
             </div>
           </div>
-          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> New ${property.relationshipEntityName}</button>
-          <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
+          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownControllerUrl}', '${property.relationshipEntityName}')"><i x-h-lucide data-lucide="plus" class="size-4"></i> New ${property.relationshipEntityName}</button>
+          <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
         <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
@@ -148,7 +148,7 @@
       <div x-h-toolbar data-variant="transparent">
         <span x-h-toolbar-title class="shrink-0" x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></span>
         <div x-h-toolbar-spacer></div>
-        <button type="button" x-h-button data-variant="primary" data-size="sm" x-show="!isPreview" @click="openRowDialog(null)"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
+        <button type="button" x-h-button data-variant="primary" data-size="sm" x-show="!isPreview" @click="openRowDialog(null)"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
       </div>
       <div x-show="itemsError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemsError"></div></div>
 
@@ -167,7 +167,7 @@
               </template>
               <td x-h-table-cell data-row-actions x-show="!isPreview" @click.stop>
                 <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions">
-                  <i role="img" data-lucide="ellipsis"></i>
+                  <i role="img" x-h-lucide data-lucide="ellipsis"></i>
                 </button>
                 <ul x-h-menu data-align="bottom-end">
                   <li x-h-menu-item @click="openRowDialog(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
@@ -210,7 +210,7 @@
         <div x-h-card-header>
           <h3 x-h-card-title x-text="T(d.tkey, d.label)"></h3>
           <div x-h-card-action x-show="masterId && !isPreview">
-            <button x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
+            <button x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
           </div>
         </div>
         <div x-h-card-content>
@@ -234,7 +234,7 @@
                       <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
                     </template>
                     <td x-h-table-cell data-row-actions x-show="!isPreview">
-                      <button x-h-button data-variant="transparent" data-size="sm" aria-label="Delete" @click="askDelete(row)"><i role="img" data-lucide="trash-2"></i></button>
+                      <button x-h-button data-variant="transparent" data-size="sm" aria-label="Delete" @click="askDelete(row)"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
                     </td>
                   </tr>
                 </template>
@@ -266,7 +266,7 @@
       <!-- Actionable BPM user-task buttons (edit only, hidden in read-only preview), left-aligned. -->
       <template x-for="task in $store.processTasks.getTasks(form)" :key="task.id">
         <button type="button" x-h-button data-variant="primary" x-show="!isPreview" @click="$store.processTasks.openTask(task)">
-          <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+          <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
         </button>
       </template>
 #end
@@ -276,12 +276,12 @@
            language when several exist. Stays available in preview (printing is read-only). -->
       <button type="button" x-h-button data-variant="outline" x-show="isEdit || isPreview" :disabled="printBusy" @click="openPrint()">
         <span x-show="printBusy" x-h-spinner></span>
-        <i role="img" data-lucide="printer" x-show="!printBusy"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+        <svg x-h-lucide role="img" data-lucide="printer" x-show="!printBusy"></svg><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
       </button>
 #if($duplicable)
       <!-- Built-in Duplicate action: clones this document (header + items) into a new draft and opens it. -->
       <button type="button" x-h-button data-variant="outline" x-show="isEdit || isPreview" :disabled="state === 'saving'" @click="duplicate()">
-        <i role="img" data-lucide="copy"></i><span x-text="T('$projectName:${tprefix}.defaults.duplicate', 'Duplicate')"></span>
+        <i role="img" x-h-lucide data-lucide="copy"></i><span x-text="T('$projectName:${tprefix}.defaults.duplicate', 'Duplicate')"></span>
       </button>
 #end
       <!-- Developer-contributed per-record actions for this document (customActions extension point).
@@ -294,12 +294,12 @@
       <!-- Preview footer: Close + Edit instead of Cancel + Save. -->
       <button type="button" x-h-button data-variant="transparent" x-show="isPreview" @click="backToList()" x-text="T('$projectName:${tprefix}.defaults.close', 'Close')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="isPreview" @click="goEdit()">
-        <i role="img" data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span>
+        <i role="img" x-h-lucide data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span>
       </button>
       <button type="button" x-h-button data-variant="transparent" x-show="!isPreview" @click="backToList()" :disabled="state === 'saving'" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="!isPreview" :disabled="state === 'saving'" @click="save()">
         <span x-show="state === 'saving'" x-h-spinner></span>
-        <i role="img" data-lucide="save" x-show="state !== 'saving'"></i><span x-text="isEdit ? T('$projectName:${tprefix}.defaults.update', 'Save') : T('$projectName:${tprefix}.defaults.create', 'Create')"></span>
+        <svg x-h-lucide role="img" data-lucide="save" x-show="state !== 'saving'"></svg><span x-text="isEdit ? T('$projectName:${tprefix}.defaults.update', 'Save') : T('$projectName:${tprefix}.defaults.create', 'Create')"></span>
       </button>
     </div>
     </div>
@@ -364,8 +364,8 @@
                   </div>
                   <!-- Non-setting association: Add new (opens the target's create page in a dialog) + Refresh. -->
                   <div class="hbox gap-1 mt-1" x-show="col.lookup && col.lookup.creatable && !col.readonly">
-                    <button type="button" x-h-button data-variant="outline" @click="addRelatedItem(col)"><i data-lucide="plus" class="size-4"></i> <span x-text="'New ' + (col.lookup && col.lookup.entity)"></span></button>
-                    <button type="button" x-h-button data-variant="transparent" aria-label="Refresh" @click="refreshItemOptions(col)"><i data-lucide="refresh-cw" class="size-4"></i></button>
+                    <button type="button" x-h-button data-variant="outline" @click="addRelatedItem(col)"><i x-h-lucide data-lucide="plus" class="size-4"></i> <span x-text="'New ' + (col.lookup && col.lookup.entity)"></span></button>
+                    <button type="button" x-h-button data-variant="transparent" aria-label="Refresh" @click="refreshItemOptions(col)"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
                   </div>
                 </div>
               </template>
@@ -425,7 +425,7 @@
         <div class="vbox gap-2">
           <template x-for="lang in printLanguages" :key="lang.code">
             <button type="button" x-h-button data-variant="outline" @click="printLangOpen = false; printDoc(lang.code)">
-              <i role="img" data-lucide="printer"></i><span x-text="lang.name"></span>
+              <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="lang.name"></span>
             </button>
           </template>
         </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
@@ -45,7 +45,7 @@
   <!-- Empty -->
   <div x-show="displayState === 'empty'" x-h-info-page class="p-4">
     <div x-h-info-page-header>
-      <div x-h-info-page-media.icon><i role="img" data-lucide="inbox"></i></div>
+      <div x-h-info-page-media.icon><i role="img" x-h-lucide data-lucide="inbox"></i></div>
       <div x-h-info-page-title x-text="T('$projectName:${tprefix}.messages.noDataYet', 'No ${name} yet', { name: T('$projectName:${tprefix}.t.${dataName}', '${name}') })"></div>
       <div x-h-info-page-description x-text="T('$projectName:${tprefix}.messages.noData', 'There is nothing to show here.')"></div>
     </div>
@@ -68,9 +68,9 @@
                 <th x-h-table-head scope="col" data-hoverable="true" data-activable="true"#if($property.isFloatType) class="text-right"#end @click="cycleSort('${property.name}')">
                   <div class="hbox items-center justify-between">
                     <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '${property.name}')"></span>
-                    <i role="img" data-lucide="arrow-up"      class="size-4" x-show="isSortedAsc('${property.name}')"></i>
-                    <i role="img" data-lucide="arrow-down"    class="size-4" x-show="isSortedDesc('${property.name}')"></i>
-                    <i role="img" data-lucide="arrow-up-down" class="size-4" x-show="isUnsorted('${property.name}')"></i>
+                    <svg x-h-lucide role="img" data-lucide="arrow-up"      class="size-4" x-show="isSortedAsc('${property.name}')"></svg>
+                    <svg x-h-lucide role="img" data-lucide="arrow-down"    class="size-4" x-show="isSortedDesc('${property.name}')"></svg>
+                    <svg x-h-lucide role="img" data-lucide="arrow-up-down" class="size-4" x-show="isUnsorted('${property.name}')"></svg>
                   </div>
                 </th>
 #end
@@ -103,9 +103,9 @@
         </div>
 
         <div class="hbox items-center gap-2 p-2" x-show="totalPages > 1">
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage <= 1" @click="goPage(currentPage - 1)"><i role="img" data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage <= 1" @click="goPage(currentPage - 1)"><i role="img" x-h-lucide data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
           <span x-h-text.muted x-text="'Page ' + currentPage + ' / ' + totalPages"></span>
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage >= totalPages" @click="goPage(currentPage + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" data-lucide="chevron-right"></i></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage >= totalPages" @click="goPage(currentPage + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" x-h-lucide data-lucide="chevron-right"></i></button>
         </div>
       </div>
     </div>
@@ -131,7 +131,7 @@
         <div x-show="$store.processTasks.getTasks(selected).length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
           <template x-for="task in $store.processTasks.getTasks(selected)" :key="task.id">
             <button x-h-button data-variant="primary" data-size="sm" @click="$store.processTasks.openTask(task)">
-              <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+              <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
             </button>
           </template>
         </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -109,8 +109,8 @@
               </template>
             </div>
           </div>
-          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownAppUrl}', '${property.relationshipEntityName}')"><i data-lucide="plus" class="size-4"></i> <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>&nbsp;<span x-text="T('$projectName:${tprefix}.t.${property.relationshipEntityName}', '${property.relationshipEntityName}')"></span></button>
-          <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i data-lucide="refresh-cw" class="size-4"></i></button>
+          <button type="button" x-h-button data-variant="outline" class="shrink-0" x-show="!isPreview" @click="addRelated('${property.name}', '${property.widgetDropdownAppUrl}', '${property.relationshipEntityName}')"><i x-h-lucide data-lucide="plus" class="size-4"></i> <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>&nbsp;<span x-text="T('$projectName:${tprefix}.t.${property.relationshipEntityName}', '${property.relationshipEntityName}')"></span></button>
+          <button type="button" x-h-button data-variant="transparent" class="shrink-0" x-show="!isPreview" aria-label="Refresh" @click="loadOptions()"><i x-h-lucide data-lucide="refresh-cw" class="size-4"></i></button>
         </div>
 #else
         <div x-h-select data-filter="contains"#if($readonly) data-disabled="true"#else :data-disabled="isPreview"#end>
@@ -190,7 +190,7 @@
           <div x-h-card-header>
             <h3 x-h-card-title x-text="d.label"></h3>
             <div x-h-card-action x-show="!isPreview">
-              <button type="button" x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
+              <button type="button" x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
             </div>
           </div>
           <div x-h-card-content>
@@ -214,7 +214,7 @@
                         <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
                       </template>
                       <td x-h-table-cell data-row-actions x-show="!isPreview">
-                        <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" data-lucide="ellipsis"></i></button>
+                        <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" x-h-lucide data-lucide="ellipsis"></i></button>
                         <ul x-h-menu data-align="bottom-end">
                           <li x-h-menu-item @click="previewRow(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
                           <li x-h-menu-item @click="editRow(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
@@ -255,7 +255,7 @@
       <!-- Actionable BPM user-task buttons (edit only, hidden in read-only preview), left-aligned. -->
       <template x-for="task in $store.processTasks.getTasks(form)" :key="task.id">
         <button type="button" x-h-button data-variant="primary" x-show="!isPreview" @click="$store.processTasks.openTask(task)">
-          <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+          <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
         </button>
       </template>
 #end
@@ -263,12 +263,12 @@
       <!-- Preview footer: Close + Edit instead of Cancel + Save. -->
       <button type="button" x-h-button data-variant="transparent" x-show="isPreview" @click="cancel()" x-text="T('$projectName:${tprefix}.defaults.close', 'Close')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="isPreview" @click="goEdit()">
-        <i role="img" data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span>
+        <i role="img" x-h-lucide data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span>
       </button>
       <button type="button" x-h-button data-variant="transparent" x-show="!isPreview" @click="cancel()" :disabled="state === 'saving'" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="!isPreview" :disabled="state === 'saving'" @click="save()">
         <span x-show="state === 'saving'" x-h-spinner></span>
-        <i role="img" data-lucide="save" x-show="state !== 'saving'"></i><span x-text="isEdit ? T('$projectName:${tprefix}.defaults.update', 'Save') : T('$projectName:${tprefix}.defaults.create', 'Create')"></span>
+        <svg x-h-lucide role="img" data-lucide="save" x-show="state !== 'saving'"></svg><span x-text="isEdit ? T('$projectName:${tprefix}.defaults.update', 'Save') : T('$projectName:${tprefix}.defaults.create', 'Create')"></span>
       </button>
     </div>
     </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -16,7 +16,7 @@
       </div>
     </div>
     <button x-h-button data-variant="primary" @click="newEntity()">
-      <i role="img" data-lucide="plus"></i>
+      <i role="img" x-h-lucide data-lucide="plus"></i>
       <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>
     </button>
     <!-- Developer-contributed page actions for this view (customActions extension point). -->
@@ -45,7 +45,7 @@
   <!-- Empty -->
   <div x-show="displayState === 'empty'" x-h-info-page class="p-4">
     <div x-h-info-page-header>
-      <div x-h-info-page-media.icon><i role="img" data-lucide="inbox"></i></div>
+      <div x-h-info-page-media.icon><i role="img" x-h-lucide data-lucide="inbox"></i></div>
       <div x-h-info-page-title x-text="T('$projectName:${tprefix}.messages.noDataYet', 'No ${menuLabel} yet', { name: T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}') })"></div>
       <div x-h-info-page-description x-text="T('$projectName:${tprefix}.messages.getStarted', 'Get started by creating the first record.')"></div>
     </div>
@@ -71,9 +71,9 @@
                 <th x-h-table-head scope="col" data-hoverable="true" data-activable="true"#if($property.isNumberType && $property.widgetType != "DROPDOWN" && $property.widgetType != "DOCUMENT_STATUS") class="text-right"#end @click="cycleSort('${property.name}')">
                   <div class="hbox items-center justify-between">
                     <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '${property.name}')"></span>
-                    <i role="img" data-lucide="arrow-up"      class="size-4" x-show="isSortedAsc('${property.name}')"></i>
-                    <i role="img" data-lucide="arrow-down"    class="size-4" x-show="isSortedDesc('${property.name}')"></i>
-                    <i role="img" data-lucide="arrow-up-down" class="size-4" x-show="isUnsorted('${property.name}')"></i>
+                    <svg x-h-lucide role="img" data-lucide="arrow-up"      class="size-4" x-show="isSortedAsc('${property.name}')"></svg>
+                    <svg x-h-lucide role="img" data-lucide="arrow-down"    class="size-4" x-show="isSortedDesc('${property.name}')"></svg>
+                    <svg x-h-lucide role="img" data-lucide="arrow-up-down" class="size-4" x-show="isUnsorted('${property.name}')"></svg>
                   </div>
                 </th>
 #end
@@ -102,7 +102,7 @@
                 <th x-h-table-head scope="col" class="text-center">
                   <button type="button" x-show="hasActiveColumnFilters" @click="clearColumnFilters()"
                           :title="T('$projectName:${tprefix}.defaults.clearFilters', 'Clear filters')" class="text-muted-foreground hover:text-foreground">
-                    <i role="img" data-lucide="filter-x" class="size-4"></i>
+                    <i role="img" x-h-lucide data-lucide="filter-x" class="size-4"></i>
                   </button>
                 </th>
               </tr>
@@ -130,7 +130,7 @@
 #end
                   <td x-h-table-cell data-row-actions @click.stop>
                     <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions">
-                      <i role="img" data-lucide="ellipsis"></i>
+                      <i role="img" x-h-lucide data-lucide="ellipsis"></i>
                     </button>
                     <ul x-h-menu data-align="bottom-end">
                       <li x-h-menu-item @click="previewEntity(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
@@ -146,9 +146,9 @@
         </div>
 
         <div class="hbox items-center gap-2 p-2" x-show="totalPages > 1">
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage <= 1" @click="goPage(currentPage - 1)"><i role="img" data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage <= 1" @click="goPage(currentPage - 1)"><i role="img" x-h-lucide data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
           <span x-h-text.muted x-text="'Page ' + currentPage + ' / ' + totalPages"></span>
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage >= totalPages" @click="goPage(currentPage + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" data-lucide="chevron-right"></i></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="currentPage >= totalPages" @click="goPage(currentPage + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" x-h-lucide data-lucide="chevron-right"></i></button>
         </div>
       </div>
     </div>
@@ -168,9 +168,9 @@
         <div x-h-toolbar data-variant="transparent" data-size="sm">
           <span x-h-toolbar-title class="shrink-0" x-text="T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}') + ' #' + selectedId"></span>
           <div x-h-toolbar-spacer></div>
-          <button x-h-button data-variant="outline" data-size="sm" @click="previewEntity(selected)"><i role="img" data-lucide="eye"></i><span x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></span></button>
-          <button x-h-button data-variant="outline" data-size="sm" @click="editEntity(selected)"><i role="img" data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span></button>
-          <button x-h-button data-variant="transparent" data-size="sm" @click="askDelete(selected)" aria-label="Delete"><i role="img" data-lucide="trash-2"></i></button>
+          <button x-h-button data-variant="outline" data-size="sm" @click="previewEntity(selected)"><i role="img" x-h-lucide data-lucide="eye"></i><span x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></span></button>
+          <button x-h-button data-variant="outline" data-size="sm" @click="editEntity(selected)"><i role="img" x-h-lucide data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span></button>
+          <button x-h-button data-variant="transparent" data-size="sm" @click="askDelete(selected)" aria-label="Delete"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
         </div>
 
 #if($hasProcess)
@@ -178,7 +178,7 @@
         <div x-show="$store.processTasks.getTasks(selected).length" class="hbox gap-2 flex-wrap px-4 pt-4 pb-2">
           <template x-for="task in $store.processTasks.getTasks(selected)" :key="task.id">
             <button x-h-button data-variant="primary" data-size="sm" @click="$store.processTasks.openTask(task)">
-              <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+              <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
             </button>
           </template>
         </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -13,7 +13,7 @@
       <input x-h-input.group type="text" :placeholder="T('$projectName:${tprefix}.messages.inputSearch', 'Search ${name}...', { name: T('$projectName:${tprefix}.t.${dataName}', '${name}') })" x-model="searchTerm" @input="page = 1; refreshIcons()" />
       <div x-h-input-group-addon data-align="inline-start"><svg x-h-icon data-icon="search" class="size-4" role="img" aria-label="search"></svg></div>
     </div>
-    <button x-h-button data-variant="primary" @click="newMaster()"><i role="img" data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span></button>
+    <button x-h-button data-variant="primary" @click="newMaster()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span></button>
     <!-- Developer-contributed page actions for this view (customActions extension point). -->
     <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
       <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">
@@ -63,7 +63,7 @@
 #end
 #end
                 <td x-h-table-cell data-row-actions @click.stop>
-                  <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" data-lucide="ellipsis"></i></button>
+                  <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" x-h-lucide data-lucide="ellipsis"></i></button>
                   <ul x-h-menu data-align="bottom-end">
                     <li x-h-menu-item @click="previewMaster(row)" x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></li>
                     <li x-h-menu-item @click="editMaster(row)" x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></li>
@@ -77,9 +77,9 @@
         </table>
       </div>
       <div class="hbox items-center gap-2 p-2" x-show="(state === 'default' || state === 'empty') && pageCount > 1">
-        <button x-h-button data-variant="outline" data-size="sm" :disabled="page <= 1" @click="goPage(page - 1)"><i role="img" data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
+        <button x-h-button data-variant="outline" data-size="sm" :disabled="page <= 1" @click="goPage(page - 1)"><i role="img" x-h-lucide data-lucide="chevron-left"></i><span x-text="T('$projectName:${tprefix}.defaults.previous', 'Prev')"></span></button>
         <span x-h-text.muted x-text="'Page ' + page + ' / ' + pageCount"></span>
-        <button x-h-button data-variant="outline" data-size="sm" :disabled="page >= pageCount" @click="goPage(page + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" data-lucide="chevron-right"></i></button>
+        <button x-h-button data-variant="outline" data-size="sm" :disabled="page >= pageCount" @click="goPage(page + 1)"><span x-text="T('$projectName:${tprefix}.defaults.next', 'Next')"></span><i role="img" x-h-lucide data-lucide="chevron-right"></i></button>
       </div>
     </div>
 
@@ -97,9 +97,9 @@
         <div x-h-toolbar data-variant="transparent" data-size="sm">
           <span x-h-toolbar-title class="shrink-0" x-text="T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}') + ' #' + selectedId"></span>
           <div x-h-toolbar-spacer></div>
-          <button x-h-button data-variant="outline" data-size="sm" @click="previewMaster(selected)"><i role="img" data-lucide="eye"></i><span x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></span></button>
-          <button x-h-button data-variant="outline" data-size="sm" @click="editMaster(selected)"><i role="img" data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span></button>
-          <button x-h-button data-variant="transparent" data-size="sm" @click="askDelete(selected)" aria-label="Delete"><i role="img" data-lucide="trash-2"></i></button>
+          <button x-h-button data-variant="outline" data-size="sm" @click="previewMaster(selected)"><i role="img" x-h-lucide data-lucide="eye"></i><span x-text="T('$projectName:${tprefix}.defaults.preview', 'Preview')"></span></button>
+          <button x-h-button data-variant="outline" data-size="sm" @click="editMaster(selected)"><i role="img" x-h-lucide data-lucide="pencil"></i><span x-text="T('$projectName:${tprefix}.defaults.edit', 'Edit')"></span></button>
+          <button x-h-button data-variant="transparent" data-size="sm" @click="askDelete(selected)" aria-label="Delete"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
         </div>
 
 #if($hasProcess)
@@ -107,7 +107,7 @@
         <div x-show="$store.processTasks.getTasks(selected).length" class="hbox gap-2 flex-wrap">
           <template x-for="task in $store.processTasks.getTasks(selected)" :key="task.id">
             <button x-h-button data-variant="primary" data-size="sm" @click="$store.processTasks.openTask(task)">
-              <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+              <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
             </button>
           </template>
         </div>
@@ -189,10 +189,10 @@
                         <td x-h-table-cell data-row-actions>
                           <template x-for="task in $store.processTasks.getTasks(row)" :key="task.id">
                             <button x-h-button data-variant="primary" data-size="sm" @click="$store.processTasks.openTask(task)">
-                              <i role="img" data-lucide="inbox"></i><span x-text="task.name"></span>
+                              <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="task.name"></span>
                             </button>
                           </template>
-                          <button x-h-button data-variant="transparent" data-size="sm" aria-label="Preview" @click="previewRow(row)"><i role="img" data-lucide="eye"></i></button>
+                          <button x-h-button data-variant="transparent" data-size="sm" aria-label="Preview" @click="previewRow(row)"><i role="img" x-h-lucide data-lucide="eye"></i></button>
                         </td>
                       </tr>
                     </template>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
@@ -29,17 +29,18 @@
         <div x-h-toolbar-spacer></div>
 #if($chart)
         <button x-h-button data-variant="outline" data-size="sm" @click="toggleView()">
-          <i role="img" :data-lucide="view === 'chart' ? 'table-2' : 'bar-chart-3'"></i>
+          <svg x-h-lucide role="img" data-lucide="table-2" x-show="view === 'chart'"></svg>
+          <svg x-h-lucide role="img" data-lucide="bar-chart-3" x-show="view !== 'chart'"></svg>
           <span x-text="view === 'chart' ? 'Table' : 'Chart'"></span>
         </button>
 #end
         <button x-h-button data-variant="outline" data-size="sm" @click="showFilters = !showFilters; refreshIcons()">
-          <i role="img" data-lucide="filter"></i><span>Filters</span>
+          <i role="img" x-h-lucide data-lucide="filter"></i><span>Filters</span>
           <span x-show="activeFilterCount > 0" x-h-badge data-variant="information" x-text="activeFilterCount"></span>
         </button>
-        <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" data-lucide="refresh-cw"></i><span>Refresh</span></button>
-        <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" data-lucide="download"></i><span>Export</span></button>
-        <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" data-lucide="printer"></i><span>Print</span></button>
+        <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span>Refresh</span></button>
+        <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" x-h-lucide data-lucide="download"></i><span>Export</span></button>
+        <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" x-h-lucide data-lucide="printer"></i><span>Print</span></button>
       </div>
 
       <!-- Per-column filters, typed from the report metadata: date -> range, number -> range,
@@ -82,8 +83,8 @@
             </template>
           </div>
           <div class="hbox gap-2">
-            <button x-h-button data-size="sm" @click="applyFilters()"><i role="img" data-lucide="check"></i><span>Apply</span></button>
-            <button x-h-button data-variant="outline" data-size="sm" @click="clearFilters()"><i role="img" data-lucide="x"></i><span>Clear</span></button>
+            <button x-h-button data-size="sm" @click="applyFilters()"><i role="img" x-h-lucide data-lucide="check"></i><span>Apply</span></button>
+            <button x-h-button data-variant="outline" data-size="sm" @click="clearFilters()"><i role="img" x-h-lucide data-lucide="x"></i><span>Clear</span></button>
           </div>
         </div>
       </div>
@@ -124,9 +125,9 @@
         </div>
 
         <div x-show="!preview" class="hbox items-center gap-2">
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="page <= 1" @click="prev()"><i role="img" data-lucide="chevron-left"></i><span>Prev</span></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="page <= 1" @click="prev()"><i role="img" x-h-lucide data-lucide="chevron-left"></i><span>Prev</span></button>
           <span x-h-text.muted x-text="'Page ' + page + ' / ' + totalPages"></span>
-          <button x-h-button data-variant="outline" data-size="sm" :disabled="page >= totalPages" @click="next()"><span>Next</span><i role="img" data-lucide="chevron-right"></i></button>
+          <button x-h-button data-variant="outline" data-size="sm" :disabled="page >= totalPages" @click="next()"><span>Next</span><i role="img" x-h-lucide data-lucide="chevron-right"></i></button>
         </div>
 #if($chart)
         </div>
@@ -144,10 +145,9 @@
     <script defer src="/webjars/alpinejs/dist/cdn.min.js"></script>
     <script src="/webjars/codbex__harmonia/dist/harmonia.min.js"></script>
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
-    <script>
-      document.addEventListener('alpine:initialized', () => { if (window.lucide) window.lucide.createIcons(); }, { once: true });
-      // Cross-frame / cross-tab colour-scheme sync is handled by Harmonia itself (harmonia.min.js
-      // registers its own `storage` listener and re-applies codbex.harmonia.colorMode without re-persisting).
-    </script>
+    <!-- opt-in Harmonia Lucide plugin: registers x-h-lucide (renders Lucide icons + keeps them in sync); needs window.lucide (above). -->
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
+    <!-- Lucide icons render via x-h-lucide (harmonia-lucide bundle above). Cross-frame/tab colour-scheme
+         sync is handled by Harmonia itself (its own storage listener), so no extra script is needed. -->
   </body>
 </html>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/index.html.template
@@ -146,18 +146,8 @@
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
     <script>
       document.addEventListener('alpine:initialized', () => { if (window.lucide) window.lucide.createIcons(); }, { once: true });
-      // Re-apply the colour scheme when the shell (parent window) switches theme. Harmonia applies the
-      // shared localStorage key only at load; the `storage` event fires in this iframe when the parent
-      // changes it, so without this the embedded report (e.g. a dashboard tile) stays on the old theme
-      // until a full refresh. (Can't gate on Harmonia.getColorScheme() — it reads the same key, which
-      // already holds the new value — so track the last applied scheme to re-apply once and avoid loops.)
-      var __harmoniaScheme = null;
-      window.addEventListener('storage', (e) => {
-        if (e.key === 'codbex.harmonia.colorMode' && window.Harmonia) {
-          const scheme = e.newValue || 'light';
-          if (scheme !== __harmoniaScheme) { __harmoniaScheme = scheme; Harmonia.setColorScheme(scheme); }
-        }
-      });
+      // Cross-frame / cross-tab colour-scheme sync is handled by Harmonia itself (harmonia.min.js
+      // registers its own `storage` listener and re-applies codbex.harmonia.colorMode without re-persisting).
     </script>
   </body>
 </html>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report-file/report.js.template
@@ -280,8 +280,6 @@ document.addEventListener('alpine:init', () => {
       }
     },
 
-    refreshIcons() {
-      this.${dollar}nextTick(() => { if (window.lucide && window.lucide.createIcons) window.lucide.createIcons(); });
-    },
+    refreshIcons() {}, // no-op: Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle)
   }));
 }, { once: true });

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/chart-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/chart-view.html.template
@@ -3,8 +3,8 @@
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title>${name}</span>
     <div x-h-toolbar-spacer></div>
-    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" data-lucide="refresh-cw"></i><span>Refresh</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="printChart()"><i role="img" data-lucide="printer"></i><span>Print</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span>Refresh</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="printChart()"><i role="img" x-h-lucide data-lucide="printer"></i><span>Print</span></button>
   </div>
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
   <div x-show="state === 'error'" x-h-alert data-variant="negative" role="alert" class="m-4"><div x-h-alert-description x-text="error"></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-view.html.template
@@ -3,9 +3,9 @@
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title>${name}</span>
     <div x-h-toolbar-spacer></div>
-    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" data-lucide="refresh-cw"></i><span>Refresh</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" data-lucide="download"></i><span>Export</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" data-lucide="printer"></i><span>Print</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span>Refresh</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" x-h-lucide data-lucide="download"></i><span>Export</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" x-h-lucide data-lucide="printer"></i><span>Print</span></button>
   </div>
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
   <div x-show="state === 'error'" x-h-alert data-variant="negative" role="alert" class="m-4"><div x-h-alert-description x-text="error"></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/dashboard.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/dashboard.html.template
@@ -12,14 +12,14 @@
          tile opens the full report. -->
     <div class="vbox gap-3" x-show="kpis.length > 0 || customKpis.length > 0" x-cloak>
       <div class="hbox items-center gap-2 text-xs font-bold uppercase text-muted-foreground">
-        <i role="img" data-lucide="gauge" class="size-4"></i><span x-text="T('application-core:shell.dashboard.kpis', 'Key Indicators')"></span>
+        <i role="img" x-h-lucide data-lucide="gauge" class="size-4"></i><span x-text="T('application-core:shell.dashboard.kpis', 'Key Indicators')"></span>
       </div>
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <template x-for="w in customKpis" :key="w.name">
           <div x-h-card>
             <div x-h-card-header>
               <div class="hbox items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
-                <i role="img" :data-lucide="w.icon" class="size-4"></i><span x-text="T(w.tkey, w.label)"></span>
+                <i role="img" x-h-lucide :data-lucide="w.icon" class="size-4"></i><span x-text="T(w.tkey, w.label)"></span>
               </div>
             </div>
             <div x-h-card-content>
@@ -36,7 +36,7 @@
                @click="openReport(r)" @keydown.enter.prevent="openReport(r)">
             <div x-h-card-header>
               <div class="hbox items-center gap-2 text-xs font-semibold uppercase text-muted-foreground">
-                <i role="img" :data-lucide="r.widget.icon" class="size-4"></i><span x-text="$store.reports.widgetLabel(r)"></span>
+                <i role="img" x-h-lucide :data-lucide="r.widget.icon" class="size-4"></i><span x-text="$store.reports.widgetLabel(r)"></span>
               </div>
             </div>
             <div x-h-card-content>
@@ -87,7 +87,7 @@
           <div x-h-card>
             <div x-h-card-header>
               <h3 x-h-card-title class="hbox items-center gap-2">
-                <i role="img" :data-lucide="w.icon" class="size-4"></i><span x-text="T(w.tkey, w.label)"></span>
+                <i role="img" x-h-lucide :data-lucide="w.icon" class="size-4"></i><span x-text="T(w.tkey, w.label)"></span>
               </h3>
             </div>
             <div x-h-card-content class="vbox gap-2">
@@ -103,18 +103,18 @@
     <!-- Reports -->
     <div class="vbox gap-3" x-show="reports.length > 0" x-cloak>
       <div class="hbox items-center gap-2 text-xs font-bold uppercase text-muted-foreground">
-        <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="T('application-core:shell.nav.reports', 'Reports')"></span>
+        <i role="img" x-h-lucide data-lucide="bar-chart-3" class="size-4"></i><span x-text="T('application-core:shell.nav.reports', 'Reports')"></span>
       </div>
       <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <template x-for="r in reports" :key="r.url">
           <div x-h-card>
             <div x-h-card-header>
               <h3 x-h-card-title class="hbox items-center gap-2 cursor-pointer" @click="openReport(r)">
-                <i role="img" data-lucide="bar-chart-3" class="size-4"></i><span x-text="$store.reports.displayLabel(r)"></span>
+                <i role="img" x-h-lucide data-lucide="bar-chart-3" class="size-4"></i><span x-text="$store.reports.displayLabel(r)"></span>
               </h3>
               <div x-h-card-action>
                 <button x-h-button data-variant="transparent" data-size="icon-sm" @click="openReport(r)" aria-label="Open report">
-                  <i role="img" data-lucide="arrow-up-right"></i>
+                  <i role="img" x-h-lucide data-lucide="arrow-up-right"></i>
                 </button>
               </div>
             </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -64,7 +64,7 @@
 #if($appIcon.contains("/") || $appIcon.contains("."))
               <img src="${appIcon}" alt="${appTitle}" class="size-5" />
 #else
-              <i role="img" data-lucide="${appIcon}" class="size-5 text-primary"></i>
+              <i role="img" x-h-lucide data-lucide="${appIcon}" class="size-5 text-primary"></i>
 #end
               <span class="font-bold"#if($appDescription && $appDescription != '') title="${appDescription}"#end>${appTitle}</span>
             </div>
@@ -77,17 +77,17 @@
                 <ul x-h-sidebar-menu>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isDashboard" @click="navigate('/dashboard')">
-                      <i role="img" data-lucide="layout-dashboard"></i><span x-text="T('application-core:shell.nav.dashboard', 'Dashboard')"></span>
+                      <i role="img" x-h-lucide data-lucide="layout-dashboard"></i><span x-text="T('application-core:shell.nav.dashboard', 'Dashboard')"></span>
                     </button>
                   </li>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isActive('/inbox')" @click="navigate('/inbox')">
-                      <i role="img" data-lucide="inbox"></i><span x-text="T('application-core:shell.nav.inbox', 'Inbox')"></span>
+                      <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="T('application-core:shell.nav.inbox', 'Inbox')"></span>
                     </button>
                   </li>
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isActive('/documents')" @click="navigate('/documents')">
-                      <i role="img" data-lucide="folder"></i><span x-text="T('application-core:shell.nav.documents', 'Documents')"></span>
+                      <i role="img" x-h-lucide data-lucide="folder"></i><span x-text="T('application-core:shell.nav.documents', 'Documents')"></span>
                     </button>
                   </li>
                 </ul>
@@ -105,7 +105,7 @@
 #if(($entity.layoutType == "LIST" || $entity.layoutType == "MANAGE" || $entity.layoutType == "LIST_MASTER" || $entity.layoutType == "MANAGE_MASTER" || $entity.layoutType == "MANAGE_DOCUMENT") && $entity.type == "PRIMARY")
                   <li x-h-sidebar-menu-item>
                     <button x-h-sidebar-menu-button :data-active="isActive('/${entity.name}')" @click="navigate('/${entity.name}')">
-                      <i role="img" data-lucide="#if($entity.iconName && $entity.iconName != '')${entity.iconName}#{else}list#end"></i>
+                      <i role="img" x-h-lucide data-lucide="#if($entity.iconName && $entity.iconName != '')${entity.iconName}#{else}list#end"></i>
                       <span x-text="T('$projectName:${tprefix}.t.${entity.dataName}_plural', navLabel('#if($entity.menuLabel && $entity.menuLabel != '')${entity.menuLabel}#{else}${entity.name}#end'))"></span>
                     </button>
                   </li>
@@ -126,7 +126,7 @@
                   <template x-for="r in $store.reports.items" :key="r.url">
                     <li x-h-sidebar-menu-item>
                       <button x-h-sidebar-menu-button :data-active="isActive('/reports') && $store.reports.selected && $store.reports.selected.url === r.url" @click="$store.reports.selected = r; navigate('/reports')">
-                        <i role="img" data-lucide="bar-chart-3"></i><span x-text="${dollar}store.reports.displayLabel(r)"></span>
+                        <i role="img" x-h-lucide data-lucide="bar-chart-3"></i><span x-text="${dollar}store.reports.displayLabel(r)"></span>
                       </button>
                     </li>
                   </template>
@@ -142,7 +142,7 @@
             <ul x-h-sidebar-menu>
               <li x-h-sidebar-menu-item>
                 <button x-h-sidebar-menu-button :data-active="isActive('/settings')" @click="navigate('/settings')">
-                  <i role="img" data-lucide="settings"></i><span x-text="T('application-core:shell.nav.settings', 'Settings')"></span>
+                  <i role="img" x-h-lucide data-lucide="settings"></i><span x-text="T('application-core:shell.nav.settings', 'Settings')"></span>
                 </button>
               </li>
             </ul>
@@ -159,7 +159,7 @@
           <div x-h-toolbar data-variant="transparent" x-cloak x-show="!embedded">
             <button x-show="hiddenPanels.left && !embedded" x-h-button data-variant="transparent"
                     aria-label="Navigation" @click="openSideNav()" data-size="icon">
-              <i role="img" data-lucide="menu"></i>
+              <i role="img" x-h-lucide data-lucide="menu"></i>
             </button>
             <nav x-h-breadcrumb data-overflow="scroll"
                  :data-variant="hiddenPanels.left ? 'outline' : 'default'" data-size="md">
@@ -187,14 +187,14 @@
                  load harmonia.min.js — honours the same choice. -->
             <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.theme.toggle()"
                     :aria-label="$store.theme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'" title="Toggle theme">
-              <i x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></i>
-              <i x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></i>
+              <svg x-h-lucide x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></svg>
+              <svg x-h-lucide x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></svg>
             </button>
 
             <!-- Notifications: the bell shows the unread count (absolutely positioned so the count
                  pill never widens the button into its neighbours); the popover lists them. -->
             <button x-h-button x-h-popover-trigger data-variant="transparent" data-size="icon-sm" aria-label="Notifications" class="relative">
-              <i role="img" data-lucide="bell"></i>
+              <i role="img" x-h-lucide data-lucide="bell"></i>
               <!-- Small count badge tucked into the bell's bottom-right corner (doesn't cover the icon). -->
               <span x-show="$store.notifications.unreadCount > 0" class="absolute" x-text="$store.notifications.unreadCount"
                     style="right:-2px; bottom:-2px; min-width:15px; height:15px; padding:0 3px; border-radius:9999px; background:#e01b24; color:#fff; font-size:9px; line-height:15px; text-align:center; font-weight:700;"></span>
@@ -204,7 +204,7 @@
                 <span x-h-toolbar-title class="shrink-0" x-text="T('application-core:shell.notifications.title', 'Notifications') + ' (' + $store.notifications.unreadCount + ')'"></span>
                 <div x-h-toolbar-spacer></div>
                 <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.notifications.markAllRead()"
-                        title="Mark all as read" aria-label="Mark all as read"><i role="img" data-lucide="check-check"></i></button>
+                        title="Mark all as read" aria-label="Mark all as read"><i role="img" x-h-lucide data-lucide="check-check"></i></button>
               </div>
               <div x-show="$store.notifications.items.length === 0" x-h-text.muted class="p-3 text-sm" x-text="T('application-core:shell.notifications.caughtUp', 'You\u2019re all caught up.')"></div>
               <ol x-show="$store.notifications.items.length" x-h-notification-list>
@@ -224,18 +224,18 @@
             <!-- Logged-in user: a Lucide avatar; the dropdown shows the user name and Log out. -->
             <button x-h-button x-h-menu-trigger.dropdown data-variant="transparent" data-size="icon-sm"
                     :aria-label="$store.currentUser.name || 'Account'">
-              <i role="img" data-lucide="circle-user"></i>
+              <i role="img" x-h-lucide data-lucide="circle-user"></i>
             </button>
             <ul x-h-menu aria-label="User menu" data-align="bottom-end">
               <div x-h-tile class="mb-1">
-                <div x-h-tile-media><i role="img" data-lucide="circle-user" class="size-6"></i></div>
+                <div x-h-tile-media><i role="img" x-h-lucide data-lucide="circle-user" class="size-6"></i></div>
                 <div x-h-tile-content>
                   <div x-h-tile-title x-text="$store.currentUser.name || T('application-core:shell.user.user', 'User')"></div>
                 </div>
               </div>
               <div x-h-menu-separator></div>
               <li x-h-menu-item data-variant="negative" @click="$store.currentUser.logout()">
-                <i role="img" data-lucide="log-out"></i> <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
+                <i role="img" x-h-lucide data-lucide="log-out"></i> <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
               </li>
             </ul>
           </div>
@@ -458,16 +458,12 @@
 
     <!-- 4. Lucide icons (webjar) -->
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
+    <!-- opt-in Harmonia Lucide plugin: registers x-h-lucide (renders Lucide icons + keeps them in sync); needs window.lucide (above). -->
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
     <!-- 5. Chart.js (webjar) — used by REPORT_BAR/LINE/PIE/... chart pages -->
     <script src="/webjars/chart.js/dist/chart.umd.js"></script>
-    <script>
-      document.addEventListener('alpine:initialized', () => {
-        if (window.lucide) window.lucide.createIcons();
-      }, { once: true });
-      document.addEventListener('pinecone:end', () => {
-        if (window.lucide) window.lucide.createIcons();
-      });
-    </script>
+    <!-- Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle above): it upgrades
+         icons on init and inside router-swapped views, so no manual createIcons scan is needed. -->
 
     <!-- Add-related dialog: an FK combobox's "Add" button (see the entity forms) opens the target
          entity's OWN generated create page in this iframe (App.utils.relatedCreateUrl, cross-model

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -486,21 +486,9 @@
       </div>
     </div>
 
-    <!-- React to a theme switch from the parent window: when this shell is embedded in an iframe (the
-         application shell, or an FK "Add new" dialog) and the parent flips the shared colour-scheme key,
-         the `storage` event fires here; re-apply it (Harmonia reads the key only at load), so every
-         routed view (list / manage / master-detail / document) follows the parent's light/dark switch.
-         Track the last applied scheme rather than gating on Harmonia.getColorScheme(), which already
-         holds the new value (gating there would always skip and nothing would re-apply). -->
-    <script>
-      var __harmoniaScheme = null;
-      window.addEventListener('storage', (e) => {
-        if (e.key === 'codbex.harmonia.colorMode' && window.Harmonia) {
-          const scheme = e.newValue || 'light';
-          if (scheme !== __harmoniaScheme) { __harmoniaScheme = scheme; Harmonia.setColorScheme(scheme); }
-        }
-      });
-    </script>
+    <!-- Cross-frame / cross-tab colour-scheme sync is handled by Harmonia itself: harmonia.min.js
+         registers its own `storage` listener and re-applies the shared `codbex.harmonia.colorMode`
+         key (without re-persisting) whenever the parent shell or another tab flips the theme. -->
   </body>
 
 </html>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/settings.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/settings.html.template
@@ -57,7 +57,7 @@
         <button x-h-button data-variant="outline" class="justify-start"
                 :data-state="selected === '${entity.name}' ? 'selected' : ''"
                 @click="select('${entity.name}', './views/${entity.perspectiveName}/${entity.name}-manage-list.html')">
-          <i role="img" data-lucide="settings"></i><span x-text="T('$projectName:${tprefix}.t.${entity.dataName}', '${entity.name}')"></span>
+          <i role="img" x-h-lucide data-lucide="settings"></i><span x-text="T('$projectName:${tprefix}.t.${entity.dataName}', '${entity.name}')"></span>
         </button>
 #end
 #end

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
@@ -240,8 +240,6 @@ document.addEventListener('alpine:init', () => {
       return isNaN(d.getTime()) ? String(value) : d.toISOString();
     },
 
-    refreshIcons() {
-      this.$nextTick(() => { if (window.lucide && window.lucide.createIcons) window.lucide.createIcons(); });
-    },
+    refreshIcons() {}, // no-op: Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle)
   }));
 }, { once: true });

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
@@ -155,17 +155,8 @@
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
     <script>
       document.addEventListener('alpine:initialized', () => { if (window.lucide) window.lucide.createIcons(); }, { once: true });
-      // Re-apply the colour scheme when the shell (parent window) switches theme — the `storage` event
-      // fires in this iframe when the parent changes the shared key; without it the embedded form stays
-      // on the old theme until a full refresh. (Can't gate on Harmonia.getColorScheme() — it reads the
-      // same key, already holding the new value — so track the last applied scheme to re-apply once.)
-      var __harmoniaScheme = null;
-      window.addEventListener('storage', (e) => {
-        if (e.key === 'codbex.harmonia.colorMode' && window.Harmonia) {
-          const scheme = e.newValue || 'light';
-          if (scheme !== __harmoniaScheme) { __harmoniaScheme = scheme; Harmonia.setColorScheme(scheme); }
-        }
-      });
+      // Cross-frame / cross-tab colour-scheme sync is handled by Harmonia itself (harmonia.min.js
+      // registers its own `storage` listener and re-applies codbex.harmonia.colorMode without re-persisting).
     </script>
   </body>
 </html>

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
@@ -153,10 +153,9 @@
     <script defer src="/webjars/alpinejs/dist/cdn.min.js"></script>
     <script src="/webjars/codbex__harmonia/dist/harmonia.min.js"></script>
     <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
-    <script>
-      document.addEventListener('alpine:initialized', () => { if (window.lucide) window.lucide.createIcons(); }, { once: true });
-      // Cross-frame / cross-tab colour-scheme sync is handled by Harmonia itself (harmonia.min.js
-      // registers its own `storage` listener and re-applies codbex.harmonia.colorMode without re-persisting).
-    </script>
+    <!-- opt-in Harmonia Lucide plugin: registers x-h-lucide (renders Lucide icons + keeps them in sync); needs window.lucide (above). -->
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
+    <!-- Lucide icons render via x-h-lucide (harmonia-lucide bundle above). Cross-frame/tab colour-scheme
+         sync is handled by Harmonia itself (its own storage listener), so no extra script is needed. -->
   </body>
 </html>


### PR DESCRIPTION
Phase 2 of the Harmonia 2.x migration. **Stacked on #6198** (base = `feat/harmonia-2-migration`); review/merge that first, then this retargets to `master`.

## Dark-mode cleanup
Harmonia 2.x's theme util registers its own `storage` listener and re-applies `codbex.harmonia.colorMode` across same-origin iframes and tabs (verified in the 2.1.0 source), without re-persisting. Removed the hand-rolled cross-frame `storage` sync from the generated shell, report-file, and form-builder templates (written for 1.24.2, which lacked it). One theme toggle stays in the shells; `theme.js` is already a thin Harmonia-API wrapper.

## Lucide -> x-h-lucide
Migrated all Lucide placeholders to the `x-h-lucide` directive (opt-in `harmonia-lucide` bundle) so icons render on init and inside router-swapped / `x-for` / `x-if` content automatically:
- Load `harmonia-lucide.min.js` after the Lucide UMD in the live shell, generated shell, report-file, and form-builder pages (Lucide webjar stays - Harmonia doesn't bundle it).
- Static `<i data-lucide>` -> add `x-h-lucide` (drop-in).
- Icons with `x-show`/reactive state on the `<i>` (theme sun/moon, sort arrows, save/print spinners) -> `<svg x-h-lucide>` (rendered in place; an `<i>` would be replaced and throw).
- Toggled-name icons (report chart/table, inbox play/pause) -> two `<svg x-h-lucide>` with `x-show` (the directive reads the name once).
- Removed the manual `createIcons` scans (alpine:initialized / pinecone:end / x-init) and neutralized `refreshIcons()` to no-ops.

## Verification
Built (Harmonia 2.1.0), ran an instance, drove the shell + built-in views in a headless browser:
- All Lucide placeholders render via `x-h-lucide` (shell 14, inbox 18, documents 21); **0 unprocessed** `<i data-lucide>`; no `x-h-lucide`/`createIcons` console errors.
- Theme toggle flips light<->dark; the sun/moon `<svg x-h-lucide>` pair and the inbox play/pause pair swap correctly; dark theme applied across shell and views.
- Generated per-app templates verified statically (0 old-form, correct `<svg>` pairs); they share the same patterns as the runtime-verified shell/views.

Next: **Phase 3** (native inputs -> Harmonia pickers + `x-h-input-number`) and **Phase 4** (adopt the `harmonia-i18next` plugin: `x-h-translate`/`$t` for reactive language switching, replacing the non-reactive `window.T()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)