### PR TITLE
Include Console view in the Git perspective by default

### DIFF
--- a/components/ui/perspective-git/src/main/resources/META-INF/dirigible/perspective-git/index.html
+++ b/components/ui/perspective-git/src/main/resources/META-INF/dirigible/perspective-git/index.html
@@ -28,7 +28,7 @@
         <script type="text/javascript">
             angular.module('git', ['platformView', 'platformLayout', 'blimpKit']).controller('GitController', ($scope) => {
                 $scope.layoutConfig = {
-                    views: ['gitProjects', 'branchesLocal', 'branchesRemote', 'diff', 'gitStaging', 'gitHistory'],
+                    views: ['gitProjects', 'branchesLocal', 'branchesRemote', 'diff', 'gitStaging', 'console', 'gitHistory'],
                     viewSettings: {
                         gitProjects: {
                             expanded: true


### PR DESCRIPTION
## Summary

Adds the built-in `console` view to the Git perspective's bottom pane, ordered before History so it is the first and initially focused tab on a fresh layout.

## Motivation

Cloning a project with many git dependencies (`project.json` git deps resolved recursively) currently gives no feedback in the Git perspective until the whole operation completes - the user waits on a spinner with no indication of what is happening. `CloneCommand` already logs each cloned project, dependency retrieval, and publish at INFO level; surfacing the Console view in the perspective makes that progress visible as each project lands.

## Details

- One-line change in `perspective-git/index.html`: `views: [... 'gitStaging', 'console', 'gitHistory']`.
- The Console view registers at the global `platform-views` extension point (`region: 'bottom'`), so listing it is sufficient; placed before `gitHistory`, it becomes the first bottom tab and the tab bar auto-selects the first registered tab when none is selected.
- Browsers with an existing saved layout state for the Git perspective get the Console tab appended via the initial-open-views reconciliation, keeping their saved order/selection; fresh layouts get it first and focused.

## Verification

- `mvn -P quick-build install -pl components/ui/perspective-git` passes; the built jar contains the updated view list.
- Exercised live against a running instance (registry copy refreshed): `/services/web/perspective-git/index.html` serves the new list and the Console tab renders first in the bottom pane, streaming clone log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)