### PR TITLE
fix(template): Harmonia personal (my) pages call the wrong API object

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
@@ -44,7 +44,7 @@ document.addEventListener('alpine:init', () => {
       await this.loadOptions();
       if (this.id) {
         try {
-          const record = await App.api.get(this.apiPath + '/' + this.id);
+          const record = await App.services.api.get(this.apiPath + '/' + this.id);
           for (const key of Object.keys(this.form)) {
             if (record[key] !== undefined && record[key] !== null) this.form[key] = record[key];
           }
@@ -113,9 +113,9 @@ document.addEventListener('alpine:init', () => {
       this.error = null;
       try {
         if (this.mode === 'edit') {
-          await App.api.put(this.apiPath + '/' + this.id, this.toPayload());
+          await App.services.api.put(this.apiPath + '/' + this.id, this.toPayload());
         } else {
-          await App.api.post(this.apiPath, this.toPayload());
+          await App.services.api.post(this.apiPath, this.toPayload());
         }
         this.goBack();
       } catch (e) {
@@ -128,7 +128,7 @@ document.addEventListener('alpine:init', () => {
     async confirmDelete() {
       this.deleteBusy = true;
       try {
-        await App.api.del(this.apiPath + '/' + this.id);
+        await App.services.api.delete(this.apiPath + '/' + this.id);
         this.deleteOpen = false;
         this.goBack();
       } catch (e) {
@@ -167,7 +167,7 @@ document.addEventListener('alpine:init', () => {
     async loadChildren() {
       for (const child of this.children) {
         try {
-          child.rows = await App.api.get(child.apiPath + '?' + encodeURIComponent(child.fkProperty) + '=' + encodeURIComponent(this.id)) || [];
+          child.rows = await App.services.api.get(child.apiPath + '?' + encodeURIComponent(child.fkProperty) + '=' + encodeURIComponent(this.id)) || [];
           if (child.calendar) child.calCfg = { view: child.calendar.view, events: this.buildEvents(child) };
           child.state = 'default';
         } catch (e) {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
@@ -26,7 +26,7 @@ document.addEventListener('alpine:init', () => {
     async load() {
       this.state = 'loading';
       try {
-        this.items = await App.api.get(this.apiPath) || [];
+        this.items = await App.services.api.get(this.apiPath) || [];
         this.state = this.items.length ? 'default' : 'empty';
       } catch (e) {
         this.error = (e && e.message) || 'Could not load your ${menuLabel}.';


### PR DESCRIPTION
## Problem

Every generated **personal (\"my\") surface** in the Harmonia Java runtime was broken. Opening e.g. the My shell route

```
/services/web/my/index.html#/app/kf-mod-vacations-my-VacationRequest/my/VacationRequest
```

rendered the page's **error state** with:

```
Cannot read properties of undefined (reading 'get')
```

## Cause

The personal list/form page templates called `App.api.get/put/post/del`, but the shared Harmonia runtime exposes its fetch client as **`App.services.api`** (and the delete method is `delete()`, not `del()`). `App.api` is `undefined`, so `App.api.get(...)` throws on load.

Every non-personal generated page already uses `App.services.api.*` — and the `loadOptions()` call in the *same* form template used `App.services.api.getAll` correctly — so these were copy typos in the two `ui/my/` templates only.

## Fix

Point `my-list-page.js.template` and `my-form-page.js.template` at `App.services.api.{get,put,post,delete}`. Six call sites across the two templates; no behavioural change beyond hitting the object that actually exists.

## Verification

Driven on a running instance (Chrome, form-login):

- `#/app/kf-mod-vacations-my-VacationRequest/my/VacationRequest` → list renders (empty-state \"No records yet.\"), no console error.
- `.../my/VacationRequest/create` → form renders all fields, no console error.

Confirmed the served generated JS now emits `App.services.api.get(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)