### PR TITLE
fix(template): personal (my) form uses Harmonia date/time pickers, not native inputs

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -44,9 +44,24 @@
 #elseif($property.widgetType == "CHECKBOX")
         <span x-h-checkbox><input type="checkbox" x-model="form.${property.name}" /></span>
 #elseif($property.widgetType == "DATE")
-        <input x-h-input type="date" x-model="form.${property.name}" />
+        <!-- Harmonia date picker: model is YYYY-MM-DD (same as the native date input it replaces),
+             so form.${property.name} round-trips unchanged through toDateInput/toPayload. -->
+        <div x-h-date-picker>
+          <input type="text" />
+          <button x-h-date-picker-trigger aria-label="Choose date"></button>
+          <div x-h-date-picker-popup x-model="form.${property.name}"></div>
+        </div>
 #elseif($property.widgetType == "DATETIME-LOCAL")
-        <input x-h-input type="datetime-local" x-model="form.${property.name}" />
+        <div x-h-datetime-picker>
+          <input type="text" />
+          <button x-h-datetime-picker-trigger aria-label="Choose date and time"></button>
+          <div x-h-datetime-picker-popup x-model="form.${property.name}"></div>
+        </div>
+#elseif($property.widgetType == "TIME")
+        <div x-h-time-picker>
+          <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
+          <div x-h-time-picker-popup></div>
+        </div>
 #else
         <input x-h-input type="text" x-model="form.${property.name}" />
 #end


### PR DESCRIPTION
## Problem

The generated **personal (my) form** still rendered **native** date controls:

```html
<input x-h-input type="date" ... />
<input x-h-input type="datetime-local" ... />
```

even though the main `form-view` and the Harmonia form-builder already use the Harmonia components. Native pickers are not to be used where a Harmonia component exists.

## Fix

Mirror the canonical `form-view` markup in `ui/my/my-form-view.html.template`:

- `DATE` → `x-h-date-picker`
- `DATETIME-LOCAL` → `x-h-datetime-picker`
- `TIME` → `x-h-time-picker` (added; previously fell through to a text input)

The model formats are identical to the native inputs (`YYYY-MM-DD` / ISO-with-`T`), so the form page's existing `toDateInput` / `toPayload` conversions round-trip unchanged — same as the main form-view proves.

## Audit result (all Harmonia templates)

After this change, the **only** remaining native date-family inputs across every Harmonia template are `type="month"` and `type="week"` in the main `form-view` — because **Harmonia ships no month or week picker** (it has `date-picker`, `datetime-picker`, `time-picker`, `calendar`, `inline-calendar`, `slot-picker`). See the notify note in the PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)