### PR TITLE
docs(intent): planned-list refresh - #6237/#6238 landed

### DIFF
--- a/components/engine/engine-intent/README.md
+++ b/components/engine/engine-intent/README.md
@@ -468,8 +468,8 @@ UI-test manifest, and its perspective in the generated Harmonia SPA + the shared
   generates, postings.
 - **Cross-model schedule SOURCE** - a schedule's `entity` must be local (the generate target may
   be cross-model).
-- **`generates` completion hook** - flipping the SOURCE record's status after creating the target
-  (`onDone`-style) is not yet expressible.
+- ~~`generates` completion hook~~ - LANDED (#6237): `sourceStatus` flips the source's
+  EntityStatus after the target is created.
 - **Embedded calendar panel for a DEPENDENT composition child** inside its master page - calendar
   views require a PRIMARY entity today.
 - **Pipeline hardening follow-ups** (tracked on the emission-coverage IT): seed-row key


### PR DESCRIPTION
The README's recognised-but-not-yet-implemented list predates the generates sourceStatus completion hook (#6237) and function: Calendar (#6238) - both landed; marked accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)