### PR TITLE
fix(core): retry BROKEN definitions every synchronization pass — self-healing for transient parse failures

### DIFF
--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -566,8 +566,31 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
                             }
                             addArtefacts(parsed);
                             break;
-                        case BROKEN: // has been broken
-                            // do not try to parse it again as it is still not modified
+                        case BROKEN: // has been broken - retry every pass (self-healing)
+                            // The original failure may have been transient: a race with a concurrent
+                            // publish, or a cross-artefact condition that a later pass resolved (a
+                            // duplicate-FQN Java source whose twin was since deleted). Skipping until
+                            // the content changes leaves the definition permanently dead - one
+                            // unparsed .java source is invisible to the client-Java batch compile and
+                            // fails the WHOLE batch until someone edits the file's bytes. A genuinely
+                            // broken definition re-fails cheaply; state and message are rewritten only
+                            // when the error changes, so there is no per-pass churn.
+                            try {
+                                parsed = synchronizer.parse(definition.getLocation(), definition.getContent());
+                                parsed.forEach(a -> {
+                                    a.setPhase(ArtefactPhase.CREATE);
+                                    synchronizer.setStatus((a), ArtefactLifecycle.NEW, "");
+                                });
+                                addArtefacts(parsed);
+                                registerParsedState(definition);
+                                logger.info("Previously broken definition [{}] parsed successfully on retry", definition.getLocation());
+                            } catch (ParseException e) {
+                                if (!Objects.equals(definition.getMessage(), e.getMessage())) {
+                                    registerBrokenState(definition, e.getMessage());
+                                } else {
+                                    logger.debug("Definition [{}] is still broken: {}", definition.getLocation(), e.getMessage(), e);
+                                }
+                            }
                             break;
                         case DELETED: // has been deleted before, but appeared again
                             try {

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/synchronizer/JavaSynchronizer.java
@@ -324,6 +324,7 @@ public class JavaSynchronizer extends BaseSynchronizer<JavaFile, Long> {
     @Override
     protected void cleanupImpl(JavaFile artefact) {
         try {
+            LOGGER.info("Removing Java artefact [{}] ([{}]) - its source is gone", artefact.getLocation(), artefact.getClassFqn());
             javaFileService.delete(artefact);
             // Clear any compilation problems for the removed source - the next rebuild won't see it,
             // so its entries would otherwise linger.

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaEngineIT.java
@@ -105,6 +105,36 @@ class JavaEngineIT extends IntegrationTest {
         assertEndpointStatus(404);
     }
 
+    @Test
+    void broken_definition_self_heals_without_a_byte_change() {
+        // A duplicate FQN breaks the SECOND source's parse (definition state BROKEN) - one
+        // deterministic instance of the "transient parse failure" class. The regression this guards:
+        // a BROKEN definition used to be skipped until its CONTENT changed, so removing the cause
+        // (the first duplicate) never healed the second source, and - because one unparsed .java is
+        // invisible to the registry-wide javac batch - the whole client codebase stayed broken until
+        // someone edited the file's bytes.
+        writeAndSync(handlerSource("original"));
+        assertEndpointReturns(200, "hello from original");
+
+        String duplicatePath = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/other/Hello.java";
+        repository.createResource(duplicatePath, handlerSource("duplicate").getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+        // The duplicate is rejected; the original keeps serving.
+        assertEndpointReturns(200, "hello from original");
+
+        // Remove the ORIGINAL - the duplicate's bytes stay untouched. The heal needs two passes
+        // (one whose cleanup drops the stale FQN claim, one whose retry re-parses), and a concurrent
+        // scheduled run can consume a force after its parse phase already ran - so force a few.
+        repository.removeResource(REGISTRY_PATH);
+        for (int i = 0; i < 3; i++) {
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+        assertEndpointReturns(200, "hello from duplicate");
+
+        repository.removeResource(duplicatePath);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
     @AfterEach
     void removeArtefactFromRegistry() {
         // Best-effort cleanup so the next test starts from a clean registry. The


### PR DESCRIPTION
## The problem

`SynchronizationProcessor.parseDefinitions` skipped `BROKEN` definitions until their **content checksum changed**:

```java
case BROKEN: // has been broken
    // do not try to parse it again as it is still not modified
    break;
```

A parse failure is not always deterministic on content: a race with a concurrent publish, or a cross-artefact condition that a later pass resolves (e.g. a duplicate-FQN Java source whose twin is deleted afterwards). Such a definition stayed dead forever — republishing **identical bytes** computes the same checksum and no-ops.

For client Java this is catastrophic: one unparsed `.java` source never becomes a `JavaFile` artefact, so it is invisible to the registry-wide `javac` batch — and since the batch is all-or-nothing, **the whole client codebase fails to compile until someone edits that one file's bytes**. Observed in a real deployment pipeline: a transient mid-publish failure of a single custom class kept a 564-unit batch broken through any number of republish cycles; appending a newline to the file healed everything instantly.

## The fix

The `BROKEN` case now **retries the parse on every pass** — consistent with the platform's self-healing doctrine (artefact-level `FAILED` states already retry; CSVIM imports retry until their table exists). A genuinely broken definition re-fails cheaply: its state and message are rewritten only when the error text changes, so there is no per-pass DB churn or log spam (repeat identical failures log at debug). A transiently broken one heals as soon as its blocking condition clears.

`JavaSynchronizer.cleanupImpl` additionally logs the removal of a Java artefact at INFO — the release of an FQN claim is operationally significant when tracing exactly this class of issue.

## Test

`JavaEngineIT.broken_definition_self_heals_without_a_byte_change`: a second source claiming an already-declared FQN parses BROKEN; deleting the original must heal the duplicate **without touching its bytes** (cleanup drops the stale FQN claim in one pass, the retry re-parses in the next). Before the fix the duplicate stayed dead. All 5 `JavaEngineIT` tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)