### PR TITLE
feat(intent): DocumentStatus becomes a validation error (EntityStatus rename, step 3 of 3)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RelationIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RelationIntent.java
@@ -32,8 +32,9 @@ public class RelationIntent {
      */
     private String model;
     /**
-     * Legacy boolean form of the status role - kept only so old {@code documentStatus: true} intents
-     * parse; the canonical form is {@code function: EntityStatus}.
+     * Pre-rename boolean form of the status role - REJECTED by the parser with a clear migration
+     * message; kept as a field only so the validator can detect it. Author {@code function:
+     * EntityStatus} instead.
      */
     private boolean documentStatus;
 
@@ -151,20 +152,17 @@ public class RelationIntent {
     }
 
     /**
-     * Whether this to-one relation is the entity's status badge - the canonical
-     * {@code function: EntityStatus}, the pre-rename {@code function: DocumentStatus} (still accepted
-     * for one release while the sample/consumer intents migrate), or the legacy
-     * {@code documentStatus: true}.
+     * Whether this to-one relation is the entity's status badge - {@code function: EntityStatus}. The
+     * pre-rename {@code function: DocumentStatus} and the {@code documentStatus: true} boolean are
+     * rejected at parse time with a migration message.
      */
     public boolean isEntityStatus() {
-        if (documentStatus) {
-            return true;
-        }
-        if (function == null) {
-            return false;
-        }
-        String f = function.trim();
-        return "EntityStatus".equalsIgnoreCase(f) || "DocumentStatus".equalsIgnoreCase(f);
+        return function != null && "EntityStatus".equalsIgnoreCase(function.trim());
+    }
+
+    /** Whether the pre-rename {@code documentStatus: true} boolean was authored (parse-rejected). */
+    public boolean isLegacyDocumentStatus() {
+        return documentStatus;
     }
 
     public void setDocumentStatus(boolean documentStatus) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -87,12 +87,8 @@ public final class IntentParser {
     private static final Set<String> ENTITY_FUNCTIONS_RESERVED = Set.of("calendar", "board", "gantt", "timeline");
     /** Implemented field {@code function} values (lower-cased). */
     private static final Set<String> FIELD_FUNCTIONS = Set.of("documenttitle");
-    /**
-     * Implemented relation {@code function} values (lower-cased). {@code entitystatus} is the canonical
-     * status role, valid on any entity; {@code documentstatus} is the pre-rename spelling, accepted for
-     * one release while the sample and consumer intents migrate - it then becomes a validation error.
-     */
-    private static final Set<String> RELATION_FUNCTIONS = Set.of("entitystatus", "documentstatus");
+    /** Implemented relation {@code function} values (lower-cased). */
+    private static final Set<String> RELATION_FUNCTIONS = Set.of("entitystatus");
     private static final Set<String> STEP_KINDS = Set.of("userTask", "serviceTask", "decision", "script", "end");
     /** Entity lifecycle events a declarative-glue item (notification, reaction) can bind to. */
     private static final Set<String> EVENT_KINDS = Set.of("onCreate", "onUpdate", "onDelete");
@@ -247,8 +243,18 @@ public final class IntentParser {
                 }
             }
             for (RelationIntent relation : entity.getRelations()) {
+                if (relation.isLegacyDocumentStatus()) {
+                    issues.add("entity [" + name + "] relation [" + relation.getName()
+                            + "] uses documentStatus: true - the status role was renamed; use function: EntityStatus");
+                }
                 String rf = relation.getFunction();
                 if (rf == null || rf.isBlank()) {
+                    continue;
+                }
+                if ("documentstatus".equals(rf.trim()
+                                              .toLowerCase(Locale.ROOT))) {
+                    issues.add("entity [" + name + "] relation [" + relation.getName()
+                            + "] uses function: DocumentStatus - the status role was renamed; use function: EntityStatus");
                     continue;
                 }
                 if (!RELATION_FUNCTIONS.contains(rf.trim()

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -108,8 +108,9 @@ composition is opt-in.
   forms, badge pills in the list tables - never as an editable input. The value is managed by the
   platform (an `init:` seed, a workflow `setRelationField`, a roll-up status); an entity whose status
   must be hand-set simply does not mark the relation. Typical pairing on a document: the number field
-  is `DocumentTitle`, the workflow-managed status FK is `EntityStatus`. (`DocumentStatus` is the
-  pre-rename spelling of `EntityStatus` and is being removed - always author `EntityStatus`.)
+  is `DocumentTitle`, the workflow-managed status FK is `EntityStatus`. (`DocumentStatus` /
+  `documentStatus: true` are the pre-rename spellings and are rejected with a migration message -
+  always author `EntityStatus`.)
 - `precision` / `scale` - override the DECIMAL default (16, 2): `{ name: rate, type: decimal, precision: 18, scale: 6 }`.
 - `size` (on a field OR a to-one relation) - the form-control width as a 12-column grid span
   (3 = quarter, 4 = third, 6 = half, 12 = full). The generated form maps it to `grid-column: span N`;

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionIntentTest.java
@@ -18,9 +18,10 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Coverage for the explicit {@code function} presentation role at entity / field / relation level,
- * and its back-compat with the legacy {@code documentTitle} / {@code documentStatus} /
- * {@code kind: setting} flags, the pre-rename {@code function: DocumentStatus} spelling, and the
- * {@code *Item} naming.
+ * its back-compat with the legacy {@code documentTitle} / {@code kind: setting} flags and the
+ * {@code *Item} naming, and the hard rename of the status role: the pre-rename
+ * {@code function: DocumentStatus} and {@code documentStatus: true} are rejected with a migration
+ * message.
  */
 class FunctionIntentTest {
 
@@ -69,7 +70,7 @@ class FunctionIntentTest {
     }
 
     @Test
-    void legacyBooleanFlagsStillResolveTheSameRoles() {
+    void legacyDocumentTitleBooleanStillResolvesButTheStatusBooleanIsRejected() {
         String yaml = """
                 name: sales
                 entities:
@@ -78,7 +79,7 @@ class FunctionIntentTest {
                       - { name: id, type: integer, primaryKey: true, generated: true }
                       - { name: number, type: string, documentTitle: true }
                     relations:
-                      - { name: Status, kind: manyToOne, to: SalesInvoiceStatus, documentStatus: true }
+                      - { name: Status, kind: manyToOne, to: SalesInvoiceStatus, function: EntityStatus }
                   - name: SalesInvoiceItem
                     fields:
                       - { name: id, type: integer, primaryKey: true, generated: true }
@@ -104,10 +105,12 @@ class FunctionIntentTest {
         assertTrue(model.getEntities()
                         .get(2)
                         .isSetting());
+        assertIssue(yaml.replace("function: EntityStatus", "documentStatus: true"),
+                "uses documentStatus: true - the status role was renamed; use function: EntityStatus");
     }
 
     @Test
-    void entityStatusIsValidOnANonDocumentEntityAndTheOldSpellingStillParses() {
+    void entityStatusIsValidOnANonDocumentEntityAndTheOldSpellingIsRejected() {
         String yaml = """
                 name: vacations
                 entities:
@@ -127,7 +130,8 @@ class FunctionIntentTest {
                       - { name: id, type: integer, primaryKey: true, generated: true }
                       - { name: name, type: string }
                 """;
-        IntentModel model = IntentParser.parse(yaml);
+        assertIssue(yaml, "uses function: DocumentStatus - the status role was renamed; use function: EntityStatus");
+        IntentModel model = IntentParser.parse(yaml.replace("function: DocumentStatus", "function: EntityStatus"));
         assertTrue(model.getEntities()
                         .get(0)
                         .getRelations()
@@ -139,7 +143,7 @@ class FunctionIntentTest {
                         .getRelations()
                         .get(0)
                         .isEntityStatus(),
-                "pre-rename function: DocumentStatus still resolves while consumers migrate");
+                "the flipped relation resolves the same role");
     }
 
     @Test


### PR DESCRIPTION
Completes the staged hard rename of the intent status role:

1. #6208 (merged) - `function: EntityStatus` canonical, old spellings accepted for one window.
2. dirigiblelabs/sample-intent-multi-model#13 (merged) - the only sample usage flipped.
3. **This PR** - `function: DocumentStatus` and the legacy `documentStatus: true` boolean are rejected at parse time with an explicit migration message (`... the status role was renamed; use function: EntityStatus`). `RelationIntent.isEntityStatus()` honors only the canonical spelling.

The sample-cloning ITs are safe: the samples carry no old spelling anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)