### PR TITLE
feat(resources): Partner shell (/partner/) + application-partner-perspectives extension point

### DIFF
--- a/components/group/group-ui/pom.xml
+++ b/components/group/group-ui/pom.xml
@@ -41,6 +41,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-resources-partner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-resources-inbox</artifactId>
         </dependency>
         <dependency>

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -252,6 +252,7 @@
         <module>resources/resources-dashboard</module>
         <module>resources/resources-application</module>
         <module>resources/resources-my</module>
+        <module>resources/resources-partner</module>
         <module>resources/resources-inbox</module>
         <module>resources/resources-documents</module>
         <module>resources/resources-karavan-libs</module>
@@ -1379,6 +1380,11 @@
             <dependency>
                 <groupId>org.eclipse.dirigible</groupId>
                 <artifactId>dirigible-components-resources-my</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.dirigible</groupId>
+                <artifactId>dirigible-components-resources-partner</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/components/resources/resources-partner/pom.xml
+++ b/components/resources/resources-partner/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dirigible</groupId>
+		<artifactId>dirigible-components-parent</artifactId>
+		<version>14.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+
+	<name>Components - Resources - Partner</name>
+	<artifactId>dirigible-components-resources-partner</artifactId>
+	<packaging>jar</packaging>
+
+	<properties>
+		<license.header.location>../../../licensing-header.txt</license.header.location>
+		<parent.pom.folder>../../../</parent.pom.folder>
+	</properties>
+
+</project>

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/configs/partner-group.js
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/configs/partner-group.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+/*
+ * The single navigation group of the Partner shell: every partner perspective declares
+ * groupId 'partner', defined once here (the same one-definition pattern as the application shell's
+ * navigation groups).
+ */
+exports.getPerspectiveGroup = () => ({
+	id: 'partner',
+	label: 'Partner',
+	order: 10,
+	// The service classifies a group by the presence of `items` - the aggregated personal
+	// perspectives are pushed into it by groupId.
+	items: []
+});

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/configs/shell.js
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/configs/shell.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ */
+const shellData = {
+    id: 'partnerShell',
+    path: '/services/web/partner/index.html',
+    label: 'Partner'
+};
+if (typeof exports !== 'undefined') {
+    exports.getShell = () => shellData;
+}

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/css/app.css
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/css/app.css
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Minimal shell styles on top of Harmonia. Layout is Harmonia's (vbox/hbox/size-full/x-h-*); this
+ * only hides x-cloak content until Alpine initialises and ensures the hosted iframe fills its panel.
+ */
+[x-cloak] {
+  display: none !important;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extension-points/partner-perspective.extensionpoint
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extension-points/partner-perspective.extensionpoint
@@ -1,0 +1,4 @@
+{
+    "name": "application-partner-perspectives",
+    "description": "Extension Point for the External partner perspective providers, aggregated by the Partner shell"
+}

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extensions/partner-group.extension
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extensions/partner-group.extension
@@ -1,0 +1,5 @@
+{
+    "module": "partner/configs/partner-group.js",
+    "extensionPoint": "application-partner-perspectives",
+    "description": "Partner Shell - the 'partner' navigation group"
+}

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extensions/shell.extension
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/extensions/shell.extension
@@ -1,0 +1,5 @@
+{
+    "module": "partner/configs/shell.js",
+    "extensionPoint": "platform-shells",
+    "description": "Partner Shell"
+}

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
@@ -1,0 +1,339 @@
+<!--
+
+    Copyright (c) 2010-2026 Eclipse Dirigible contributors
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v2.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v20.html
+
+    SPDX-FileCopyrightText: Eclipse Dirigible contributors
+    SPDX-License-Identifier: EPL-2.0
+
+-->
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  The Harmonia application shell (pure Java + Harmonia; the IDE stays AngularJS + BlimpKit). It
+  REUSES the shared Harmonia runtime served from /services/web/application-core/shell for the
+  built-in pages (Dashboard/Inbox/Documents/Reports) and aggregates the `application-perspectives`
+  extension point for the domain apps, which it hosts in an iframe (their generated SPA, embedded).
+-->
+<!-- data-brand-title: services/branding.js sets the tab title to the instance brand name. -->
+<html lang="en" data-brand-title>
+
+  <head>
+    <meta charset="UTF-8" />
+    <!-- Placeholder favicon, replaced at runtime by services/branding.js (DIRIGIBLE_BRANDING_FAVICON). -->
+    <link rel="icon" sizes="any" href="data:;base64,iVBORw0KGgo=" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Partner</title>
+
+    <link href="/webjars/codbex__harmonia/dist/harmonia.css" rel="stylesheet" />
+    <link href="/services/web/application-core/shell/css/app.css" rel="stylesheet" />
+    <link href="./css/app.css" rel="stylesheet" />
+
+    <script>
+      (function () {
+        try { if (!localStorage.getItem('codbex.harmonia.colorMode')) localStorage.setItem('codbex.harmonia.colorMode', 'light'); } catch (e) { /* no storage */ }
+      })();
+    </script>
+  </head>
+
+  <body class="vbox size-full" x-data="app">
+
+    <!-- Narrow-viewport drawer host. -->
+    <div x-h-sheet-overlay="isOpen">
+      <div x-h-sheet data-align="left" x-ref="overlay"></div>
+    </div>
+
+    <!-- x-cloak hides the shell until Alpine + Harmonia upgrade the markup (no raw-chrome flash). -->
+    <div x-cloak x-h-split class="size-full" data-orientation="horizontal" data-variant="border">
+
+      <!-- Sidebar -->
+      <div x-h-split-panel :data-hidden="hiddenPanels.left" data-max="280" data-min="220"
+           data-locked="true" data-gutterless="true" x-ref="sidebarPanel">
+        <div x-h-sidebar x-ref="sidebar">
+          <!-- Instance brand mark (DIRIGIBLE_BRANDING_LOGO / _NAME / _SUBTITLE via the `branding` store),
+               the Harmonia counterpart of the AngularJS shell header. With 2+ projections declared
+               (the application-projections extension point) it becomes the Harmonia
+               product-switch-header: the selected projection filters the shell. -->
+          <div x-h-sidebar-header>
+            <template x-if="projections.length > 1">
+              <div>
+                <button x-h-sidebar-menu-button data-size="lg" x-h-menu-trigger.dropdown>
+                  <img :src="$store.branding.logo" :alt="$store.branding.name" class="size-9 rounded-control" />
+                  <div class="vbox min-w-0 text-left">
+                    <span class="truncate font-medium" x-text="projectionLabel()"></span>
+                    <span class="truncate text-xs font-normal" x-text="projectionSubtitle()"></span>
+                  </div>
+                  <i x-h-lucide role="img" data-lucide="chevrons-up-down"></i>
+                </button>
+                <ul x-h-menu aria-label="Projections" data-align="bottom-start">
+                  <div x-h-menu-label x-text="T('application-core:shell.projections.title', 'Applications')"></div>
+                  <template x-for="p in projections" :key="p.id">
+                    <li x-h-menu-item @click="selectProjection(p)">
+                      <template x-if="isSvgIcon(p.icon)"><svg x-h-icon :data-link="p.icon" class="size-4" role="presentation"></svg></template>
+                      <template x-if="isImageIcon(p.icon)"><img :src="p.icon" alt="" class="size-4" /></template>
+                      <template x-if="!isSvgIcon(p.icon) && !isImageIcon(p.icon)"><i role="img" x-h-lucide :data-lucide="p.icon || 'box'"></i></template>
+                      <span class="flex-1" x-text="p.tkey ? T(p.tkey, p.label) : p.label"></span>
+                      <!-- svg placeholder: x-show on an <i x-h-lucide> is lost when the i is replaced by the svg -->
+                      <svg x-h-lucide x-show="projectionId === p.id" role="img" data-lucide="check"></svg>
+                    </li>
+                  </template>
+                </ul>
+              </div>
+            </template>
+            <template x-if="projections.length <= 1">
+              <div class="hbox items-center gap-2 p-1">
+                <img :src="$store.branding.logo" :alt="$store.branding.name" class="size-5" />
+                <div class="vbox gap-0">
+                  <span class="font-bold leading-tight" x-text="$store.branding.name"></span>
+                  <span x-show="$store.branding.subtitle" class="text-xs text-muted-foreground leading-tight" x-text="$store.branding.subtitle"></span>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <div x-h-sidebar-content>
+            <!-- Built-in shell sections (native Harmonia, reused from the shared runtime). -->
+            <div x-h-sidebar-group>
+              <div x-h-sidebar-group-label x-text="T('application-core:shell.nav.application', 'Application')"></div>
+              <div x-h-sidebar-group-content>
+                <ul x-h-sidebar-menu>
+                  <!-- The shell is task-first (inherited from the My shell copy; partner-scoped Inbox is a later phase): the Inbox IS the home page - a personal task
+                       ("Fill & confirm your July timesheet") is how work arrives here. -->
+                  <li x-h-sidebar-menu-item>
+                    <button x-h-sidebar-menu-button :data-active="isBuiltinActive('/inbox') || isBuiltinActive('/')" @click="navigate('/inbox')">
+                      <i role="img" x-h-lucide data-lucide="inbox"></i><span x-text="T('application-core:shell.nav.inbox', 'Inbox')"></span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <!-- Loading / empty states for the aggregated domain apps. -->
+            <div x-show="loading" x-cloak x-h-text.muted class="p-3 text-sm" x-text="T('application-core:shell.apps.loading', 'Loading applications...')"></div>
+            <div x-show="!loading && groups.length === 0" x-cloak x-h-text.muted class="p-3 text-sm" x-text="T('application-core:shell.apps.empty', 'No applications published yet.')"></div>
+
+            <!-- Domain apps: one group per navigation group (filtered by the active projection),
+                 items host the embedded app. -->
+            <template x-for="group in visibleGroups()" :key="group.id">
+              <div x-h-sidebar-group>
+                <div x-h-sidebar-group-label x-text="group.tkey ? T(group.tkey, group.label) : group.label"></div>
+                <div x-h-sidebar-group-content>
+                  <ul x-h-sidebar-menu>
+                    <template x-for="item in group.items" :key="item.id">
+                      <li x-h-sidebar-menu-item>
+                        <button x-h-sidebar-menu-button :data-active="isAppActive(item)" @click="openApp(item)">
+                          <template x-if="isSvgIcon(item.icon)"><svg x-h-icon :data-link="item.icon" class="size-4" role="presentation"></svg></template>
+                          <template x-if="isImageIcon(item.icon)"><img :src="item.icon" alt="" class="size-4" /></template>
+                          <template x-if="!isSvgIcon(item.icon) && !isImageIcon(item.icon)"><i role="img" x-h-lucide :data-lucide="item.icon || 'box'"></i></template>
+                          <span x-text="item.tkey ? T(item.tkey, item.label) : item.label"></span>
+                        </button>
+                      </li>
+                    </template>
+                  </ul>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          <!-- Settings pinned to the footer; it aggregates every app's SETTING entities. -->
+          <div x-h-sidebar-footer>
+            <ul x-h-sidebar-menu>
+              <li x-h-sidebar-menu-item x-show="visibleSettingsItems().length > 0">
+                <button x-h-sidebar-menu-button :data-active="settingsMode" @click="openSettings()">
+                  <i role="img" x-h-lucide data-lucide="settings"></i><span x-text="T('application-core:shell.nav.settings', 'Settings')"></span>
+                </button>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- Main panel -->
+      <div x-h-split-panel>
+        <div class="vbox size-full">
+          <div x-h-toolbar data-variant="transparent" x-cloak>
+            <button x-show="hiddenPanels.left" x-h-button data-variant="transparent"
+                    aria-label="Navigation" @click="openSideNav()" data-size="icon">
+              <i role="img" x-h-lucide data-lucide="menu"></i>
+            </button>
+            <span x-h-toolbar-title x-text="T('application-core:shell.nav.partnerPortal', 'Partner Portal')"></span>
+            <div x-h-toolbar-spacer></div>
+            <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.theme.toggle()"
+                    :aria-label="$store.theme.value === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'" title="Toggle theme">
+              <svg x-h-lucide x-show="$store.theme.value !== 'dark'" role="img" data-lucide="moon"></svg>
+              <svg x-h-lucide x-show="$store.theme.value === 'dark'" role="img" data-lucide="sun"></svg>
+            </button>
+
+            <!-- Notifications: the bell shows the unread count; the popover lists them. -->
+            <button x-h-button x-h-popover-trigger data-variant="transparent" data-size="icon-sm" aria-label="Notifications" class="relative">
+              <i role="img" x-h-lucide data-lucide="bell"></i>
+              <span x-show="$store.notifications.unreadCount > 0" class="absolute" x-text="$store.notifications.unreadCount"
+                    style="right:-2px; bottom:-2px; min-width:15px; height:15px; padding:0 3px; border-radius:9999px; background:#e01b24; color:#fff; font-size:9px; line-height:15px; text-align:center; font-weight:700;"></span>
+            </button>
+            <div class="w-80" x-h-popover data-innerclicks="true">
+              <div x-h-toolbar data-size="sm">
+                <span x-h-toolbar-title class="shrink-0" x-text="T('application-core:shell.notifications.title', 'Notifications') + ' (' + $store.notifications.unreadCount + ')'"></span>
+                <div x-h-toolbar-spacer></div>
+                <button x-h-button data-variant="transparent" data-size="icon-sm" @click="$store.notifications.markAllRead()"
+                        title="Mark all as read" aria-label="Mark all as read"><i role="img" x-h-lucide data-lucide="check-check"></i></button>
+              </div>
+              <div x-show="$store.notifications.items.length === 0" x-h-text.muted class="p-3 text-sm" x-text="T('application-core:shell.notifications.caughtUp', 'You\u2019re all caught up.')"></div>
+              <ol x-show="$store.notifications.items.length" x-h-notification-list>
+                <template x-for="n in $store.notifications.items" :key="n.id">
+                  <li x-h-notification class="hbox" :data-unread="n.unread ? 'true' : 'false'"
+                      :class="n.task ? 'cursor-pointer' : ''" @click="openNotification(n)">
+                    <div x-h-notification-media><svg x-h-icon data-icon="circle-info" class="size-5" role="img" aria-label="info"></svg></div>
+                    <div class="vbox flex-1">
+                      <h1 x-h-notification-title x-text="n.title"></h1>
+                      <p x-h-notification-description x-text="n.description"></p>
+                    </div>
+                  </li>
+                </template>
+              </ol>
+            </div>
+
+            <!-- Logged-in user: avatar; the dropdown shows the user name and Log out. -->
+            <button x-h-button x-h-menu-trigger.dropdown data-variant="transparent" data-size="icon-sm"
+                    :aria-label="$store.currentUser.name || 'Account'">
+              <i role="img" x-h-lucide data-lucide="circle-user"></i>
+            </button>
+            <ul x-h-menu aria-label="User menu" data-align="bottom-end">
+              <div x-h-tile class="mb-1">
+                <div x-h-tile-media><i role="img" x-h-lucide data-lucide="circle-user" class="size-6"></i></div>
+                <div x-h-tile-content>
+                  <div x-h-tile-title x-text="$store.currentUser.name || T('application-core:shell.user.user', 'User')"></div>
+                </div>
+              </div>
+              <div x-h-menu-separator></div>
+              <li x-h-menu-item data-variant="negative" @click="$store.currentUser.logout()">
+                <i role="img" x-h-lucide data-lucide="log-out"></i> <span x-text="T('application-core:shell.user.logout', 'Log out')"></span>
+              </li>
+            </ul>
+          </div>
+
+          <!-- Built-in pages (incl. the Settings master-detail) render here via Pinecone; a hosted
+               domain app shows in the iframe instead. -->
+          <div id="app" x-show="!hostedUrl" class="size-full overflow-auto flex-1">
+            <!-- Pinecone Router renders the matched built-in view fragment here. -->
+          </div>
+          <div x-show="hostedUrl" class="flex-1 size-full" style="position: relative;">
+            <iframe :src="hostedUrl" title="Application" @load="onIframeLoad($event)"
+                    style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
+          </div>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- App-wide BPM task form dialog (driven by the processTasks store). Opened from a task
+         notification in the bell popover; the store re-fetches on close so badges update. -->
+    <div x-h-dialog-overlay :data-open="$store.processTasks.formOpen">
+      <div x-h-dialog style="width: 92vw; max-width: 1100px;">
+        <div x-h-dialog-header>
+          <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+        </div>
+        <div x-h-dialog-content>
+          <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
+                  title="Task form" style="width:100%; height:70vh; border:0;"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- App-wide dialog for developer-contributed custom actions (driven by the customActions store).
+         The contributed action page is shown in an iframe; it posts harmonia.form.close to dismiss and
+         the store then raises harmonia:action-done so the originating view refreshes. -->
+    <div x-h-dialog-overlay :data-open="$store.customActions.dialogOpen">
+      <div x-h-dialog style="width: 92vw; max-width: 1100px;">
+        <div x-h-dialog-header>
+          <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+        </div>
+        <div x-h-dialog-content>
+          <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"
+                  title="Action" style="width:100%; height:70vh; border:0;"></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- App-wide transient toasts (raised through Harmonia's notifications magic with this template). -->
+    <section x-h-notification-overlay>
+      <template id="toast">
+        <li x-h-notification.floating data-variant="toast" class="hbox items-center gap-3 min-w-3xs max-w-md">
+          <div x-h-notification-media>
+            <span x-h-avatar class="rounded-full" :data-variant="variant">
+              <template x-if="variant === 'positive'"><svg x-h-icon data-icon="circle-success" role="img" aria-label="success"></svg></template>
+              <template x-if="variant === 'negative'"><svg x-h-icon data-icon="circle-error" role="img" aria-label="error"></svg></template>
+              <template x-if="variant !== 'positive' && variant !== 'negative'"><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></template>
+            </span>
+          </div>
+          <span x-h-notification-title class="flex-1" x-text="message"></span>
+          <div x-h-notification-actions data-orientation="vertical">
+            <button x-h-button x-h-notification-close class="rounded-full" data-variant="transparent" data-size="icon-md" aria-label="Dismiss">
+              <svg x-h-icon data-icon="close" role="img" aria-label="close"></svg>
+            </button>
+          </div>
+        </li>
+      </template>
+    </section>
+
+    <!-- Built-in routes. Dashboard is local (generic landing); the rest reuse the shared runtime. -->
+    <template x-route="/" x-template.target.app="/services/web/application-core/shell/views/_inbox.html"></template>
+    <template x-route="/dashboard" x-template.target.app="./views/_dashboard.html"></template>
+    <template x-route="/inbox" x-template.target.app="/services/web/application-core/shell/views/_inbox.html"></template>
+    <template x-route="/documents" x-template.target.app="/services/web/application-core/shell/views/_documents.html"></template>
+    <!-- Settings: list (/settings) or a selected entity (/settings/<perspective-id>). The master-detail
+         fragment renders into #app (visible) so its split lays out correctly. -->
+    <template x-route="/settings" x-template.target.app="./views/_settings.html"></template>
+    <template x-route="/settings/:id" x-template.target.app="./views/_settings.html"></template>
+    <!-- Hosted domain apps: /app/<perspective-id>[/<inner-route>]. No template - the iframe renders them;
+         the optional inner segment mirrors the embedded app's own hash route (deep-linkable). -->
+    <template x-route="/app/:id/:inner*"></template>
+    <template x-route="notfound" x-template.target.app="/services/web/application-core/shell/views/_notfound.html"></template>
+
+    <!-- 1. Plugins (vendored) -->
+    <script src="/webjars/pinecone-router/dist/router.min.js"></script>
+
+    <!-- 2. Shared Harmonia runtime (served from application-core) + local config/shell (defer keeps order) -->
+    <script src="/services/web/application-core/shell/js/app.js" defer></script>
+    <script src="./js/config.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/i18n.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/api.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/apiError.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/format.js"></script>
+    <!-- Instance branding (same DIRIGIBLE_BRANDING_* env vars as the AngularJS shell): the platform
+         service sets top.PlatformBranding; the adapter applies the favicon/title and exposes it as the
+         Alpine `branding` store. Load the source before the adapter. -->
+    <script src="/services/js/platform-branding/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/services/branding.js" defer></script>
+    <script src="/services/web/application-core/shell/js/components/pages/basePage.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/notifications.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/processTasks.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/customActions.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/reports.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/theme.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/locale.js" defer></script>
+    <script src="/services/web/application-core/shell/js/stores/currentUser.js" defer></script>
+    <script src="/services/web/application-core/shell/js/components/pages/inboxPage.js" defer></script>
+    <script src="/services/web/application-core/shell/js/components/pages/documentsPage.js" defer></script>
+    <script src="./js/appShell.js" defer></script>
+
+    <!-- 3. Alpine LAST (the Harmonia bundle auto-starts Alpine - do NOT call Alpine.start()) -->
+    <script defer src="/webjars/alpinejs/dist/cdn.min.js"></script>
+    <script src="/webjars/codbex__harmonia/dist/harmonia.min.js"></script>
+
+    <!-- 4. Lucide icons -->
+    <script src="/webjars/lucide/dist/umd/lucide.min.js"></script>
+    <!-- opt-in Harmonia Lucide plugin: registers x-h-lucide (renders Lucide icons + keeps them in sync); needs window.lucide (above). -->
+    <script src="/webjars/codbex__harmonia/dist/harmonia-lucide.min.js"></script>
+    <!-- Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle above): it upgrades
+         icons on init and inside router-swapped views, so no manual createIcons scan is needed. -->
+  </body>
+
+</html>

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/appShell.js
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/appShell.js
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * The Harmonia application shell controller. It reuses the shared Harmonia runtime
+ * (/services/web/application-core/shell) for the built-in pages (Dashboard/Inbox/Documents/Reports,
+ * Pinecone-routed into #app) and aggregates the `application-perspectives` extension point for the
+ * domain apps, which it hosts in an iframe (their generated SPA in embedded mode).
+ *
+ * Only NAMED perspective groups are shown (the platform's ungrouped/utility AngularJS perspectives -
+ * e.g. the old Settings - are intentionally excluded; this is the pure-Harmonia application layer).
+ */
+const PERSPECTIVES_URL = '/services/js/platform-core/extension-services/perspectives.js?extensionPoints=application-partner-perspectives';
+const PROJECTIONS_URL = '/services/js/platform-core/extension-services/projections.js?extensionPoints=partner-shell-no-projections';
+// Last selected projection, persisted like the theme/language flags (shared localStorage convention).
+const PROJECTION_KEY = 'codbex.harmonia.projection';
+
+document.addEventListener('alpine:init', () => {
+  window.PineconeRouter.settings({
+    basePath: (App.config && App.config.basePath) || '',
+    hash: true
+  });
+
+  Alpine.data('app', () => ({
+    hiddenPanels: { left: false },
+    isOpen: false,
+    currentPath: '/dashboard',
+    loading: true,
+    groups: [],
+    // Projections: named lenses over the deployed module set (the `application-projections`
+    // extension point). With 2+ the sidebar header becomes a Harmonia product switcher and the
+    // selected projection filters the sidebar groups / reports / dashboard tiles / settings.
+    // With 0 or 1 no switcher is shown (a single projection still filters).
+    projections: [],
+    projectionId: '',
+    // The currently hosted domain app (a perspective). When set, the iframe is shown instead of #app.
+    hostedUrl: '',
+    hostedId: '',
+    // Settings: the SETTING entities from every app (the 'settings' perspective group), surfaced as a
+    // single footer entry + master-detail page (list left, the selected setting hosted in an iframe).
+    settingsItems: [],
+    settingsMode: false,
+    settingsSelected: '',
+    settingsUrl: '',
+    // Region & Language: the platform-wide language flag (the shared locale store), offered here
+    // because the shell's Settings is where users look for it. The offered codes are the PLATFORM's
+    // supported set (DIRIGIBLE_APPLICATION_LANGUAGES via the locale store) - modules never define
+    // what the stack supports. Each app's generated js/config.js declares which languages it
+    // PROVIDES translations for; apps missing a platform language are listed as warnings so
+    // developers know where translations are still needed (data falls back to the default language).
+    language: 'en',
+    appLanguages: [],
+    // Tenant Configuration: a built-in settings entry showing the predefined, per-tenant-overridable
+    // properties (the branding properties for now). Backed by the platform endpoint
+    // /services/core/configurations/tenant; requires ADMINISTRATOR/OPERATOR (a 403 is surfaced as a
+    // read-only notice). Each entry is { key, value }; an empty value means "not overridden".
+    tenantConfig: [],
+    tenantConfigLoading: false,
+    tenantConfigSaving: false,
+    tenantConfigError: null,
+
+    /** A human-friendly label for a predefined key, derived from its DIRIGIBLE_BRANDING_* name. */
+    tenantConfigLabel(key) {
+      return key.replace(/^DIRIGIBLE_BRANDING_/, '')
+                .toLowerCase()
+                .replace(/_/g, ' ')
+                .replace(/\b\w/g, (c) => c.toUpperCase());
+    },
+
+    /** Load the predefined properties and the current tenant's value for each. */
+    async loadTenantConfig() {
+      this.tenantConfigLoading = true;
+      this.tenantConfigError = null;
+      try {
+        const res = await fetch('/services/core/configurations/tenant/predefined', {
+          credentials: 'same-origin',
+          headers: { 'Accept': 'application/json' }
+        });
+        if (res.status === 403) {
+          this.tenantConfig = [];
+          this.tenantConfigError = 'forbidden';
+          return;
+        }
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        this.tenantConfig = data.map((e) => ({ key: e.key, value: e.value == null ? '' : e.value }));
+      } catch (e) {
+        console.error('tenant-configuration: failed to load', e);
+        this.tenantConfig = [];
+        this.tenantConfigError = 'load';
+      } finally {
+        this.tenantConfigLoading = false;
+        this.refreshIcons();
+      }
+    },
+
+    /** Persist the edited values: a non-empty value is stored (PUT), an emptied one is cleared (DELETE). */
+    async saveTenantConfig() {
+      this.tenantConfigSaving = true;
+      this.tenantConfigError = null;
+      try {
+        for (const entry of this.tenantConfig) {
+          const value = (entry.value || '').trim();
+          if (value.length) {
+            const res = await fetch('/services/core/configurations/tenant', {
+              method: 'PUT',
+              credentials: 'same-origin',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ key: entry.key, value: value })
+            });
+            if (!res.ok) throw new Error('PUT ' + entry.key + ' -> HTTP ' + res.status);
+          } else {
+            const res = await fetch('/services/core/configurations/tenant?key=' + encodeURIComponent(entry.key), {
+              method: 'DELETE',
+              credentials: 'same-origin'
+            });
+            if (!res.ok && res.status !== 404) throw new Error('DELETE ' + entry.key + ' -> HTTP ' + res.status);
+          }
+        }
+        await this.loadTenantConfig();
+      } catch (e) {
+        console.error('tenant-configuration: failed to save', e);
+        this.tenantConfigError = 'save';
+      } finally {
+        this.tenantConfigSaving = false;
+      }
+    },
+
+    // Language coverage of the embedded apps: which languages each generated app PROVIDES
+    // translations for (its js/config.js carries `languages: [...]` from the intent; the config is
+    // a JS file, so the array is read with a targeted match rather than executed). One entry per
+    // project; an app without a readable declaration counts as providing only the default language.
+    async loadLanguageCoverage(perspectives) {
+      const bases = new Map();
+      const collect = (item) => {
+        const path = item && item.path;
+        const match = typeof path === 'string' && path.match(/^\/services\/web\/([^\/]+)\/([^#?]*\/)?index\.html/);
+        if (match && !bases.has(match[1])) bases.set(match[1], '/services/web/' + match[1] + '/' + (match[2] || ''));
+      };
+      (perspectives || []).forEach(g => Array.isArray(g.items) ? g.items.forEach(collect) : collect(g));
+      const coverage = await Promise.all([...bases].map(async ([app, base]) => {
+        let provided = ['en'];
+        try {
+          const res = await fetch(base + 'js/config.js', { credentials: 'same-origin' });
+          if (res.ok) {
+            const match = (await res.text()).match(/languages:\s*(\[[^\]]*\])/);
+            if (match) {
+              const codes = JSON.parse(match[1].replace(/'/g, '"'));
+              if (Array.isArray(codes) && codes.length) provided = codes;
+            }
+          }
+        } catch (e) { /* undeclared coverage counts as default-language only */ }
+        return { app, provided };
+      }));
+      this.appLanguages = coverage;
+    },
+
+    // Apps that do not provide every platform language - the developers' to-do list for missing
+    // translation content. Reactive on both the coverage scan and the platform set.
+    languageWarnings() {
+      const platform = Alpine.store('locale').languages();
+      return this.appLanguages
+                 .map(({ app, provided }) => ({ app, missing: platform.filter(code => !provided.includes(code)) }))
+                 .filter(({ missing }) => missing.length > 0);
+    },
+
+    // The platform's language codes with display names for the Settings picker.
+    languageOptions() {
+      const locale = Alpine.store('locale');
+      return locale.languages().map(code => ({ value: code, text: locale.displayName(code) }));
+    },
+
+    async init() {
+      const projectionsLoaded = this.loadProjections();
+      try {
+        const res = await fetch(PERSPECTIVES_URL, { headers: { 'Accept': 'application/json' } });
+        if (res.ok) {
+          const data = await res.json();
+          // Domain apps live in named groups; skip the platform's 'undefined-group' and utilities
+          // (those are the legacy AngularJS perspectives, which do not belong in the Harmonia shell).
+          // Every app's SETTING entities are shown under the dedicated Settings footer entry, never in
+          // the sidebar - whether they were declared inside a nav group or with no group at all. A
+          // perspective is a setting when its kind is SETTING (from the generator); the legacy 'settings'
+          // group id is a fallback for apps generated before the kind tag existed.
+          const all = Array.isArray(data.perspectives) ? data.perspectives : [];
+          const settings = [];
+          const appGroups = [];
+          // App entities declared without a navigation group come back as standalone PRIMARY
+          // perspectives (no `items`); collect them into a catch-all "Other" section so they are
+          // still reachable from the shared shell instead of being silently dropped. SETTING ones go to
+          // the Settings footer; the shell's own built-ins (dashboard/inbox/documents - no `kind`) are
+          // rendered natively and must not be re-listed here.
+          const ungrouped = [];
+          all.forEach(g => {
+            if (Array.isArray(g.items)) {
+              // A navigation group: pull its SETTING entities into Settings, keep the rest in the sidebar.
+              const isSetting = (it) => it.kind === 'SETTING' || g.id === 'settings';
+              settings.push(...g.items.filter(isSetting));
+              const keep = g.items.filter(it => !isSetting(it));
+              if (g.id !== 'undefined-group' && keep.length) {
+                appGroups.push(Object.assign({}, g, { items: keep }));
+              }
+            } else if (g.path && g.kind === 'SETTING') {
+              // A standalone setting perspective declared with no navigation group.
+              settings.push(g);
+            } else if (g.path && g.kind === 'PRIMARY') {
+              // A standalone (un-grouped) app entity perspective.
+              ungrouped.push(g);
+            }
+          });
+          // Settings entities are listed alphabetically by label.
+          settings.sort((a, b) => (a.label || '').toLowerCase().localeCompare((b.label || '').toLowerCase()));
+          // Append the catch-all "Other" group last, after the named navigation groups, sorted by the
+          // perspective's declared order then label so output is stable.
+          if (ungrouped.length) {
+            ungrouped.sort((a, b) => (a.order || 0) - (b.order || 0)
+              || (a.label || '').toLowerCase().localeCompare((b.label || '').toLowerCase()));
+            appGroups.push({ id: 'other', label: 'Other', tkey: 'application-core:shell.nav.other', items: ungrouped });
+          }
+          this.groups = appGroups;
+          this.settingsItems = settings;
+          // Fire-and-forget: load the contributing apps' i18n catalogs so the sidebar / dashboard /
+          // Settings entries translate. Each perspective's tkey is '<project>:<path>' - the project
+          // is the catalog namespace, which the shell (having no project of its own) must add.
+          if (window.AppI18nAddNamespaces) {
+            const namespaces = [...new Set(all.flatMap(g => Array.isArray(g.items) ? g.items : [g])
+              .map(it => (it.tkey || '').split(':')[0])
+              .filter(ns => ns && ns !== 'application-core'))];
+            AppI18nAddNamespaces(namespaces);
+          }
+          // Fire-and-forget: scan which languages each embedded app provides translations for
+          // (drives the missing-translations warnings in Settings).
+          this.loadLanguageCoverage(all);
+        }
+      } catch (e) {
+        console.error('Failed to load application perspectives', e);
+      }
+      await projectionsLoaded;
+      this.loading = false;
+
+      // Mirror the shared locale store so the Settings picker has a plain bindable property;
+      // persisting goes through the store (the fetch client sends it as Accept-Language).
+      const locale = Alpine.store('locale');
+      if (locale) {
+        this.language = locale.value;
+        this.$watch('language', (v) => locale.set(v));
+      }
+
+      // Reports are discovered asynchronously (the store walks the registry). Once its items arrive,
+      // re-resolve a deep-linked /reports/<name> so a refresh on that URL lands on the right report
+      // instead of the "Select a report" empty state.
+      this.$watch('$store.reports.loaded', () => {
+        if (this.currentPath === '/reports' || this.currentPath.indexOf('/reports/') === 0) {
+          this.selectReportByName(this.currentPath.indexOf('/reports/') === 0
+                  ? decodeURIComponent(this.currentPath.slice('/reports/'.length))
+                  : '');
+        }
+      });
+
+      // Resolve shell state from the current route. Hosted domain apps are addressable as
+      // /app/<perspective-id>[/<inner-route>]; everything else is a built-in page rendered into #app.
+      // The inner route is the iframe app's own hash route (e.g. /SalesInvoice/42/edit), so the top
+      // URL stays in sync with what the embedded app shows and is deep-linkable.
+      const applyRoute = () => {
+        // Read the live URL hash, not PineconeRouter.context.path: for a template-less route (our
+        // /app/:id route) Pinecone fires pinecone:end BEFORE it assigns the new context, so context
+        // would be stale here - but history.pushState has already updated the hash by then.
+        const h = window.location.hash || '';
+        let p = (h.charAt(0) === '#' ? h.slice(1) : h) || '/';
+        if (p === '/') p = '/dashboard';
+        this.currentPath = p;
+        // Landing on the dashboard: re-pull the KPI widget values so freshly entered records show
+        // without a full browser refresh (the reports store memoizes, so force a reload).
+        if (p === '/dashboard') {
+          const reports = Alpine.store('reports');
+          if (reports) reports.loadWidgets(true);
+        }
+        if (p === '/settings' || p.indexOf('/settings/') === 0) {
+          // Settings master-detail: /settings (list only) or /settings/<perspective-id> (one selected).
+          this.settingsMode = true;
+          this.hostedId = '';
+          this.hostedUrl = '';
+          const rest = p.indexOf('/settings/') === 0 ? p.slice('/settings/'.length) : '';
+          if (rest) {
+            const item = this.findSettingItem(decodeURIComponent(rest));
+            if (item) {
+              this.settingsSelected = item.id;
+              this.settingsUrl = item.path || '';
+              if (item.id === 'tenant-configuration') this.loadTenantConfig();
+            }
+          }
+        } else {
+          this.settingsMode = false;
+          const match = p.match(/^\/app\/([^/]+)(?:\/(.*))?$/);
+          if (match) {
+            const id = decodeURIComponent(match[1]);
+            const inner = match[2] ? '/' + match[2] : '';
+            // Only (re)point the iframe when the app changes - while the same app is hosted the iframe
+            // owns its inner route, so we must not reset its src (that would reload it and lose state).
+            if (this.hostedId !== id) {
+              const item = this.findItem(id);
+              if (item) { this.hostedId = id; this.hostedUrl = this.appUrl(item, inner); }
+            }
+          } else {
+            this.hostedId = '';
+            this.hostedUrl = '';
+            // Reports deep-link: /reports/<name> selects that report so a browser refresh restores it.
+            // The store may still be loading (its items arrive asynchronously) - the `$store.reports.loaded`
+            // watcher below re-resolves once they do.
+            if (p === '/reports' || p.indexOf('/reports/') === 0) {
+              this.selectReportByName(p.indexOf('/reports/') === 0 ? decodeURIComponent(p.slice('/reports/'.length)) : '');
+            }
+          }
+        }
+        this.refreshIcons();
+      };
+      window.addEventListener('popstate', applyRoute);
+      document.addEventListener('pinecone:end', applyRoute);
+      // Resolve the initial route now that the perspectives are loaded (handles deep links / reloads).
+      applyRoute();
+
+      this._bp = Harmonia.getBreakpointListener((isNarrow) => {
+        this.hiddenPanels.left = isNarrow;
+        if (isNarrow) {
+          this.$refs.overlay.appendChild(this.$refs.sidebar);
+        } else {
+          this.$refs.sidebarPanel.appendChild(this.$refs.sidebar);
+        }
+      }, 1024);
+
+      this.$nextTick(() => this.refreshIcons());
+    },
+
+    destroy() { if (this._bp) this._bp.remove(); },
+
+    /** Navigate to a built-in page (Pinecone route into #app); applyRoute clears any hosted app. */
+    navigate(route) {
+      this.settingsMode = false;
+      window.PineconeRouter.navigate(route);
+      this.closeSideNav();
+    },
+
+    /** Open a discovered report deep-linkably: the report name goes in the URL (/reports/<name>) so a
+     *  refresh restores it. applyRoute (and the reports-loaded watcher) resolve the store selection. */
+    openReport(report) {
+      this.navigate('/reports/' + encodeURIComponent(report.name));
+    },
+
+    /** Select the discovered report with this name (from the shared reports store) for the Reports page.
+     *  A blank name (bare /reports) clears the selection so the empty state shows; an unknown name (the
+     *  store not loaded yet) leaves it null until the loaded watcher re-resolves. */
+    selectReportByName(name) {
+      const store = Alpine.store('reports');
+      if (!store) {
+        return;
+      }
+      store.selected = name ? (store.items || []).find(r => r.name === name) || null : null;
+    },
+
+    /** Host a domain app (a perspective) in the iframe. Swap the iframe synchronously on click (do not
+     *  wait for the router's pinecone:end - for a template-less route it can fire before the context is
+     *  ready, leaving the pane stale), then update the URL. applyRoute then no-ops (hostedId already set). */
+    openApp(item) {
+      // Re-clicking the already-hosted app is a no-op: leave its inner route (and the URL) untouched.
+      if (this.hostedId !== item.id || this.settingsMode) {
+        this.settingsMode = false;
+        this.hostedId = item.id;
+        this.hostedUrl = this.appUrl(item, '');
+        this.currentPath = '/app/' + encodeURIComponent(item.id);
+        window.PineconeRouter.navigate('/app/' + encodeURIComponent(item.id));
+        this.refreshIcons();
+      }
+      this.closeSideNav();
+    },
+
+    /** Build the iframe src for a perspective, overriding its hash with `inner` (e.g. /SalesInvoice/42/edit). */
+    appUrl(item, inner) {
+      const path = item.path || '';
+      const hashAt = path.indexOf('#');
+      const base = hashAt === -1 ? path : path.slice(0, hashAt);
+      const defaultHash = hashAt === -1 ? '' : path.slice(hashAt + 1);
+      // Normalize to exactly one leading slash: the inner route is stored without it (mirrorInner
+      // strips it), but the embedded app's hash router matches "/Entity/:id", so "#Entity/1" misses.
+      const hash = (inner || defaultHash || '').replace(/^\/+/, '');
+      return hash ? base + '#/' + hash : base;
+    },
+
+    /** Wire the hosted iframe so its inner navigation is mirrored into the shell's address bar. */
+    onIframeLoad(e) {
+      const win = e.target && e.target.contentWindow;
+      if (!win) return;
+      const mirror = () => this.mirrorInner(win);
+      // The embedded app routes with Pinecone (history.pushState, no hashchange) and signals every
+      // navigation with a `pinecone:end` event on its own document; popstate covers in-app back/forward.
+      try {
+        win.document.addEventListener('pinecone:end', mirror);
+        win.addEventListener('popstate', mirror);
+      } catch (err) { return; } // cross-origin guard
+      win.addEventListener('hashchange', mirror); // fallback for non-Pinecone embedded apps
+      mirror();
+    },
+
+    /** Reflect the embedded app's current hash route into the top URL as /app/<id>/<inner-route>. */
+    mirrorInner(win) {
+      if (!this.hostedId) return;
+      let hash;
+      try { hash = win.location.hash || ''; } catch (e) { return; } // cross-origin guard
+      const inner = hash.replace(/^#\/?/, '');
+      const top = '/app/' + encodeURIComponent(this.hostedId) + (inner ? '/' + inner : '');
+      const newHash = '#' + top;
+      if (window.location.hash !== newHash) {
+        // replaceState updates the address bar without re-triggering the shell router (no reload loop).
+        history.replaceState(history.state, '', newHash);
+        this.currentPath = top;
+      }
+    },
+
+    /** Open the Settings master-detail (the aggregated SETTING entities from every app). */
+    openSettings() {
+      this.settingsMode = true;
+      this.hostedId = '';
+      this.hostedUrl = '';
+      this.currentPath = '/settings';
+      window.PineconeRouter.navigate('/settings');
+      this.refreshIcons();
+      this.closeSideNav();
+    },
+
+    /** Select a setting entity: host its app at that entity's route in the settings detail iframe.
+     *  Update the URL with replaceState (no Pinecone re-render) so the master-detail split keeps the
+     *  layout it computed when first shown; the detail iframe just swaps its src. */
+    selectSetting(item) {
+      if (this.settingsSelected !== item.id) {
+        this.settingsSelected = item.id;
+        this.settingsUrl = item.path || '';
+        this.currentPath = '/settings/' + encodeURIComponent(item.id);
+        const url = '#/settings/' + encodeURIComponent(item.id);
+        if (window.location.hash !== url && window.history && window.history.replaceState) {
+          window.history.replaceState(window.history.state, '', url);
+        }
+        if (item.id === 'tenant-configuration') this.loadTenantConfig();
+        this.refreshIcons();
+      }
+    },
+
+    isSettingActive(item) { return this.settingsMode && this.settingsSelected === item.id; },
+
+    /** Find a setting entity (perspective) by id. 'region-language' is the built-in shell entry
+     *  (the platform language preference) - it has no app path; its detail renders locally. */
+    findSettingItem(id) {
+      if (id === 'region-language') return { id: 'region-language' };
+      if (id === 'tenant-configuration') return { id: 'tenant-configuration' };
+      return (this.settingsItems || []).find(i => i.id === id) || null;
+    },
+
+    /** Open the task behind a (task-derived) notification, and mark it read. */
+    openNotification(n) {
+      if (n && n.task) {
+        this.$store.processTasks.openTask(n.task);
+        n.unread = false;
+      }
+    },
+
+    /** Find a loaded perspective by id across all groups. */
+    findItem(id) {
+      for (const g of this.groups) {
+        const item = (g.items || []).find(i => i.id === id);
+        if (item) return item;
+      }
+      return null;
+    },
+
+    /** Load the application-projections extension point and restore the persisted selection.
+     *  Role-gated projections are filtered server-side, so what arrives here is what may be offered. */
+    async loadProjections() {
+      try {
+        const res = await fetch(PROJECTIONS_URL, { headers: { 'Accept': 'application/json' } });
+        if (res.ok) {
+          const data = await res.json();
+          this.projections = Array.isArray(data.projections) ? data.projections : [];
+        }
+      } catch (e) {
+        console.error('Failed to load application projections', e);
+      }
+      let saved = '';
+      try { saved = localStorage.getItem(PROJECTION_KEY) || ''; } catch (e) { /* no storage */ }
+      this.projectionId = this.projections.some(p => p.id === saved)
+        ? saved
+        : (this.projections.length ? this.projections[0].id : '');
+    },
+
+    /** The currently selected projection entry (for the product-switch header), or null. */
+    selectedProjection() { return this.projections.find(p => p.id === this.projectionId) || null; },
+
+    /** The projection that FILTERS the shell: null when none is selected or the selected one is
+     *  the declared "everything" entry (all: true), in which case nothing is filtered. */
+    activeProjection() {
+      const p = this.selectedProjection();
+      return p && !p.all ? p : null;
+    },
+
+    /** Switch the product-switch selection; persist it and leave a now-hidden hosted app. */
+    selectProjection(p) {
+      if (this.projectionId === p.id) return;
+      this.projectionId = p.id;
+      try { localStorage.setItem(PROJECTION_KEY, p.id); } catch (e) { /* no storage */ }
+      if (this.hostedId && !this.visibleGroups().some(g => (g.items || []).some(i => i.id === this.hostedId))) {
+        this.navigate('/dashboard');
+      }
+      this.refreshIcons();
+    },
+
+    projectionLabel() {
+      const p = this.selectedProjection();
+      return p ? (p.tkey ? T(p.tkey, p.label) : p.label) : '';
+    },
+
+    /** Second line under the product name; the instance brand is the default. */
+    projectionSubtitle() {
+      const p = this.selectedProjection();
+      return (p && p.description) || Alpine.store('branding').name || '';
+    },
+
+    /** The sidebar groups the active projection keeps: listed groups wholesale, plus any group
+     *  reduced to its cherry-picked `items` (Employee-Portal-style selections keep their familiar
+     *  group heading); empty groups vanish. No active projection = everything. */
+    visibleGroups() {
+      const proj = this.activeProjection();
+      if (!proj) return this.groups;
+      const groupIds = proj.groups || [];
+      const itemIds = proj.items || [];
+      const visible = [];
+      for (const g of this.groups) {
+        if (groupIds.includes(g.id)) {
+          visible.push(g);
+          continue;
+        }
+        const picked = (g.items || []).filter(i => itemIds.includes(i.id));
+        if (picked.length) visible.push(Object.assign({}, g, { items: picked }));
+      }
+      return visible;
+    },
+
+    /** The projects contributing the visible perspectives — the projection's reach, used to scope
+     *  reports, dashboard tiles and settings to the apps actually shown. */
+    projectionProjects() {
+      const projects = new Set();
+      this.visibleGroups().forEach(g => (g.items || []).forEach(item => {
+        const match = typeof item.path === 'string' && item.path.match(/^\/services\/web\/([^/]+)\//);
+        if (match) projects.add(match[1]);
+      }));
+      return projects;
+    },
+
+    /** Whether a URL (report page, setting entity) belongs to a project inside the active
+     *  projection. Unattributable URLs stay visible — filtering must not hide what it can't place. */
+    inProjection(url) {
+      if (!this.activeProjection()) return true;
+      const match = typeof url === 'string' && url.match(/^\/services\/web\/([^/]+)\//);
+      return match ? this.projectionProjects().has(match[1]) : true;
+    },
+
+    visibleReports() { return Alpine.store('reports').items.filter(r => this.inProjection(r.url)); },
+    dashKpiReports() { return Alpine.store('reports').kpiReports().filter(r => this.inProjection(r.url)); },
+    dashPreviewReports() { return Alpine.store('reports').previewReports().filter(r => this.inProjection(r.url)); },
+
+    /** Settings entities scoped to the projection: explicitly cherry-picked ones always show. */
+    visibleSettingsItems() {
+      const proj = this.activeProjection();
+      if (!proj) return this.settingsItems;
+      const itemIds = proj.items || [];
+      return this.settingsItems.filter(it => itemIds.includes(it.id) || this.inProjection(it.path));
+    },
+
+    isBuiltinActive(route) { return !this.hostedUrl && this.currentPath === route; },
+    isAppActive(item) { return this.hostedId === item.id; },
+    // A report entry is active only while a report route is showing it — keying off the current route
+    // (not just $store.reports.selected) so navigating to an entity/inbox/documents clears its highlight.
+    isReportActive(report) {
+      const selected = Alpine.store('reports').selected;
+      return !this.hostedUrl && this.currentPath.indexOf('/reports') === 0 && selected && selected.url === report.url;
+    },
+    isSvgIcon(icon) { return !!icon && /\.svg(\?|#|$)/i.test(icon); },
+    isImageIcon(icon) { return !!icon && !this.isSvgIcon(icon) && (icon.indexOf('/') !== -1 || icon.indexOf('.') !== -1 || icon.indexOf('http') === 0); },
+
+    openSideNav() { this.isOpen = true; },
+    closeSideNav() { if (window.matchMedia('(max-width: 1024px)').matches) this.isOpen = false; },
+    refreshIcons() {}, // no-op: Lucide icons render via the x-h-lucide directive (harmonia-lucide bundle)
+  }));
+}, { once: true });

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/config.js
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/js/config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Runtime configuration for the partner Harmonia shell. The shared shell runtime
+ * (/services/web/application-core/shell/...) reads its wiring from window.App.config, exactly like a
+ * generated app does. The Partner shell surfaces the external partner's perspectives and serves the
+ * built-in pages itself, so it has no own REST entities.
+ */
+window.App = window.App || {};
+App.config = {
+  projectName: 'partner',
+  basePath: '/services/web/partner',
+  // No own entities; the built-in stores (inbox/documents) call platform services directly.
+  restBase: '',
+  // The Partner shell is an external-surfaces shell - it does not aggregate reports across apps.
+  aggregateReports: false
+};

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/views/_settings.html
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/views/_settings.html
@@ -1,0 +1,143 @@
+<!--
+  Copyright (c) 2010-2026 Eclipse Dirigible contributors
+  SPDX-License-Identifier: EPL-2.0
+
+  Settings master-detail for the application shell, Pinecone-routed into #app (so the split is laid out
+  while visible - an inline x-show=display:none block measures 0x0 and ignores data-size). No own
+  x-data: it inherits the shell's `app` component (settingsItems / selectSetting / settingsUrl).
+-->
+<div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
+  <div x-h-split-panel data-size="25%" data-min="200">
+    <div class="vbox gap-2 p-3">
+      <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.configAll', 'Configuration and nomenclature across all applications.')"></span>
+      <!-- Region & Language: a built-in settings entry (not from an app) - the platform-wide
+           data-language preference. Selecting it renders the local detail page on the right. -->
+      <button x-h-button data-variant="outline" class="justify-start"
+              :data-state="isSettingActive({ id: 'region-language' }) ? 'selected' : ''"
+              @click="selectSetting({ id: 'region-language' })">
+        <i role="img" x-h-lucide data-lucide="globe"></i>
+        <span x-text="T('application-core:shell.settings.regionLanguage', 'Region & Language')"></span>
+      </button>
+      <!-- Tenant Configuration: a built-in settings entry (not from an app) - the predefined,
+           per-tenant-overridable properties (branding). Selecting it renders the local detail on the right. -->
+      <button x-h-button data-variant="outline" class="justify-start"
+              :data-state="isSettingActive({ id: 'tenant-configuration' }) ? 'selected' : ''"
+              @click="selectSetting({ id: 'tenant-configuration' })">
+        <i role="img" x-h-lucide data-lucide="sliders-horizontal"></i>
+        <span x-text="T('application-core:shell.settings.tenantConfig', 'Tenant Configuration')"></span>
+      </button>
+      <template x-for="item in visibleSettingsItems()" :key="item.id">
+        <button x-h-button data-variant="outline" class="justify-start"
+                :data-state="isSettingActive(item) ? 'selected' : ''" @click="selectSetting(item)">
+          <i role="img" x-h-lucide data-lucide="settings"></i>
+          <span x-text="item.tkey ? T(item.tkey, item.label) : item.label"></span>
+        </button>
+      </template>
+    </div>
+  </div>
+  <div x-h-split-panel data-size="75%" style="position: relative;">
+    <div x-show="!settingsUrl && settingsSelected !== 'region-language' && settingsSelected !== 'tenant-configuration'" x-h-info-page class="p-4">
+      <div x-h-info-page-header>
+        <div x-h-info-page-media.icon><svg x-h-icon data-icon="circle-info" role="img" aria-label="info"></svg></div>
+        <div x-h-info-page-title x-text="T('application-core:shell.settings.selectSetting', 'Select a setting')"></div>
+        <div x-h-info-page-description x-text="T('application-core:shell.settings.selectSettingHint', 'Choose a configuration entity on the left to manage it here.')"></div>
+      </div>
+    </div>
+    <!-- Region & Language detail: rendered locally (no iframe) - the platform-wide language
+         preference (localStorage codbex.harmonia.language, sent as Accept-Language by every app's
+         fetch client). Offered codes are the PLATFORM's set (DIRIGIBLE_APPLICATION_LANGUAGES,
+         default en,bg) - never per-module; modules missing a platform language are listed as
+         warnings (their untranslated content falls back to the default language). -->
+    <div x-show="settingsSelected === 'region-language'" class="size-full overflow-auto">
+      <div class="vbox gap-4 p-4" style="max-width: 40rem;">
+        <div class="vbox gap-1">
+          <span class="text-lg font-medium" x-text="T('application-core:shell.settings.regionLanguage', 'Region & Language')"></span>
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.rlDescription', 'One preference for the whole stack: the user interface, the data and document printing all follow the selected language. Content a module has not translated yet falls back to the default language.')"></span>
+        </div>
+        <div class="vbox gap-1">
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.language', 'Language')"></span>
+          <div x-h-select>
+            <input x-h-select-input x-model="language" placeholder="Language" />
+            <div x-h-select-content>
+              <template x-for="opt in languageOptions()" :key="opt.value">
+                <div x-h-select-option="opt.text" :data-value="String(opt.value)"></div>
+              </template>
+            </div>
+          </div>
+        </div>
+        <!-- Display formats: instance-wide patterns for dates, timestamps and floating-point numbers,
+             persisted per user in localStorage (like the language flag) and applied across every app on
+             this origin. Number pattern controls the grouping/decimal separators; each field keeps its
+             own decimal count. Apply reloads so all views re-format at once. -->
+        <div class="vbox gap-1">
+          <span class="text-base font-medium" x-text="T('application-core:shell.settings.formats', 'Display formats')"></span>
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.formatsHint', 'Patterns for dates, timestamps and numbers across all applications. The number pattern sets the grouping and decimal separators; each field keeps its own number of decimals.')"></span>
+        </div>
+        <div class="vbox gap-1">
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.dateFormat', 'Date format')"></span>
+          <input x-h-input x-model="$store.formats.date" placeholder="yyyy-MM-dd" />
+        </div>
+        <div class="vbox gap-1">
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.timestampFormat', 'Timestamp format')"></span>
+          <input x-h-input x-model="$store.formats.dateTime" placeholder="yyyy-MM-dd HH:mm:ss" />
+        </div>
+        <div class="vbox gap-1">
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.numberFormat', 'Number format')"></span>
+          <input x-h-input x-model="$store.formats.number" placeholder="### ### ### ##0.00" />
+        </div>
+        <div class="hbox gap-2">
+          <button x-h-button data-variant="emphasized" @click="$store.formats.apply()" x-text="T('application-core:shell.settings.apply', 'Apply')"></button>
+          <button x-h-button data-variant="outline" @click="$store.formats.reset()" x-text="T('application-core:shell.settings.resetDefaults', 'Reset to defaults')"></button>
+        </div>
+        <template x-if="languageWarnings().length > 0">
+          <div class="vbox gap-2">
+            <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.missingTranslations', 'Missing translations')"></span>
+            <template x-for="warn in languageWarnings()" :key="warn.app">
+              <div x-h-alert data-variant="warning" role="alert">
+                <div x-h-alert-description
+                     x-text="T('application-core:shell.settings.missingWarning', warn.app + ' does not provide: ' + warn.missing.join(', ') + ' - falls back to the default language.', { app: warn.app, missing: warn.missing.join(', ') })"></div>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+    </div>
+    <!-- Tenant Configuration detail: rendered locally (no iframe) - the predefined, per-tenant
+         overridable properties (branding for now), read from and written to the platform endpoint
+         /services/core/configurations/tenant. An empty value means the property is not overridden and
+         falls back to the platform default. -->
+    <div x-show="settingsSelected === 'tenant-configuration'" class="size-full overflow-auto">
+      <div class="vbox gap-4 p-4" style="max-width: 40rem;">
+        <div class="vbox gap-1">
+          <span class="text-lg font-medium" x-text="T('application-core:shell.settings.tenantConfig', 'Tenant Configuration')"></span>
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.tenantConfigHint', 'Per-tenant overrides for the predefined branding properties. Leave a value empty to fall back to the platform default.')"></span>
+        </div>
+        <template x-if="tenantConfigError">
+          <div x-h-alert data-variant="warning" role="alert">
+            <div x-h-alert-description
+                 x-text="tenantConfigError === 'forbidden' ? T('application-core:shell.settings.tenantConfigForbidden', 'You do not have permission to view or change the tenant configuration.') : T('application-core:shell.settings.tenantConfigFailed', 'Something went wrong. Please try again.')"></div>
+          </div>
+        </template>
+        <template x-if="tenantConfigLoading">
+          <span x-h-text.muted class="text-sm" x-text="T('application-core:shell.settings.loading', 'Loading...')"></span>
+        </template>
+        <template x-if="!tenantConfigLoading && tenantConfigError !== 'forbidden'">
+          <div class="vbox gap-4">
+            <template x-for="entry in tenantConfig" :key="entry.key">
+              <div class="vbox gap-1">
+                <span x-h-text.muted class="text-sm" x-text="tenantConfigLabel(entry.key)"></span>
+                <input x-h-input x-model="entry.value" :placeholder="entry.key" />
+              </div>
+            </template>
+            <div class="hbox gap-2">
+              <button x-h-button data-variant="emphasized" @click="saveTenantConfig()" x-text="T('application-core:shell.settings.save', 'Save')"></button>
+              <button x-h-button data-variant="outline" @click="loadTenantConfig()" x-text="T('application-core:shell.settings.reload', 'Reload')"></button>
+            </div>
+          </div>
+        </template>
+      </div>
+    </div>
+    <iframe x-show="settingsUrl" :src="settingsUrl" title="Settings"
+            style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
+  </div>
+</div>


### PR DESCRIPTION
A third Harmonia shell for **external partners** (customers, distributors, suppliers), mirroring the shipped **My shell**: a `resources-partner` module serving `/services/web/partner/`, reusing the shared `application-core/shell` runtime, aggregating a new **`application-partner-perspectives`** extension point.

**The separation is the safety property.** Each shell fetches exactly one extension point, so a perspective appears in the Partner portal iff it explicitly registers on `application-partner-perspectives`. A personal (`my`) or application perspective can never leak in - it is never even fetched. A UI meant for both registers on both points, deliberately. The distinct URI also makes partner access a single entry-point authz decision.

Container only - partner-scoping of data, external auth, and partner writes are follow-ups.

Verified on a running instance: `/services/web/partner/` serves; the partner perspectives service returns only the empty `partner` group; the personal service is unchanged and disjoint (My Expenses/Vacations/Timesheets stay in `/my/`); `Partner` is listed in `platform-shells`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)