### PR TITLE
ci: split integration tests into per-PR smoke + nightly full suite

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,148 @@
+name: Nightly Integration Tests
+
+# The full Selenide UI integration suite (everything, incl. the sample-project clone/publish tests)
+# on both H2 and PostgreSQL. It is heavy (~1.5h per DB), so it does not run on every PR - PRs run the
+# fast "smoke-tests" job (see pull-request.yml). Runs on a nightly schedule and on demand; the same
+# full suite also runs on every push to master (see build.yml).
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests-h2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Set up JDK Corretto 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '24'
+          architecture: x64
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install TypeScript and esbuild
+        run: npm install -g typescript@5.9.3 esbuild
+
+      - name: Install ttyd (prebuilt)
+        run: |
+          sudo apt update
+          sudo apt install -y ttyd
+
+      - name: Verify ttyd installation
+        run: ttyd --version
+
+      - name: Integration tests
+        run: mvn clean install -P integration-tests
+
+      - name: Generate a random artifact name
+        if: always()
+        id: generate_name
+        run: |
+          TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+          echo "ARTIFACT_NAME=selenide-screenshots-h2-${TIMESTAMP}.zip" >> $GITHUB_ENV
+
+      - name: Upload selenide screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          retention-days: 3
+          name: ${{ env.ARTIFACT_NAME }}
+          path: tests/tests-integrations/build/reports/tests
+
+  integration-tests-postgresql:
+    runs-on: ubuntu-latest
+    env:
+      POSTGRES_DB: testdb
+      POSTGRES_USER: testuser
+      POSTGRES_PASS: testpass
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: ${{ env.POSTGRES_DB }}
+          POSTGRES_USER: ${{ env.POSTGRES_USER }}
+          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASS }}
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
+      - name: Set up JDK Corretto 24
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '24'
+          architecture: x64
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install TypeScript and esbuild
+        run: npm install -g typescript@5.9.3 esbuild
+
+      - name: Install ttyd (prebuilt)
+        run: |
+          sudo apt update
+          sudo apt install -y ttyd
+
+      - name: Verify ttyd installation
+        run: ttyd --version
+
+      - name: Integration tests
+        run: mvn clean install -P integration-tests
+        env:
+          DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: org.postgresql.Driver
+          DIRIGIBLE_DATASOURCE_DEFAULT_URL: jdbc:postgresql://localhost:5432/${{ env.POSTGRES_DB }}
+          DIRIGIBLE_DATASOURCE_DEFAULT_USERNAME: ${{ env.POSTGRES_USER }}
+          DIRIGIBLE_DATASOURCE_DEFAULT_PASSWORD: ${{ env.POSTGRES_PASS }}
+
+      - name: Generate a random artifact name
+        if: always()
+        id: generate_name
+        run: |
+          TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+          echo "ARTIFACT_NAME=selenide-screenshots-postgresql-${TIMESTAMP}.zip" >> $GITHUB_ENV
+
+      - name: Upload selenide screenshots
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          retention-days: 3
+          name: ${{ env.ARTIFACT_NAME }}
+          path: tests/tests-integrations/build/reports/tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -106,80 +106,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
 
-  integration-tests-h2:
+  smoke-tests:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Cache local Maven repository
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-maven-
-
-      - name: Set up JDK Corretto 24
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '24'
-          architecture: x64
-
-      - name: Install NodeJS
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-
-      - name: Install TypeScript and esbuild
-        run: npm install -g typescript@5.9.3 esbuild
-
-      - name: Install ttyd (prebuilt)
-        run: |
-          sudo apt update
-          sudo apt install -y ttyd
-      - name: Verify ttyd installation
-        run: ttyd --version
-
-      - name: Integration tests
-        run: mvn clean install -P integration-tests
-
-      - name: Generate a random artifact name
-        if: always()
-        id: generate_name
-        run: |
-          TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-          echo "ARTIFACT_NAME=selenide-screenshots-${TIMESTAMP}.zip" >> $GITHUB_ENV
-
-      - name: Upload selenide screenshots
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          retention-days: 3
-          name: ${{ env.ARTIFACT_NAME }}
-          path: tests/tests-integrations/build/reports/tests
-
-  integration-tests-postgresql:
-    runs-on: ubuntu-latest
-    env:
-      POSTGRES_DB: testdb
-      POSTGRES_USER: testuser
-      POSTGRES_PASS: testpass
-    services:
-      postgres:
-        image: postgres:16
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_DB: ${{ env.POSTGRES_DB }}
-          POSTGRES_USER: ${{ env.POSTGRES_USER }}
-          POSTGRES_PASSWORD: ${{ env.POSTGRES_PASS }}
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -215,13 +143,11 @@ jobs:
       - name: Verify ttyd installation
         run: ttyd --version
 
-      - name: Integration tests
-        run: mvn clean install -P integration-tests
-        env:
-          DIRIGIBLE_DATASOURCE_DEFAULT_DRIVER: org.postgresql.Driver
-          DIRIGIBLE_DATASOURCE_DEFAULT_URL: jdbc:postgresql://localhost:5432/${{ env.POSTGRES_DB }}
-          DIRIGIBLE_DATASOURCE_DEFAULT_USERNAME: ${{ env.POSTGRES_USER }}
-          DIRIGIBLE_DATASOURCE_DEFAULT_PASSWORD: ${{ env.POSTGRES_PASS }}
+      # Fast per-PR gate on H2: the HTTP-level ITs plus the few smoke-tagged UI journeys
+      # (including two full clone -> generate -> validate app lifecycles). The heavy Selenide
+      # suite (@Tag "ui") runs nightly and on master push - see nightly.yml and build.yml.
+      - name: Smoke integration tests (H2)
+        run: mvn clean install -P integration-tests -Dit.groups="!ui | smoke"
 
       - name: Generate a random artifact name
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,11 +368,23 @@ Treat `modules/commons/commons-config/src/main/java/org/eclipse/dirigible/common
 
 ## CI reference
 
-`.github/workflows/build.yml` is the source of truth for "does this build pass":
+`.github/workflows/build.yml` is the source of truth for "does this build pass" on **push to master**:
 
 - `code-style`: `mvn -T 1C formatter:validate`
 - `tests` (ubuntu + windows matrix): `mvn clean install -P unit-tests`
-- `integration-tests-h2` / `-postgresql`: `mvn clean install -P integration-tests` with the matching `DIRIGIBLE_DATASOURCE_DEFAULT_*` env vars (MSSQL is no longer a CI leg — removed in #6150)
+- `integration-tests-h2` / `-postgresql`: the **full** Selenide IT suite, `mvn clean install -P integration-tests` with the matching `DIRIGIBLE_DATASOURCE_DEFAULT_*` env vars (MSSQL is no longer a CI leg — removed in #6150)
 - `build-deploy`: `mvn clean install -P quick-build` then Docker buildx multi-arch image push to `dirigiblelabs/dirigible`
 
-`pull-request.yml`, `codeql.yml`, `release.yml` cover PR validation, CodeQL, and Maven Central release respectively.
+### PR gate vs full suite (smoke / nightly split)
+
+The full Selenide UI suite takes ~1.5h per DB, so it does **not** run on every PR:
+
+- **`pull-request.yml`** (every PR) runs `code-style`, unit `tests`, `docker-build`, and a single fast **`smoke-tests`** job on H2: `mvn clean install -P integration-tests -Dit.groups="!ui | smoke"`. The tag expression selects the HTTP-level ITs (untagged, so `!ui`) plus the few UI journeys explicitly marked `@Tag("smoke")` - including two full clone->generate->validate app lifecycles (`IntentEditorLoadsIT`, `JavaEntityDecoratorsSampleProjectIT`).
+- **`nightly.yml`** (cron `0 2 * * *` + `workflow_dispatch`) and **push to master** (`build.yml`) run the **full** suite on H2 + PostgreSQL.
+
+**Test tagging convention (JUnit 5 `@Tag`, wired to failsafe via the `${it.groups}` / `${it.excludedGroups}` properties in the root `pom.xml`):**
+- Every browser-driven IT is `@Tag("ui")` - inherited from the `UserInterfaceIntegrationTest` base (and thus by `SampleProjectRepositoryIT` and all sample-project ITs). Do not tag these individually.
+- HTTP-level ITs (`extends IntegrationTest` directly) carry no tag, so they are always in the smoke set.
+- To force a specific UI IT to run on every PR, add `@Tag("smoke")` to that class (keep the list small - smoke must stay fast).
+
+`codeql.yml`, `release.yml` cover CodeQL and Maven Central release respectively.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -379,7 +379,7 @@ Treat `modules/commons/commons-config/src/main/java/org/eclipse/dirigible/common
 
 The full Selenide UI suite takes ~1.5h per DB, so it does **not** run on every PR:
 
-- **`pull-request.yml`** (every PR) runs `code-style`, unit `tests`, `docker-build`, and a single fast **`smoke-tests`** job on H2: `mvn clean install -P integration-tests -Dit.groups="!ui | smoke"`. The tag expression selects the HTTP-level ITs (untagged, so `!ui`) plus the few UI journeys explicitly marked `@Tag("smoke")` - including two full clone->generate->validate app lifecycles (`IntentEditorLoadsIT`, `JavaEntityDecoratorsSampleProjectIT`).
+- **`pull-request.yml`** (every PR) runs `code-style`, unit `tests`, `docker-build`, and a single fast **`smoke-tests`** job on H2: `mvn clean install -P integration-tests -Dit.groups="!ui | smoke"`. The tag expression selects the HTTP-level ITs (untagged, so `!ui`) plus the few UI journeys explicitly marked `@Tag("smoke")` - including one full clone->generate->validate app lifecycle (`IntentEditorLoadsIT`, the intent Generate flow). Keep the smoke set small so the PR gate stays fast.
 - **`nightly.yml`** (cron `0 2 * * *` + `workflow_dispatch`) and **push to master** (`build.yml`) run the **full** suite on H2 + PostgreSQL.
 
 **Test tagging convention (JUnit 5 `@Tag`, wired to failsafe via the `${it.groups}` / `${it.excludedGroups}` properties in the root `pom.xml`):**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,11 @@ If you want to contribute in any way, you must go through the following steps:
 10. In case multiple modules get updated, use `git status` to see all changes and then use `git add /path/to/changed/file` to add ONLY the changes in the module which you are responsible for.
 11. Commit and push your changes.
 12. Create a PR to the master branch in `eclipse/dirigible` by giving it a short but descriptive name and mention the issue number/numbers in the description (See [closing issues via PR](https://github.blog/2013-05-14-closing-issues-via-pull-requests/)).
+
+### Integration tests: smoke on PRs, full suite nightly
+
+The browser-driven (Selenide) integration suite is heavy, so on every pull request only a fast **smoke** subset runs (`mvn clean install -P integration-tests -Dit.groups="!ui | smoke"`); the full suite runs nightly and on every push to master. Tagging rules for new `*IT` tests:
+
+- A UI test extends `UserInterfaceIntegrationTest`, which is `@Tag("ui")` - it is automatically excluded from the PR smoke run (no action needed).
+- An HTTP-level test extends `IntegrationTest` directly - it carries no tag and is always part of the smoke run. Prefer this style when the feature can be exercised over HTTP (it is far faster and needs no browser).
+- If a UI test must run on every PR, add `@Tag("smoke")` to it - but keep that set small so the PR gate stays fast.

--- a/pom.xml
+++ b/pom.xml
@@ -401,8 +401,6 @@
                         <includes>
                             <include>**/*IT.java</include>
                         </includes>
-                        <groups>${it.groups}</groups>
-                        <excludedGroups>${it.excludedGroups}</excludedGroups>
                     </configuration>
                     <executions>
                         <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
              the "testcontainers" profile runs only them (see surefire config below). -->
         <surefire.groups></surefire.groups>
         <surefire.excludedGroups>testcontainers</surefire.excludedGroups>
+        <!-- Integration-test (failsafe) tag selection. Empty by default so `-P integration-tests`
+             runs every *IT (the nightly/master full suite). The PR "smoke" job overrides it with a
+             JUnit tag expression, e.g. -Dit.groups="!ui | smoke", to run only the fast HTTP-level ITs
+             plus the few explicitly-smoke UI journeys. -->
+        <it.groups></it.groups>
+        <it.excludedGroups></it.excludedGroups>
     </properties>
 
     <build>
@@ -395,6 +401,8 @@
                         <includes>
                             <include>**/*IT.java</include>
                         </includes>
+                        <groups>${it.groups}</groups>
+                        <excludedGroups>${it.excludedGroups}</excludedGroups>
                     </configuration>
                     <executions>
                         <execution>

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/UserInterfaceIntegrationTest.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/base/UserInterfaceIntegrationTest.java
@@ -12,8 +12,17 @@ package org.eclipse.dirigible.tests.base;
 import org.eclipse.dirigible.tests.framework.browser.Browser;
 import org.eclipse.dirigible.tests.framework.ide.IDE;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 
+/**
+ * Base for Selenide/Chrome UI integration tests. Tagged {@code "ui"} (inherited by every subclass,
+ * incl. the sample-project ITs) so the heavy browser-driven suite runs in the nightly/master full
+ * run and is excluded from the per-PR smoke run. A UI test that must run on every PR opts back in
+ * with an explicit {@code @Tag("smoke")} on the class; the smoke selector is the tag expression
+ * {@code "!ui | smoke"}.
+ */
+@Tag("ui")
 public abstract class UserInterfaceIntegrationTest extends IntegrationTest {
 
     @Autowired

--- a/tests/tests-integrations/pom.xml
+++ b/tests/tests-integrations/pom.xml
@@ -114,6 +114,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <!-- JUnit 5 tag selection lives here (not in the root pom) so only this module -
+                     which has the JUnit 5 engine and the tagged ITs - applies it. Empty by default
+                     (full run); the PR smoke job passes -Dit.groups="!ui | smoke". Putting it in the
+                     root failsafe config breaks other modules (e.g. dirigible-cli) that run failsafe
+                     without a JUnit 5 engine, since non-empty groups require one on the classpath. -->
+                <configuration>
+                    <groups>${it.groups}</groups>
+                    <excludedGroups>${it.excludedGroups}</excludedGroups>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/CreateNewFileIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/CreateNewFileIT.java
@@ -9,12 +9,14 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlAttribute;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.eclipse.dirigible.tests.framework.ide.Workbench;
 import org.junit.jupiter.api.Test;
 
+@Tag("smoke")
 public class CreateNewFileIT extends UserInterfaceIntegrationTest {
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/CreateNewProjectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/CreateNewProjectIT.java
@@ -9,9 +9,11 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.junit.jupiter.api.Test;
 
+@Tag("smoke")
 public class CreateNewProjectIT extends UserInterfaceIntegrationTest {
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabasePerspectiveIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DatabasePerspectiveIT.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.eclipse.dirigible.components.data.sources.manager.DataSourcesManager;
 import org.eclipse.dirigible.components.database.DatabaseSystem;
 import org.eclipse.dirigible.database.sql.ISqlDialect;
@@ -22,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.sql.SQLException;
 
+@Tag("smoke")
 public class DatabasePerspectiveIT extends UserInterfaceIntegrationTest {
 
     private static final String TEST_TABLE_NAME = "STUDENT";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DirigibleHomepageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DirigibleHomepageIT.java
@@ -9,10 +9,12 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
 
+@Tag("smoke")
 public class DirigibleHomepageIT extends UserInterfaceIntegrationTest {
 
     private static final String ECLIPSE_DIRIGIBLE_HEADER = "Dirigible";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/HomepageRedirectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/HomepageRedirectIT.java
@@ -9,10 +9,12 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import org.eclipse.dirigible.tests.base.UserInterfaceIntegrationTest;
 import org.eclipse.dirigible.tests.framework.browser.HtmlElementType;
 import org.junit.jupiter.api.Test;
 
+@Tag("smoke")
 public class HomepageRedirectIT extends UserInterfaceIntegrationTest {
 
     @Test

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentEditorLoadsIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/IntentEditorLoadsIT.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests;
 
+import org.junit.jupiter.api.Tag;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -48,6 +49,7 @@ import org.openqa.selenium.By;
  * The diagram uses fixed brand colours that read on both the light and dark themes (like the
  * EDM/schema modelers), so it renders identically in either theme and needs no theme-switch probe.
  */
+@Tag("smoke")
 public class IntentEditorLoadsIT extends UserInterfaceIntegrationTest {
 
     private static final String REPOSITORY_URL = "https://github.com/dirigiblelabs/sample-intent-model.git";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaEntityDecoratorsSampleProjectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaEntityDecoratorsSampleProjectIT.java
@@ -9,7 +9,6 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests.sample;
 
-import org.junit.jupiter.api.Tag;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
@@ -19,7 +18,6 @@ import static org.hamcrest.Matchers.containsString;
  * CSVIM-seeded country CRUD and OpenAPI registration, plus the Spring-style DI showcase
  * (constructor injection and the {@code Beans} facade).
  */
-@Tag("smoke")
 public class JavaEntityDecoratorsSampleProjectIT extends SampleProjectRepositoryIT {
 
     private static final String PROJECT = "sample-java-entity-decorators";

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaEntityDecoratorsSampleProjectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaEntityDecoratorsSampleProjectIT.java
@@ -9,6 +9,7 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests.sample;
 
+import org.junit.jupiter.api.Tag;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 
@@ -18,6 +19,7 @@ import static org.hamcrest.Matchers.containsString;
  * CSVIM-seeded country CRUD and OpenAPI registration, plus the Spring-style DI showcase
  * (constructor injection and the {@code Beans} facade).
  */
+@Tag("smoke")
 public class JavaEntityDecoratorsSampleProjectIT extends SampleProjectRepositoryIT {
 
     private static final String PROJECT = "sample-java-entity-decorators";


### PR DESCRIPTION
## Problem

The browser-driven (Selenide) integration suite takes **~1.5h per database**, and PRs run it twice (H2 + PostgreSQL) - a ~2-3h gate on every PR.

## Solution

Split the ITs with JUnit 5 tags so PRs get fast feedback while full coverage still runs regularly.

**Tagging (inheritance does the work - minimal edits):**
- `@Tag("ui")` on the `UserInterfaceIntegrationTest` base -> inherited by all UI ITs *and* the `SampleProjectRepositoryIT` sample-project ITs. Marks the heavy browser suite.
- HTTP-level ITs (`extends IntegrationTest`) stay untagged.
- `@Tag("smoke")` opts a small set of critical UI journeys back into the PR gate: `HomepageRedirectIT`, `DirigibleHomepageIT`, `CreateNewProjectIT`, `CreateNewFileIT`, `DatabasePerspectiveIT`, plus **two full clone->generate->validate app lifecycles**: `IntentEditorLoadsIT` (intent Generate) and `JavaEntityDecoratorsSampleProjectIT` (Java entity app).

**Selection:** failsafe now honours `${it.groups}` / `${it.excludedGroups}`. Smoke = the tag expression `!ui | smoke`.

**CI:**
- `pull-request.yml`: the two full `integration-tests-{h2,postgresql}` jobs -> one fast **`smoke-tests`** job on H2 (`-Dit.groups="!ui | smoke"`).
- New **`nightly.yml`**: full suite on H2 + PostgreSQL (`cron '0 2 * * *'` + `workflow_dispatch`).
- `build.yml` (push to master) still runs the full suite - unchanged.

**Docs:** tagging convention added to `CLAUDE.md` and `CONTRIBUTING.md`.

## Verification

- Test modules compile; formatter clean.
- Confirmed the tag expression is honoured by failsafe: a `ui`-tagged test (`TerminalIT`) selects **0 tests** under `-Dit.groups="!ui | smoke"`.
- Smoke wall-clock is measured on this PR's first `smoke-tests` run (target <= ~15 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)