### PR TITLE
fix(tests): fork a fresh JVM per IT class - the shared fork OOMs late in the full run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,9 @@ jobs:
 
   integration-tests-h2:
     runs-on: ubuntu-latest
+    # A green full IT run takes ~1h30m; a heap-exhausted JVM used to thrash for 4h+ before anyone
+    # noticed. Cap the job well above the healthy time so hangs fail fast instead of burning runners.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v4
         with:
@@ -217,6 +220,8 @@ jobs:
 
   integration-tests-postgresql:
     runs-on: ubuntu-latest
+    # Same rationale as integration-tests-h2: green run ~1h30m, cap runaway JVMs.
+    timeout-minutes: 150
     env:
       POSTGRES_DB: testdb
       POSTGRES_USER: testuser

--- a/tests/tests-integrations/pom.xml
+++ b/tests/tests-integrations/pom.xml
@@ -122,6 +122,23 @@
                 <configuration>
                     <groups>${it.groups}</groups>
                     <excludedGroups>${it.excludedGroups}</excludedGroups>
+                    <!-- Fresh JVM per test class. Every IT boots a full Dirigible context per test
+                         method (@DirtiesContext AFTER_EACH_TEST_METHOD) and closed contexts do not
+                         release all their heap (schedulers, engine pools, statics), so a single
+                         shared fork accumulates the leak across the ~85 IT classes and OOMs late in
+                         the full run (the -Xmx6g fork died at DependsOnHarmoniaIT). Per-class forks
+                         bound the accumulation at one class; JVM startup is noise next to the
+                         per-method Spring boots. ExitOnOutOfMemoryError kills the fork on the first
+                         OOM instead of letting a heap-thrashing JVM drag the job out for hours.
+                         argLine here REPLACES the root pom's (no merge) - keep the add-opens list. -->
+                    <reuseForks>false</reuseForks>
+                    <argLine>
+                        -Xmx6g
+                        -XX:+ExitOnOutOfMemoryError
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens=java.base/java.nio=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/tests-integrations/src/main/resources/MultitenancyHarmoniaIT/cmis/DocumentService.ts
+++ b/tests/tests-integrations/src/main/resources/MultitenancyHarmoniaIT/cmis/DocumentService.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Post, Delete } from "@aerokit/sdk/http"
-import { cmis, Document } from "@aerokit/sdk/cms";
+import { cmis, Document, Folder } from "@aerokit/sdk/cms";
 import { streams } from "@aerokit/sdk/io";
 import { response } from "@aerokit/sdk/http";
 
@@ -43,7 +43,7 @@ class DocumentService {
         try {
             const id = ctx.pathParameters.id;
             const cmisSession = cmis.getSession();
-            const doc: Document = cmisSession.getObjectByPath(id);
+            const doc = cmisSession.getObjectByPath(id) as Document;
 
             const inputStream = doc.getContentStream()?.getStream();
             const outputStream = streams.createByteArrayOutputStream();


### PR DESCRIPTION
## Problem

[Build run 28955226818](https://github.com/eclipse-dirigible/dirigible/actions/runs/28955226818) (master) failed:

- `DependsOnHarmoniaIT.test` died after 1755s with `java.lang.OutOfMemoryError: Java heap space` (the Selenide `UnreachableBrowserException` is a symptom - the driver comms died inside the OOMing JVM).
- `HomepageRedirectIT` / `DirigibleHomepageIT` then failed to load their ApplicationContext in the same exhausted JVM (`Failed to instantiate ProcessEngine ... Java heap space`).
- The h2 job heap-thrashed for **4h15m** before being manually cancelled.

The previous master run ([28952421832](https://github.com/eclipse-dirigible/dirigible/actions/runs/28952421832)) OOMed at the same class. `DependsOnHarmoniaIT` is a victim, not the culprit - in the last green run it passes in minutes. Every IT boots a full Dirigible context per test method (`@DirtiesContext AFTER_EACH_TEST_METHOD`) and closed contexts do not release all their heap, so the single shared failsafe fork (already at `-Xmx6g`) accumulates the leak across the ~85 IT classes until it falls over late in the run. The suite just grew past the cliff with the latest ITs (#6205, #6209).

## Fix

- **`reuseForks=false`** for `tests-integrations` failsafe: a fresh JVM per test class bounds the leak accumulation at one class. JVM startup (~5s/class, ~7min over 85 classes) is noise next to the per-method Spring boots. The module-level `argLine` replaces the root pom's, so the `--add-opens` list and `-Xmx6g` are repeated there.
- **`-XX:+ExitOnOutOfMemoryError`**: an OOMing fork dies immediately and fails the run instead of thrashing for hours.
- **`timeout-minutes: 150`** on both IT jobs (green run ~1h30m) as a backstop against runaway JVMs.
- Drive-by: fixed the two tsc type errors in `MultitenancyHarmoniaIT/cmis/DocumentService.ts` (`Folder` not imported; `Folder | Document` union assigned to `Document`) that spam every transpile pass in the IT logs.

## Verification

Ran `TenantConfigurationIT` + `JavaComponentIT` locally with the new config: separate fork PIDs per class (4905 / 4968), all 3 tests green, BUILD SUCCESS.

## Follow-up

The underlying per-context heap leak (what exactly keeps closed contexts reachable - scheduler/engine threads, statics) is worth a dedicated hunt with `-XX:+HeapDumpOnOutOfMemoryError` locally; this PR makes CI immune to the accumulation and makes any single-class leak show up attributed to its class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)