### PR TITLE
feat(ui): list the Application and My shells in the IDE Window -> Shells menu

### DIFF
--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/configs/shell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/configs/shell.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const shellData = {
+    id: 'applicationShell',
+    path: '/services/web/application/index.html',
+    label: 'Applications'
+};
+if (typeof exports !== 'undefined') {
+    exports.getShell = () => shellData;
+}

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/extensions/shell.extension
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/extensions/shell.extension
@@ -1,0 +1,5 @@
+{
+    "module": "application/configs/shell.js",
+    "extensionPoint": "platform-shells",
+    "description": "Application Shell"
+}

--- a/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/configs/shell.js
+++ b/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/configs/shell.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const shellData = {
+    id: 'myShell',
+    path: '/services/web/my/index.html',
+    label: 'My'
+};
+if (typeof exports !== 'undefined') {
+    exports.getShell = () => shellData;
+}

--- a/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/extensions/shell.extension
+++ b/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/extensions/shell.extension
@@ -1,0 +1,5 @@
+{
+    "module": "my/configs/shell.js",
+    "extensionPoint": "platform-shells",
+    "description": "My Shell"
+}


### PR DESCRIPTION
## What

The Web IDE's **Window -> Shells** submenu is populated from the `platform-shells` extension point, but only the Workbench (`shell-ide`) and the Dashboard contributed a shell extension. The shared application shell (`/services/web/application/`) and the new personal **My Shell** (`/services/web/my/`, #6260) were not reachable from the menu.

This registers both, mirroring the Dashboard's extension + config pattern:

- `resources-application`: `applicationShell` — **Applications** -> `/services/web/application/index.html`
- `resources-my`: `myShell` — **My** -> `/services/web/my/index.html`

## Verified

On a freshly packaged fat jar, the menus extension service (`/services/js/platform-core/extension-services/menus.js`) returns Window -> Shells with all four entries — Applications, Dashboard, My, Workbench — and both linked pages serve 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)