### PR TITLE
fix(view-git): sort the Git Projects, Local and Remote branch views

### DIFF
--- a/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/git-projects.js
+++ b/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/git-projects.js
@@ -585,6 +585,7 @@ gitProjectsView.controller('GitProjectsController', ($scope, StatusBar, Dialogs,
                 }
                 $scope.projects.push(project);
             }
+            $scope.projects.sort((a, b) => a.text.localeCompare(b.text, undefined, { numeric: true, sensitivity: 'base' }));
             $scope.$evalAsync(() => {
                 $scope.state.isBusy = false;
             });
@@ -939,6 +940,13 @@ gitProjectsView.controller('GitProjectsController', ($scope, StatusBar, Dialogs,
             }
             treeChildren.push(child);
         }
+        // Folders first, then files, each ordered alphabetically (case-insensitive, natural).
+        treeChildren.sort((a, b) => {
+            const rankA = a.type === 'folder' ? 0 : 1;
+            const rankB = b.type === 'folder' ? 0 : 1;
+            if (rankA !== rankB) return rankA - rankB;
+            return a.text.localeCompare(b.text, undefined, { numeric: true, sensitivity: 'base' });
+        });
         return treeChildren;
     }
 

--- a/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/local.js
+++ b/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/local.js
@@ -196,7 +196,7 @@ localBranchesView.controller('LocalBranchesViewController', ($scope, GitService,
         GitService.branches($scope.selectedWorkspace, $scope.selectedRepository, true).then(
             (response) => {
                 $scope.$evalAsync(() => {
-                    $scope.branches = response.data.local;
+                    $scope.branches = response.data.local.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
                     for (let i = 0; i < $scope.branches.length; i++) {
                         if ($scope.branches[i].current) {
                             $scope.activeBranch.name = $scope.branches[i].name;

--- a/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/remote.js
+++ b/components/ui/view-git/src/main/resources/META-INF/dirigible/view-git/js/remote.js
@@ -247,7 +247,7 @@ remoteBranchesView.controller('RemoteBranchesViewController', ($scope, GitServic
         GitService.branches($scope.selectedWorkspace, $scope.selectedRepository, false).then(
             (response) => {
                 $scope.$evalAsync(() => {
-                    $scope.branches = response.data.remote;
+                    $scope.branches = response.data.remote.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' }));
                     for (let i = 0; i < $scope.branches.length; i++) {
                         if ($scope.branches[i].current) {
                             $scope.activeBranch.name = $scope.branches[i].name;


### PR DESCRIPTION
## What

The three views of the Git perspective rendered their lists in backend response order, which is not sorted. This adds client-side sorting after each list loads.

- **Git Projects** (`git-projects.js`) - top-level projects sorted alphabetically; tree children sorted folders-first then alphabetically (in `processChildren`, preserving the existing folder/file grouping).
- **Local branches** (`local.js`) and **Remote branches** (`remote.js`) - sorted alphabetically by branch name.

All three use a case-insensitive, natural (numeric-aware) `localeCompare`, so `feature-2` sorts before `feature-10` and case does not fragment the order.

## Verification

- `node --check` on all three files - valid.
- Comparator logic exercised on sample data: branches -> `develop, feature-2, feature-10, Main, zeta`; tree -> folders (`api`, `Zeta`) before files (`App.js`, `b.txt`, `readme.md`), each alphabetical.
- `view-git` module packages cleanly and the sorted code is present in the built artifact.

**Not exercised:** the in-browser render of the Git perspective (would need a Selenide UI run); verified at the source-logic + packaged-artifact layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)