### PR TITLE
[Templates] Generated report count() returns 0 on PostgreSQL

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/reportFileEntity.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/reportFileEntity.java.template
@@ -55,7 +55,7 @@ public class ${name}Repository {
     @SuppressWarnings("unchecked")
     public long count(Map<String, Object> filter) {
         List<Map<String, Object>> parameters = baseParameters(filter);
-        String sql = "SELECT COUNT(*) AS REPORT_COUNT FROM (" + filteredQuery(filter, parameters) + ") AS \"REPORT_TOTAL\"";
+        String sql = "SELECT COUNT(*) AS \"REPORT_COUNT\" FROM (" + filteredQuery(filter, parameters) + ") AS \"REPORT_TOTAL\"";
         try {
             String result = Database.queryNamed(sql, Json.stringify(parameters));
             List<Map<String, Object>> rows = (List<Map<String, Object>>) Json.parse(result, List.class);

--- a/components/template/template-application-dao-v2/src/main/resources/META-INF/dirigible/template-application-dao-v2/data/reportFileEntity.ts.template
+++ b/components/template/template-application-dao-v2/src/main/resources/META-INF/dirigible/template-application-dao-v2/data/reportFileEntity.ts.template
@@ -49,11 +49,11 @@ export class ${name}Repository {
 
     public count(filter: ${name}Filter): number {
         const sql = `
-            SELECT COUNT(*) as REPORT_COUNT FROM (
+            SELECT COUNT(*) AS "REPORT_COUNT" FROM (
 #foreach($queryLine in $queryLines)
                 ${queryLine}
 #end
-            )
+            ) AS "REPORT_TOTAL"
         `;
 
         const parameters: NamedQueryParameter[] = [];

--- a/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/reportFileEntity.ts.template
+++ b/components/template/template-application-dao/src/main/resources/META-INF/dirigible/template-application-dao/dao/reportFileEntity.ts.template
@@ -49,11 +49,11 @@ export class ${name}Repository {
 
     public count(filter: ${name}Filter): number {
         const sql = `
-            SELECT COUNT(*) as REPORT_COUNT FROM (
+            SELECT COUNT(*) AS "REPORT_COUNT" FROM (
 #foreach($queryLine in $queryLines)
                 ${queryLine}
 #end
-            )
+            ) AS "REPORT_TOTAL"
         `;
 
         const parameters: NamedQueryParameter[] = [];

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -1212,6 +1212,8 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(repository.contains("FILTER_COLUMNS"), "the report repository should carry the filterable-column allowlist");
         assertTrue(repository.contains("SELECT * FROM (\").append(QUERY).append(\") AS \\\"REPORT_DATA\\\" WHERE"),
                 "conditions should wrap the report query");
+        assertTrue(repository.contains("SELECT COUNT(*) AS \\\"REPORT_COUNT\\\" FROM ("),
+                "the count alias must be quoted - PostgreSQL folds an unquoted alias to lower case and the case-sensitive read misses it");
         assertTrue(repository.contains("\"GTE\", \">=\""), "range operators should be whitelisted");
         String controller = contentOf("gen/ordersbycustomer/api/reports/OrdersByCustomerController.java");
         assertTrue(controller.contains("exportCsv(@Body Map<String, Object> filter)"), "export should honor the active filters");


### PR DESCRIPTION
## Overview

Report count endpoints and the dashboard count KPI tiles always showed 0 on PostgreSQL, because the count alias in the generated report SQL was folded to lower case. The alias is now quoted so report counts are correct on all supported databases.

Fixes: #6218.