### PR TITLE
fix(template): personal (my) pages render EntityStatus as a badge + fix stray Delete dialog

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-page.js.template
@@ -16,6 +16,11 @@
 #else
 #set($skipParentFk = "__none__")
 #end
+## The EntityStatus relation (widget DOCUMENT_STATUS) is surfaced as a read-only badge, not a control.
+#set($statusProp = "")
+#foreach($property in $properties)
+#if($property.widgetType == "DOCUMENT_STATUS")#set($statusProp = $property.name)#end
+#end
 document.addEventListener('alpine:init', () => {
   Alpine.data('${name}MyFormPage', () => ({
     ...basePage(),
@@ -54,7 +59,7 @@ document.addEventListener('alpine:init', () => {
 #end
 #end
 #foreach($property in $properties)
-#if($property.widgetType == "DROPDOWN" && !$property.sensitiveProperty)
+#if(($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS") && !$property.sensitiveProperty)
           if (this.form.${property.name} != null && this.form.${property.name} !== '') this.form.${property.name} = String(this.form.${property.name});
 #end
 #end
@@ -85,7 +90,7 @@ document.addEventListener('alpine:init', () => {
     async loadOptions() {
       const loaded = {};
 #foreach($property in $properties)
-#if($property.widgetType == "DROPDOWN" && !$property.sensitiveProperty && $property.name != $skipOwnerFk && $property.name != $skipParentFk)
+#if(($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS") && !$property.sensitiveProperty && $property.name != $skipOwnerFk && $property.name != $skipParentFk)
       try {
         const rows = await App.services.api.getAll('${property.widgetDropdownControllerUrl}', { baseUrl: '' });
         loaded['${property.name}'] = (rows || []).map(r => ({ value: r.${property.widgetDropDownKey}, text: r.${property.widgetDropDownValue} }));
@@ -94,6 +99,25 @@ document.addEventListener('alpine:init', () => {
 #end
       this.options = loaded;
     },
+#if($statusProp != "")
+
+    // EntityStatus badge (read-only): resolve the status FK to its label + a semantic colour, the
+    // same mapping the main form-view/document-view use.
+    statusText() {
+      const v = this.form.${statusProp};
+      const opt = (this.options['${statusProp}'] || []).find((o) => String(o.value) === String(v));
+      return opt ? opt.text : '';
+    },
+    statusVariant(text) {
+      const t = String(text || '').toLowerCase();
+      if (/draft/.test(t)) return 'outline';
+      if (/(cancel|reject|declin|void|fail|overdue|insufficient|exhaust)/.test(t)) return 'negative';
+      if (/(pending|await|hold|review|partial)/.test(t)) return 'warning';
+      if (/(approv|accept|activ|complet|paid|done|available)/.test(t)) return 'positive';
+      if (/(issu|sent|ship|process|submit)/.test(t)) return 'information';
+      return 'default';
+    },
+#end
 
     toPayload() {
       const payload = { ...this.form };

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -9,11 +9,20 @@
 #else
 #set($skipParentFk = "__none__")
 #end
+## The EntityStatus relation (widget DOCUMENT_STATUS) renders as a read-only badge in the toolbar,
+## exactly like the main form-view - never as an editable control on the personal surface.
+#set($statusProp = "")
+#foreach($property in $properties)
+#if($property.widgetType == "DOCUMENT_STATUS")#set($statusProp = $property.name)#end
+#end
 <div x-data="${name}MyFormPage" class="vbox size-full">
 
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title class="shrink-0"
           x-text="(mode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit') : T('$projectName:${tprefix}.defaults.new', 'New')) + ' ' + T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}')"></span>
+#if($statusProp != "")
+    <span x-h-badge class="shrink-0" :data-variant="statusVariant(statusText())" x-show="mode === 'edit' && statusText()" x-text="statusText()"></span>
+#end
     <div x-h-toolbar-spacer></div>
     <button x-h-button data-variant="transparent" @click="goBack()" x-text="T('$projectName:${tprefix}.defaults.back', 'Back')"></button>
   </div>
@@ -24,7 +33,7 @@
   <div x-show="state === 'default'" class="p-4 vbox gap-4 overflow-auto">
     <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
-#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true")
+#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != $skipOwnerFk && $property.name != $skipParentFk && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS")
       <div x-h-field style="grid-column: span #if($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end">
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end
@@ -156,11 +165,15 @@
     </div>
   </div>
 
-  <!-- Delete confirmation -->
-  <div x-h-dialog-overlay :data-open="deleteOpen"></div>
-  <div x-h-dialog :data-open="deleteOpen">
-    <div x-h-dialog-content data-size="sm">
-      <div x-h-dialog-header><span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span></div>
+  <!-- Delete confirmation. The dialog MUST be nested inside the overlay (not a sibling) or it is
+       not hidden when closed - it would show its "Delete?" body on the New page. -->
+  <div x-h-dialog-overlay :data-open="deleteOpen">
+    <div x-h-dialog data-size="sm">
+      <div x-h-dialog-header>
+        <span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span>
+        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+      </div>
+      <div x-h-dialog-content><p x-h-text.muted x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure? This cannot be undone.')"></p></div>
       <div x-h-dialog-footer>
         <button x-h-button data-variant="transparent" @click="deleteOpen = false" :disabled="deleteBusy"
                 x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
@@ -9,17 +9,36 @@
  * scoped ${name}MyController (sensitive fields never arrive). New / row-click navigate to the
  * routed my-form.
  */
+## The EntityStatus relation (widget DOCUMENT_STATUS) shows as a coloured badge, not a number column.
+#set($statusProp = "")
+#foreach($property in $properties)
+#if($property.widgetType == "DOCUMENT_STATUS")
+#set($statusProp = $property.name)
+#set($statusUrl = $property.widgetDropdownControllerUrl)
+#set($statusKey = $property.widgetDropDownKey)
+#set($statusVal = $property.widgetDropDownValue)
+#end
+#end
 document.addEventListener('alpine:init', () => {
   Alpine.data('${name}MyListPage', () => ({
     ...basePage(),
     state: 'loading',
     items: [],
     error: null,
+#if($statusProp != "")
+    statusOptions: [],
+#end
 
     // Controller path for the PERSONAL surface, relative to App.config.restBase.
     apiPath: '/${javaPerspectiveName}/${name}MyController',
 
     async init() {
+#if($statusProp != "")
+      try {
+        const rows = await App.services.api.getAll('${statusUrl}', { baseUrl: '' });
+        this.statusOptions = (rows || []).map((r) => ({ value: r.${statusKey}, text: r.${statusVal} }));
+      } catch (e) { this.statusOptions = []; }
+#end
       await this.load();
     },
 
@@ -41,11 +60,28 @@ document.addEventListener('alpine:init', () => {
       if (col.number) return window.HarmoniaFormat ? window.HarmoniaFormat.number(v) : String(v);
       return String(v);
     },
+#if($statusProp != "")
+
+    // EntityStatus badge: resolve the FK to its label + semantic colour (same mapping as the forms).
+    statusText(row) {
+      const opt = this.statusOptions.find((o) => String(o.value) === String(row.${statusProp}));
+      return opt ? opt.text : '';
+    },
+    statusVariant(text) {
+      const t = String(text || '').toLowerCase();
+      if (/draft/.test(t)) return 'outline';
+      if (/(cancel|reject|declin|void|fail|overdue|insufficient|exhaust)/.test(t)) return 'negative';
+      if (/(pending|await|hold|review|partial)/.test(t)) return 'warning';
+      if (/(approv|accept|activ|complet|paid|done|available)/.test(t)) return 'positive';
+      if (/(issu|sent|ship|process|submit)/.test(t)) return 'information';
+      return 'default';
+    },
+#end
 
     columns: [
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "$!{personalProperty}" && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.widgetIsMajor != "false")
-      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
+      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DOCUMENT_STATUS"), status: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
 #end
 #end
     ],

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-view.html.template
@@ -32,7 +32,10 @@
         <template x-for="row in items" :key="row.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end">
           <tr x-h-table-row data-hoverable="true" class="cursor-pointer" @click="openEntity(row)">
             <template x-for="col in columns" :key="col.name">
-              <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="display(row, col)"></td>
+              <td x-h-table-cell :class="col.number ? 'text-right' : ''">
+                <template x-if="col.status"><span x-h-badge :data-variant="statusVariant(statusText(row))" x-text="statusText(row)"></span></template>
+                <template x-if="!col.status"><span x-text="display(row, col)"></span></template>
+              </td>
             </template>
           </tr>
         </template>


### PR DESCRIPTION
Two fixes to the Harmonia **personal (my)** templates, bringing them in line with the main `form-view`/`document-view`. Personal-templates only — no generator/backend change.

## 1. Status is now a badge, not a plain field

An `EntityStatus` relation (`widgetType=DOCUMENT_STATUS`) was rendered on the personal surface as an ordinary control / column:
- the **form** showed it as an editable dropdown;
- the **list** showed the raw FK **id**, right-aligned as a number (`isNumberType`).

Now it matches the main templates:
- **`my-form-view`** excludes the status from the editable field loop and renders it as a read-only `x-h-badge` in the toolbar. `my-form-page` gained `statusText()` / `statusVariant()` (the same keyword→variant map as `form-page`), loads the status options, and String-coerces the FK on edit.
- **`my-list-view` / `my-list-page`** render the status column as a badge with the resolved label (options loaded once), instead of the numeric FK id.

## 2. Stray "Delete?" dialog on the New page

The delete-confirmation dialog was a **sibling** of `x-h-dialog-overlay` (an empty overlay plus a detached `x-h-dialog`), so it was never hidden when closed — its "Delete?" body showed on the New page. It's now **nested inside** the overlay, matching the working main `form-view`.

## Notes / scope

- Velocity `#if`/`#foreach`/`#end` balanced; the status guard uses `#if($statusProp != "")` (the codebase idiom — an empty string is truthy in this Velocity config).
- Two related items from the same report are **follow-ups**, not in this PR: the "New … for <owner>" title (needs a cross-layer feature — the identity entity's display field exposed to a `/me` endpoint; the identity entity is typically cross-module) and the Project-Timesheet empty-`Name` dropdown (needs live diagnosis of whether the label was computed).
- Generation-time templates: picks up on the next app regen. Not yet driven end-to-end after a jar rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)