### PR TITLE
test(intent): guard personal (my) pages call App.services.api (regression #6263)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -311,6 +311,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(!myForm.contains("form.Person"), "the personal form must not render the owner FK control");
         String myLineForm = contentOf("gen/emission/js/components/pages/my/ClaimLineMyFormPage.js");
         assertTrue(myLineForm.contains("ClaimLineMyController"), "a personal child gets its own my form page");
+        // Regression guard (#6263): the personal pages must call the shared shell service object
+        // App.services.api. The bug emitted App.api - which does not exist - so every personal list
+        // and form load, save and delete threw "Cannot read properties of undefined (reading 'get')"
+        // at runtime while emission stayed green (the assert above only checked the controller name,
+        // which is present regardless of the API object). Assert the object, not just the path.
+        String myFormPage = contentOf("gen/emission/js/components/pages/my/ClaimMyFormPage.js");
+        for (String personalPage : new String[] {myList, myFormPage, myLineForm}) {
+            assertTrue(personalPage.contains("App.services.api"), "a personal page must call the shared API service App.services.api");
+            assertTrue(!personalPage.contains("App.api."),
+                    "a personal page must not call the nonexistent App.api object (regression #6263)");
+        }
         String spaIndex = contentOf("gen/emission/index.html");
         assertTrue(spaIndex.contains("/my/Claim"), "the SPA must route the personal pages");
         String myPerspective = contentOf("gen/emission/perspectives/my/Claim/perspective.extension");


### PR DESCRIPTION
IntentEmissionCoverageIT covers the personal (my) surface on the backend (scoped controller, forced owner FK, sensitive scrub) and checks that the my list page references its scoped controller. But that string (`ClaimMyController`) is present regardless of which API object the page calls, so **#6263** - personal pages calling the nonexistent `App.api` instead of `App.services.api` - shipped with every pipeline step green and only surfaced by driving the My shell at runtime (`Cannot read properties of undefined (reading 'get')` on every personal list/form load, save, delete).

This adds the missing assertion at the emitted-page layer: the personal list, form, and child-form pages must call `App.services.api` and must not contain `App.api.`. Closes the silent-degradation gap for this class (the same spirit as the rest of this IT - assert the outermost observable layer, not just the parsed model or an incidental substring).

No behavior change - assertions only; green on current master (the fix merged in #6263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)