### PR TITLE
feat(intent): generates completion hook — sourceStatus flips the source after the target is created

### DIFF
--- a/components/engine/engine-intent/README.md
+++ b/components/engine/engine-intent/README.md
@@ -256,10 +256,13 @@ generates:
     map: { Customer: Customer }
     defaults: { InvoiceDate: now }
     items: { from: ProjectTimesheetItem, to: SalesInvoiceItem, map: { Description: Description } }
+    sourceStatus: 3                   # optional completion hook: the SOURCE's EntityStatus after creation
 ```
 
 Adds a button on the source view; the clone saves through the target's repository so numbering,
-status init and calculated fields fire.
+status init and calculated fields fire. `sourceStatus:` flips the SOURCE to the given EntityStatus
+seed id once the target exists (proforma -> INVOICED) - a system write: no `-updated` re-fire, but
+the source's `-transitioned` topic is published.
 
 ## postings - source-document to ledger
 
@@ -458,8 +461,6 @@ UI-test manifest, and its perspective in the generated Harmonia SPA + the shared
   generates, postings.
 - **Cross-model schedule SOURCE** - a schedule's `entity` must be local (the generate target may
   be cross-model).
-- **`generates` completion hook** - flipping the SOURCE record's status after creating the target
-  (`onDone`-style) is not yet expressible.
 - **Embedded calendar panel for a DEPENDENT composition child** inside its master page - calendar
   views require a PRIMARY entity today.
 - **Pipeline hardening follow-ups** (tracked on the emission-coverage IT): seed-row key

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -462,6 +462,19 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             e.put("toPerspective", toPerspective);
             e.put("toPk", toPk);
             e.put("fieldAssignments", assignments(g.getMap(), g.getDefaults(), "source"));
+            // Completion hook: the SOURCE's EntityStatus FK is set to this seed id after the target
+            // is created (empty = no hook). Pre-resolved to the PascalCase FK property.
+            String sourceStatusProperty = "";
+            if (g.getSourceStatus() != null) {
+                for (org.eclipse.dirigible.components.intent.model.RelationIntent relation : source.getRelations()) {
+                    if (relation.isEntityStatus()) {
+                        sourceStatusProperty = IntentNaming.pascalCase(relation.getName());
+                    }
+                }
+            }
+            e.put("sourceStatusProperty", sourceStatusProperty);
+            e.put("sourceStatusValue",
+                    g.getSourceStatus() == null || sourceStatusProperty.isEmpty() ? "" : String.valueOf(g.getSourceStatus()));
 
             GeneratesItemsIntent items = g.getItems();
             boolean hasItems = items != null && items.getFrom() != null && !items.getFrom()

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/GeneratesIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/GeneratesIntent.java
@@ -72,6 +72,13 @@ public class GeneratesIntent {
 
     /** Optional ordering hint among the contributed actions of a view. */
     private Integer order;
+    /**
+     * Optional completion hook: the EntityStatus seed id the SOURCE record is set to after the target
+     * is created (e.g. a proforma flips to INVOICED once the invoice exists). A workflow-style system
+     * write - no {@code -updated} re-fire, but the source's {@code -transitioned} topic IS published.
+     * Requires the {@code from} entity to declare a {@code function: EntityStatus} relation.
+     */
+    private Integer sourceStatus;
 
     /** Target property -> source property (a field or to-one relation name of {@link #from}). */
     private Map<String, String> map = new LinkedHashMap<>();
@@ -154,6 +161,14 @@ public class GeneratesIntent {
 
     public void setOrder(Integer order) {
         this.order = order;
+    }
+
+    public Integer getSourceStatus() {
+        return sourceStatus;
+    }
+
+    public void setSourceStatus(Integer sourceStatus) {
+        this.sourceStatus = sourceStatus;
     }
 
     public Map<String, String> getMap() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -1975,6 +1975,23 @@ public final class IntentParser {
             if (!names.add(name)) {
                 issues.add("duplicate generates action [" + name + "]");
             }
+            if (g.getSourceStatus() != null) {
+                // The completion hook flips the SOURCE's status after the target is created - it
+                // needs the EntityStatus relation to write to.
+                EntityIntent from = g.getFrom() == null ? null : byName.get(g.getFrom());
+                boolean hasStatus = false;
+                if (from != null) {
+                    for (RelationIntent relation : from.getRelations()) {
+                        if (relation.isEntityStatus()) {
+                            hasStatus = true;
+                        }
+                    }
+                }
+                if (from != null && !hasStatus) {
+                    issues.add("generates [" + name + "] sourceStatus requires the from entity [" + g.getFrom()
+                            + "] to declare a function: EntityStatus relation");
+                }
+            }
             EntityIntent source = null;
             if (g.getFrom() == null || g.getFrom()
                                         .isBlank()) {

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -572,6 +572,8 @@ generates:
       map:
         Description: Description
         Amount: Amount
+    sourceStatus: 3                # optional completion hook: the SOURCE's EntityStatus seed id
+                                   # after the target is created (e.g. proforma -> INVOICED)
 ```
 
 **Rules:** unique `name`; `from` must be a declared entity in this model; `to` must be a declared
@@ -581,7 +583,10 @@ to-one relation** of the source entity - one-hop `relation.field` paths are not 
 copies a source value; `defaults` sets a constant (`now` = today's date, or a literal). Do **not** map
 the target's identity, document number, status or the item->master foreign key: they are left for the
 target to mint - the clone is saved through the **target's** generated repository, so its create-time
-logic (numbering, status init, calculated fields) fires naturally.
+logic (numbering, status init, calculated fields) fires naturally. `sourceStatus` (optional) flips the
+SOURCE record to the given EntityStatus seed id once the target exists - a workflow-style system write
+(no `-updated` re-fire; the source's `-transitioned` topic IS published, so postings/integrations can
+observe it); it requires the `from` entity to declare a `function: EntityStatus` relation.
 
 Two halves are generated: a client button (a `<name>-generate-action.extension` + `.js` contribution
 to the app's `<project>-custom-action` point, carrying an `endpoint`) and a server-side Java

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
@@ -104,6 +104,46 @@ class GlueGeneratesTest {
 
         List<Map<String, Object>> itemFields = (List<Map<String, Object>>) g.get("itemFieldAssignments");
         assertTrue(itemFields.contains(Map.of("targetProp", "Amount", "expr", "srcItem.Amount")));
+
+        // No completion hook declared - the template's #if renders nothing.
+        assertEquals("", g.get("sourceStatusProperty"));
+        assertEquals("", g.get("sourceStatusValue"));
+    }
+
+    @Test
+    void completionHookResolvesTheSourceStatusRelation() {
+        IntentModel model = IntentParser.parse("""
+                name: sales
+                entities:
+                  - name: ProformaStatus
+                    function: Setting
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: Proforma
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                    relations:
+                      - { name: Status, kind: manyToOne, to: ProformaStatus, function: EntityStatus, init: 1 }
+                  - name: Invoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                generates:
+                  - name: invoice-from-proforma
+                    from: Proforma
+                    to: Invoice
+                    forEntity: Proforma
+                    sourceStatus: 3
+                """);
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(model)
+                                                   .get(0);
+
+        // Pre-resolved to the EntityStatus FK property + the seed id the source flips to.
+        assertEquals("Status", g.get("sourceStatusProperty"));
+        assertEquals("3", g.get("sourceStatusValue"));
+        assertEquals("Proforma", g.get("fromPerspective"));
     }
 
     @SuppressWarnings("unchecked")

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
@@ -54,6 +54,16 @@ public class ${className}Generate {
             new gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Repository().save(item);
         }
 #end
+#if($sourceStatusValue != "")
+        // Completion hook (intent `sourceStatus:`): the source document reaches its post-generation
+        // status now that the target exists (e.g. a proforma flips to INVOICED). A workflow-style
+        // system write - no "-updated" re-fire (no onUpdate reactions), but the dedicated
+        // "-transitioned" topic IS published so posting glue / integrations observe the transition.
+        source.${sourceStatusProperty} = ${sourceStatusValue};
+        new gen.${javaGenFolderName}.data.${fromJavaPerspective}.${fromEntity}Repository().updateWithoutEvent(source);
+        org.eclipse.dirigible.sdk.messaging.Producer.sendToTopic(
+                "${projectName}-${fromPerspective}-${fromEntity}-transitioned", Json.stringify(source));
+#end
         return Json.stringify(saved);
     }
 }

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -800,7 +800,11 @@ export function generateFiles(model, parameters, templateSources) {
                                 toItemEntity: g.toItemEntity,
                                 srcFkProperty: g.srcFkProperty,
                                 toFkProperty: g.toFkProperty,
-                                itemFieldAssignments: g.itemFieldAssignments
+                                itemFieldAssignments: g.itemFieldAssignments,
+                                // Completion hook: flip the source's status after the target exists.
+                                fromPerspective: g.fromPerspective,
+                                sourceStatusProperty: g.sourceStatusProperty,
+                                sourceStatusValue: g.sourceStatusValue
                             };
                             const cleanGenerateParameters = cleanData(generateParameters);
                             generatedFiles.push({


### PR DESCRIPTION
## What

`generates:` (create-from) gains an optional **`sourceStatus: <EntityStatus seed id>`** — the completion hook the flow was missing:

```yaml
generates:
  - name: invoice-from-proforma
    from: ProformaInvoice
    to: SalesInvoice
    map: { Customer: Customer, Company: Company }
    defaults: { date: now }
    sourceStatus: 3        # the proforma flips to INVOICED once the invoice exists
```

Until now the create-from link was one-way: the target was created through its repository (numbering, status init, calculated fields all fire), but the **source** stayed in its pre-generation status and the flip was a manual step.

## Semantics

A workflow-style **system write**, consistent with the setter delegates: the source's EntityStatus FK is set after the target (and its cloned items) are saved, persisted via `updateWithoutEvent` — no `-updated` re-fire, so onUpdate reactions stay quiet — and the source's **`-transitioned` topic is published**, so posting glue and integrations observe the transition like any other status change.

- Parser: `sourceStatus` requires the `from` entity to declare a `function: EntityStatus` relation.
- Glue: pre-resolves the FK property (PascalCase) + seed id; empty when the hook is absent, so existing `generates` blocks generate byte-identical code.
- Template: the flip renders after the save + items clone in `Generate.java.template`.

## Verification

- Live end-to-end on a generated application: proforma → *Generate Invoice* → invoice created → proforma `Status == 3` (INVOICED).
- `GlueGeneratesTest`: the resolved hook fields and the no-hook default (guards the byte-identical path for existing blocks). Full engine-intent suite 114/114.
- Docs: `intent-assistant-guide.md`, module README (the item moves out of the Planned list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)