### PR TITLE
fix(template): Harmonia perspective icons use the Lucide name, not a unicons URL

### DIFF
--- a/components/template/template-application-ui-harmonia-java/README.md
+++ b/components/template/template-application-ui-harmonia-java/README.md
@@ -91,6 +91,17 @@ Velocity model vars (per-entity collections, same as the Angular module):
 `${primaryKeysString}`, `$hasProcess`. The aggregate `index.html` is generated with
 no `collection`, so `$models` = `model.entities`.
 
+**Perspective icons are Lucide NAMES, not unicons URLs.** The generated `perspective.js`
+(both the shared-shell `perspective/perspective.js.template` and the My-shell
+`my/my-perspective.js.template`) emits `icon: '${iconName}'` — the bare Lucide / Harmonia
+built-in icon name (the model's `iconName`), which the application shell and My shell render
+via `x-h-lucide`. It does **NOT** emit `${perspectiveIcon}` (the `/services/web/resources/unicons/<name>.svg`
+URL): that path is only meaningful to the legacy **AngularJS** perspective and 404s in the Harmonia
+shells (whose `isSvgIcon`/`isImageIcon` would send a `.svg` path down the `<svg data-link>` branch to
+a missing file). The `.model` still carries `perspectiveIcon` for the AngularJS stack — untouched.
+So the intent `icon:` must be a valid Lucide name (bundled `org.webjars.npm:lucide` `dist/esm/icons/<name>.js`,
+currently 1.8.0); an unknown name renders blank.
+
 ## Parity checklist (TODO)
 
 | View type | Angular collection | Status |

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-perspective.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-perspective.js.template
@@ -17,7 +17,9 @@ const perspectiveData = {
 #if($perspectiveOrder)
 	order: ${perspectiveOrder},
 #end
-	icon: '${perspectiveIcon}'
+	// Lucide / Harmonia built-in icon NAME (rendered by the shell via x-h-lucide), not a unicons SVG
+	// URL - the Harmonia shells resolve a bare name through Lucide; a '<name>.svg' path would 404.
+	icon: '${iconName}'
 };
 if (typeof exports !== 'undefined') {
 	exports.getPerspective = () => perspectiveData;

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/perspective.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/perspective.js.template
@@ -22,7 +22,9 @@ const perspectiveData = {
 #if($perspectiveOrder)
 	order: ${perspectiveOrder},
 #end
-	icon: '${perspectiveIcon}'
+	// Lucide / Harmonia built-in icon NAME (rendered by the shell via x-h-lucide), not a unicons SVG
+	// URL - the Harmonia shells resolve a bare name through Lucide; a '<name>.svg' path would 404.
+	icon: '${iconName}'
 };
 if (typeof exports !== 'undefined') {
 	exports.getPerspective = () => perspectiveData;


### PR DESCRIPTION
## Problem

Every generated Harmonia app's perspective 404'd its sidebar icon in the shared **application shell** and the **My shell**:

```
GET /services/web/resources/unicons/palmtree.svg → 404
GET /services/web/resources/unicons/user-clock.svg → 404   (and gauge, calendar-check, …)
```

## Cause

The generated `perspective.js` (both `perspective/perspective.js.template` and `my/my-perspective.js.template`) emitted `icon: '${perspectiveIcon}'` — a `/services/web/resources/unicons/<name>.svg` URL. But the Harmonia shells render a perspective icon via **`x-h-lucide` from a bare icon NAME**; an `.svg` path is sent down the `<svg data-link>` branch and points at a unicons file that does not exist (the intent `icon:` values — `palmtree`, `gauge`, `calendar-check`, … — are **Lucide** names, and the unicons pack uses entirely different names).

## Fix

Emit `icon: '${iconName}'` — the model's bare Lucide/Harmonia built-in icon name — which the shells resolve through Lucide. **Harmonia templates only**: the `.model` still carries `perspectiveIcon` (the unicons URL) for the legacy AngularJS stack, which is untouched.

Consequence, now documented in the module README: an intent `icon:` must be a valid **Lucide** name (bundled `org.webjars.npm:lucide`, currently 1.8.0). An unknown name renders a blank icon.

## Verification

Driven on a running instance (Chrome, form-login) after applying the equivalent change to the served perspective files:

- **My shell** `#/app/kf-mod-vacations-my-VacationRequest/my/VacationRequest` → **zero console errors** (previously two `unicons/*.svg` 404s).
- **Application shell** `/services/web/application/` → no `unicons/*.svg` requests at all (icons render via Lucide).

Downstream: the KeyFolders module intents were swept for invalid Lucide names alongside this (`palmtree→tree-palm`, `alert-triangle→triangle-alert`, `id-badge→id-card`, `user-clock→clock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)