### PR TITLE
feat(intent): function: Calendar — the presentation-role alias for view: calendar

### DIFF
--- a/components/engine/engine-intent/README.md
+++ b/components/engine/engine-intent/README.md
@@ -446,9 +446,9 @@ UI-test manifest, and its perspective in the generated Harmonia SPA + the shared
 
 ## Planned - recognised but not yet implemented
 
-- **`function: Calendar`** - reserved as an entity presentation role; rejected with a clear "not
-  yet available" message (the `view: calendar|range|slots` pages above are the current calendar
-  surface). Likewise other reserved `function` values for upcoming templates.
+- **Reserved `function:` roles** - `Board`, `Gantt`, `Timeline`; rejected with a clear "not yet
+  available" message. (`function: Calendar` is now first-class - the role alias for
+  `view: calendar`.)
 - **`manyToMany`** - parsed but never materialized; the supported shape is the explicit
   intermediate entity.
 - **Declarative glue actions beyond the current set** (see CLAUDE.md "Planned: declarative glue"):

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -30,10 +30,11 @@ public class EntityIntent {
 
     /**
      * Explicit presentation role that selects the entity's UI template - {@code Document},
-     * {@code DocumentItem}, {@code Master}, {@code Detail}, {@code List}, {@code Setting} (and reserved
-     * future templates such as {@code Calendar}). Authoritative when set; otherwise the role is
-     * inferred from structure and the legacy flags ({@code kind: setting}, an {@code *Item}-named
-     * child).
+     * {@code DocumentItem}, {@code Master}, {@code Detail}, {@code List}, {@code Setting}, or
+     * {@code Calendar} (the role alias for {@code view: calendar} - the entity renders on the Harmonia
+     * calendar, configured by the {@code calendar:} block; reserved values such as
+     * {@code Board}/{@code Gantt} stay gated). Authoritative when set; otherwise the role is inferred
+     * from structure and the legacy flags ({@code kind: setting}, an {@code *Item}-named child).
      */
     private String function;
     /**
@@ -144,10 +145,12 @@ public class EntityIntent {
     }
 
     /**
-     * Whether this entity uses the calendar renderer ({@code view: calendar} or {@code view: range}).
+     * Whether this entity uses the calendar renderer - {@code view: calendar}, {@code view: range}, or
+     * the presentation role {@code function: Calendar} (the role alias for {@code view: calendar}; the
+     * {@code calendar:} block configures it either way).
      */
     public boolean isCalendar() {
-        return viewIs("calendar") || viewIs("range");
+        return viewIs("calendar") || viewIs("range") || functionIs("Calendar");
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -82,12 +82,13 @@ public final class IntentParser {
     private static final Set<String> NUMERIC_TYPES = Set.of("integer", "int", "long", "decimal", "double");
     private static final Set<String> RELATION_KINDS = Set.of("oneToMany", "manyToOne", "oneToOne", "manyToMany");
     /** Implemented entity {@code function} values (lower-cased), selecting the entity's UI template. */
-    private static final Set<String> ENTITY_FUNCTIONS = Set.of("document", "documentitem", "master", "detail", "list", "setting");
+    private static final Set<String> ENTITY_FUNCTIONS =
+            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar");
     /**
      * Entity {@code function} values whose template is reserved but not yet shipped (gated with a
      * message).
      */
-    private static final Set<String> ENTITY_FUNCTIONS_RESERVED = Set.of("calendar", "board", "gantt", "timeline");
+    private static final Set<String> ENTITY_FUNCTIONS_RESERVED = Set.of("board", "gantt", "timeline");
     /** Implemented field {@code function} values (lower-cased). */
     private static final Set<String> FIELD_FUNCTIONS = Set.of("documenttitle");
     /** Implemented relation {@code function} values (lower-cased). */
@@ -229,7 +230,7 @@ public final class IntentParser {
                             + "] is reserved for an upcoming template and is not yet available in this version");
                 } else if (!ENTITY_FUNCTIONS.contains(key)) {
                     issues.add("entity [" + name + "] has unknown function [" + fn
-                            + "] (valid: Document, DocumentItem, Master, Detail, List, Setting)");
+                            + "] (valid: Document, DocumentItem, Master, Detail, List, Setting, Calendar)");
                 } else if (entity.isDocumentItem() && !compositionParent.containsKey(name)) {
                     issues.add("entity [" + name
                             + "] function: DocumentItem must be a composition child (a manyToOne/oneToOne relation with composition: true)");
@@ -304,10 +305,21 @@ public final class IntentParser {
     private static void validateViews(IntentModel model, List<String> issues) {
         for (EntityIntent entity : model.getEntities()) {
             String view = entity.getView();
+            String name = entity.getName();
+            boolean functionCalendar = entity.getFunction() != null && "calendar".equalsIgnoreCase(entity.getFunction()
+                                                                                                         .trim());
             if (view == null || view.isBlank()) {
+                if (!functionCalendar) {
+                    continue;
+                }
+                // function: Calendar is the role alias for view: calendar - same rendering, same
+                // required calendar block, validated below with the effective view.
+                view = "calendar";
+            } else if (functionCalendar && !"calendar".equalsIgnoreCase(view.trim())) {
+                issues.add("entity [" + name + "] declares function: Calendar together with view: " + view
+                        + " - the role implies view: calendar; drop one of the two");
                 continue;
             }
-            String name = entity.getName();
             String v = view.trim();
             if (!"calendar".equalsIgnoreCase(v) && !"range".equalsIgnoreCase(v) && !"slots".equalsIgnoreCase(v)) {
                 issues.add("entity [" + name + "] has unknown view [" + view + "] (supported: calendar, range, slots)");

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -354,6 +354,7 @@ existing breaks.
 | `Detail` | a plain composition detail | was a composition child |
 | `List` | plain searchable list | had no composition children |
 | `Setting` | nomenclature under Settings | `kind: setting` |
+| `Calendar` | records as events on the Harmonia calendar | `view: calendar` (the role alias; the `calendar:` block is required either way) |
 
 **Field `function`:** `DocumentTitle` (the document's title/number). **Relation `function`:**
 `EntityStatus` (the read-only status badge, valid on any entity).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionCalendarTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionCalendarTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.parser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code function: Calendar} - the presentation-role alias for {@code view: calendar}: previously a
+ * reserved value rejected with "not yet available", now first-class since the calendar template
+ * exists. Same rendering, same required {@code calendar:} block; other reserved roles stay gated.
+ */
+class FunctionCalendarTest {
+
+    private static String entity(String extra) {
+        return """
+                name: bookings
+                entities:
+                  - name: Appointment
+                %s
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: subject, type: string }
+                      - { name: startsAt, type: timestamp }
+                """.formatted(extra);
+    }
+
+    @Test
+    void functionCalendarSelectsTheCalendarRendering() {
+        IntentModel model = IntentParser.parse(entity("""
+                    function: Calendar
+                    calendar: { start: startsAt, title: subject }
+                """));
+        assertTrue(model.getEntities()
+                        .get(0)
+                        .isCalendar(),
+                "function: Calendar must select the calendar renderer like view: calendar");
+    }
+
+    @Test
+    void functionCalendarStillRequiresTheCalendarBlock() {
+        IntentValidationException error =
+                assertThrows(IntentValidationException.class, () -> IntentParser.parse(entity("    function: Calendar")));
+        assertTrue(error.getMessage()
+                        .contains("requires calendar.start"),
+                error.getMessage());
+    }
+
+    @Test
+    void functionCalendarConflictingWithAnotherViewIsRejected() {
+        IntentValidationException error = assertThrows(IntentValidationException.class, () -> IntentParser.parse(entity("""
+                    function: Calendar
+                    view: slots
+                    slots: { start: startsAt }
+                """)));
+        assertTrue(error.getMessage()
+                        .contains("the role implies view: calendar"),
+                error.getMessage());
+    }
+
+    @Test
+    void otherReservedRolesStayGated() {
+        IntentValidationException error =
+                assertThrows(IntentValidationException.class, () -> IntentParser.parse(entity("    function: Board")));
+        assertTrue(error.getMessage()
+                        .contains("reserved for an upcoming template"),
+                error.getMessage());
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionIntentTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/FunctionIntentTest.java
@@ -153,8 +153,10 @@ class FunctionIntentTest {
     }
 
     @Test
-    void gatesReservedCalendarFunction() {
-        String yaml = base("    function: Calendar\n");
+    void gatesReservedBoardFunction() {
+        // Calendar graduated to a first-class role (the view: calendar alias - see
+        // FunctionCalendarTest); the remaining reserved roles keep the clear gate.
+        String yaml = base("    function: Board\n");
         assertIssue(yaml, "reserved for an upcoming template");
     }
 


### PR DESCRIPTION
## What

`function: Calendar` was a **reserved** entity presentation role, rejected with "not yet available" — even though the calendar template has existed upstream since #6203/#6206, reachable only through the separate `view: calendar` selector. Since `function:` is the axis that selects an entity's UI template (`Document`, `Setting`, …), tagging an entity `Calendar` should simply select the calendar rendering — it now does:

```yaml
entities:
  - name: Appointment
    function: Calendar
    calendar: { start: startsAt, title: subject }
```

## How

- `EntityIntent.isCalendar()` gains the `function: Calendar` case — it is the single switch every downstream consumer keys on (EDM `layoutType: MANAGE_CALENDAR`, the Harmonia calendar page, pickers), so the alias needs no generator changes.
- Parser: `calendar` moves from the reserved set to the valid entity functions; the `calendar:` block is validated identically to `view: calendar` (required `start` date/timestamp field, optional end/title/color checks); declaring `function: Calendar` together with a conflicting `view:` (`slots`/`range`) is rejected with a clear message. `Board`/`Gantt`/`Timeline` stay gated.
- Docs: guide function table + README (moves out of the Planned list).

## Tests

`FunctionCalendarTest`: alias selects the renderer, block still required, view conflict rejected, other reserved roles keep the gate. The old reserved-Calendar test repointed to `Board`. Full engine-intent suite 117/117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)