### PR TITLE
fix(data-store-java): caller-generation metadata view for stale-classloader entity lookups

### DIFF
--- a/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/manager/JavaEntityManager.java
+++ b/components/data/data-store-java/src/main/java/org/eclipse/dirigible/components/data/store/java/manager/JavaEntityManager.java
@@ -13,9 +13,11 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.sql.DataSource;
 
@@ -70,6 +72,14 @@ public class JavaEntityManager implements DisposableBean {
 
     /** Current registered entities, keyed by {@code <project>::<fqn>}. */
     private final Map<String, RegisteredEntity> registered = new LinkedHashMap<>();
+
+    /**
+     * Metadata views for callers whose entity {@link Class} belongs to an OLDER client-classloader
+     * generation than the currently registered one — e.g. a Flowable-cached delegate instance that
+     * resolved its classes before its module was republished. Weakly keyed by the caller's class so a
+     * retired generation's entries are garbage-collected together with its classloader.
+     */
+    private final Map<Class<?>, RegisteredEntity> staleGenerationViews = Collections.synchronizedMap(new WeakHashMap<>());
 
     private final ReentrantLock rebuildLock = new ReentrantLock();
 
@@ -143,14 +153,30 @@ public class JavaEntityManager implements DisposableBean {
         return Optional.ofNullable(registered.get(key));
     }
 
+    /** Test seam: seed a registration without touching the Hibernate {@link SessionFactory}. */
+    void registerWithoutRebuild(String key, Class<?> entityClass) {
+        registered.put(key, JavaEntityToHbmMapper.map(key, entityClass)
+                                                 .registered());
+    }
+
     /**
      * Look up by entity {@link Class} — finds the registered entry whose
      * {@link RegisteredEntity#entityClass()} matches by identity, falling back to FQN equality so a
      * class loaded in a previous generation of the {@code ClientClassLoader} still resolves to its
      * current registration.
      *
+     * <p>
+     * The FQN fallback must NOT return the current registration as-is: its reflective surface
+     * ({@code Field}s, constructor) belongs to the CURRENT generation's class and cannot be applied to
+     * the caller's instances — {@code EntityBeanMapper} would throw {@code IllegalArgumentException}
+     * mixing a bean of one generation with fields of another (the shape a Flowable-cached delegate hits
+     * after its module is republished, stalling the workflow job on every retry). Instead the same
+     * entity is re-reflected against the CALLER's class: persistence is Hibernate dynamic-map
+     * (name-keyed), so the entity/table names line up and only the reflective surface differs per
+     * generation.
+     *
      * @param entityClass the entity class to resolve
-     * @return the registered entry, or empty if none matches
+     * @return the registered entry (or a caller-generation view of it), or empty if none matches
      */
     public Optional<RegisteredEntity> findForClass(Class<?> entityClass) {
         for (RegisteredEntity r : registered.values()) {
@@ -162,7 +188,16 @@ public class JavaEntityManager implements DisposableBean {
             if (r.entityClass()
                  .getName()
                  .equals(entityClass.getName())) {
-                return Optional.of(r);
+                String key = r.key();
+                return Optional.of(staleGenerationViews.computeIfAbsent(entityClass, clazz -> {
+                    LOGGER.info(
+                            "Entity [{}] resolved for a previous-generation class (caller classloader [{}], registered [{}])"
+                                    + " - serving a caller-generation metadata view",
+                            clazz.getName(), clazz.getClassLoader(), r.entityClass()
+                                                                      .getClassLoader());
+                    return JavaEntityToHbmMapper.map(key, clazz)
+                                                .registered();
+                }));
             }
         }
         return Optional.empty();

--- a/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/manager/GenerationFixtureInvoice.java
+++ b/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/manager/GenerationFixtureInvoice.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.store.java.manager;
+
+import org.eclipse.dirigible.sdk.db.Entity;
+import org.eclipse.dirigible.sdk.db.GeneratedValue;
+import org.eclipse.dirigible.sdk.db.GenerationType;
+import org.eclipse.dirigible.sdk.db.Id;
+
+/**
+ * Top-level fixture for {@code JavaEntityManagerGenerationTest} — deliberately NOT a nested class,
+ * because a nested class re-defined in a second classloader cannot resolve its declaring class
+ * ({@code IllegalAccessError} from {@code Class.getSimpleName()}), while a top-level class
+ * re-defines cleanly, like real client entities do.
+ */
+@Entity
+public class GenerationFixtureInvoice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Integer Id;
+    public String Number;
+}

--- a/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/manager/JavaEntityManagerGenerationTest.java
+++ b/components/data/data-store-java/src/test/java/org/eclipse/dirigible/components/data/store/java/manager/JavaEntityManagerGenerationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.data.store.java.manager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.data.store.java.store.EntityBeanMapper;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link JavaEntityManager#findForClass(Class)} across client-classloader GENERATIONS.
+ *
+ * <p>
+ * Client classes are recompiled into a fresh {@code ClientClassLoader} on every rebuild, but a
+ * caller can outlive the swap — Flowable caches delegate instances with the process definition, so
+ * after a module republish a workflow delegate still passes the OLD generation's entity class. The
+ * regression this guards: the FQN fallback used to return the CURRENT registration whose reflective
+ * {@code Field}s cannot be applied to the caller's instances — {@code EntityBeanMapper.fromMap}
+ * threw {@code IllegalArgumentException} ("Can not set … field …") on every job retry and the
+ * workflow stalled until a server restart. The fallback now serves a caller-generation metadata
+ * view, so a stale-generation caller keeps working (persistence is name-keyed dynamic-map — the
+ * Java generation is irrelevant to Hibernate).
+ */
+class JavaEntityManagerGenerationTest {
+
+    /**
+     * Re-defines ONLY the fixture entity from its bytecode, delegating everything else to the parent —
+     * two loads through two instances yield same-FQN classes with different identities, exactly like
+     * two {@code ClientClassLoader} generations.
+     */
+    private static final class GenerationClassLoader extends ClassLoader {
+        GenerationClassLoader() {
+            super(JavaEntityManagerGenerationTest.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!name.equals(GenerationFixtureInvoice.class.getName())) {
+                return super.loadClass(name, resolve);
+            }
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> loaded = findLoadedClass(name);
+                if (loaded != null) {
+                    return loaded;
+                }
+                String resource = name.replace('.', '/') + ".class";
+                try (InputStream in = getParent().getResourceAsStream(resource)) {
+                    byte[] bytes = in.readAllBytes();
+                    return defineClass(name, bytes, 0, bytes.length);
+                } catch (Exception e) {
+                    throw new ClassNotFoundException(name, e);
+                }
+            }
+        }
+    }
+
+    private static JavaEntityManager managerWith(Class<?> registeredClass) {
+        JavaEntityManager manager = new JavaEntityManager(null, null, null);
+        manager.registerWithoutRebuild("proj::" + registeredClass.getName(), registeredClass);
+        return manager;
+    }
+
+    @Test
+    void identityMatchReturnsTheRegistrationItself() {
+        JavaEntityManager manager = managerWith(GenerationFixtureInvoice.class);
+
+        RegisteredEntity meta = manager.findForClass(GenerationFixtureInvoice.class)
+                                       .orElseThrow();
+
+        assertSame(GenerationFixtureInvoice.class, meta.entityClass());
+    }
+
+    @Test
+    void staleGenerationCallerGetsACallerGenerationView() throws Exception {
+        Class<?> otherGeneration = new GenerationClassLoader().loadClass(GenerationFixtureInvoice.class.getName());
+        assertNotSame(GenerationFixtureInvoice.class, otherGeneration, "the fixture must load with a distinct identity");
+        JavaEntityManager manager = managerWith(GenerationFixtureInvoice.class);
+
+        RegisteredEntity view = manager.findForClass(otherGeneration)
+                                       .orElseThrow();
+
+        // The view's whole reflective surface belongs to the CALLER's generation …
+        assertSame(otherGeneration, view.entityClass());
+        assertSame(otherGeneration, view.idField()
+                                        .getDeclaringClass());
+        // … while the persistence coordinates match the registration (name-keyed dynamic-map).
+        RegisteredEntity registered = manager.findForClass(GenerationFixtureInvoice.class)
+                                             .orElseThrow();
+        assertEquals(registered.entityName(), view.entityName());
+        assertEquals(registered.tableName(), view.tableName());
+        // Repeat lookups reuse the cached view.
+        assertSame(view, manager.findForClass(otherGeneration)
+                                .orElseThrow());
+    }
+
+    @Test
+    void staleGenerationCallerCanMaterializeRows() throws Exception {
+        // The end-to-end regression shape: findById in a stale-generation delegate maps a Hibernate
+        // row onto a bean of the CALLER's class. With the old fallback (current-generation meta) this
+        // threw IllegalArgumentException from Field.set; with the view it materializes cleanly.
+        Class<?> otherGeneration = new GenerationClassLoader().loadClass(GenerationFixtureInvoice.class.getName());
+        JavaEntityManager manager = managerWith(GenerationFixtureInvoice.class);
+        RegisteredEntity view = manager.findForClass(otherGeneration)
+                                       .orElseThrow();
+
+        Object bean = EntityBeanMapper.fromMap(otherGeneration, Map.of("Id", 42, "Number", "SI00000042"), view);
+
+        assertTrue(otherGeneration.isInstance(bean));
+        assertEquals(42, otherGeneration.getField("Id")
+                                        .get(bean));
+        assertEquals("SI00000042", otherGeneration.getField("Number")
+                                                  .get(bean));
+    }
+}


### PR DESCRIPTION
## The problem

Client classes are recompiled into a fresh `ClientClassLoader` on every rebuild — but a caller can outlive the swap. Flowable caches delegate instances with the deployed process definition, so after a module republish a workflow delegate still holds and passes the **old generation's** entity class.

`JavaEntityManager.findForClass` already anticipated this with an FQN fallback — but it returned the **current** registration, whose reflective `Field`s belong to the current generation's class and cannot be applied to the caller's instances. `EntityBeanMapper.fromMap` (which instantiates the *caller's* class but sets the *meta's* fields) threw:

```
java.lang.IllegalArgumentException: Can not set java.lang.Integer field <Entity>.Id to <Entity>
```

on **every Flowable async-job retry**, permanently stalling the workflow until a server restart. Reproduced live twice: republish a module on a running instance → complete the workflow task → the following delegate's job fails forever (the document stays in its pre-transition state).

## The fix

On a name-match with a different `Class` identity, `findForClass` now **re-reflects the same entity against the caller's class** and returns that view. Persistence is Hibernate dynamic-map (name-keyed), so the entity/table coordinates are generation-agnostic — only the reflective surface must match the caller. A stale-generation caller then works correctly end-to-end: `fromMap` instantiates and populates the caller's own class, `toMap` reads the caller's own fields, and the dynamic-map row is identical either way.

Views are cached in a `WeakHashMap` keyed by the caller's class, so a retired generation's entries are garbage-collected together with its classloader. The fallback logs at INFO when it engages (classloaders of both sides), which makes the previously invisible condition diagnosable.

## Tests

`JavaEntityManagerGenerationTest` defines the same `@Entity` in two classloaders (the two-generation shape) and covers: identity match returns the registration; the stale-generation caller gets a view whose whole reflective surface is the caller's class while the persistence coordinates match the registration (and the view is cached); and the exact regression — `fromMap` materializing a Hibernate row onto a stale-generation bean, which previously threw. Full data-store-java suite green (16 tests). Live: a post-republish workflow run completes cleanly.

Related: #6233 (BROKEN definition retry), #6234 (deferred `-transitioned` publish) — the three findings from the same accounting-vertical activation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)