### PR TITLE
feat(intent): documentItemsLayout: chat - render document items as a conversation thread

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -279,6 +279,24 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 if (entity.isDuplicable()) {
                     entityMap.put("duplicable", "true");
                 }
+                // Chat items: render the line-items pane as a conversation thread instead of the editable
+                // table. Resolve which child property is the message body (and the optional internal
+                // flag) from the items child's field roles; author + timestamp come from its audit
+                // columns. The Harmonia document template branches on documentItemsLayout == "chat".
+                if (entity.isChatItems()) {
+                    entityMap.put("documentItemsLayout", "chat");
+                    EntityIntent itemsChild = byName.get(itemsEntity);
+                    if (itemsChild != null) {
+                        for (FieldIntent itemField : itemsChild.getFields()) {
+                            if (itemField.isMessageBody()) {
+                                entityMap.put("chatBodyProperty", IntentNaming.pascalCase(itemField.getName()));
+                            }
+                            if (itemField.isMessageInternal()) {
+                                entityMap.put("chatInternalProperty", IntentNaming.pascalCase(itemField.getName()));
+                            }
+                        }
+                    }
+                }
             }
             // A plain PRIMARY entity with NO composition children of its own is standalone, not a
             // master-detail. Give it the fuller MANAGE list layout (search / sort / per-column filter,

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -98,6 +98,13 @@ public class EntityIntent {
      * inferred from structure.
      */
     private String view;
+    /**
+     * Optional rendering of a document master's line-items pane. Default (unset) renders the items as
+     * an editable table; {@code documentItemsLayout: chat} renders them as a conversation thread
+     * (bubbles + a composer) - the document header/status/process stay intact. Only meaningful on a
+     * document master.
+     */
+    private String documentItemsLayout;
     /** Calendar-view configuration; used when {@code view: calendar} or {@code view: range}. */
     private CalendarIntent calendar;
     /** Slots-view configuration; used when {@code view: slots}. */
@@ -195,6 +202,22 @@ public class EntityIntent {
     /** Whether this entity is rendered as a slot picker ({@code view: slots}). */
     public boolean isSlots() {
         return viewIs("slots");
+    }
+
+    public String getDocumentItemsLayout() {
+        return documentItemsLayout;
+    }
+
+    public void setDocumentItemsLayout(String documentItemsLayout) {
+        this.documentItemsLayout = documentItemsLayout;
+    }
+
+    /**
+     * Whether this document master renders its line-items as a chat thread ({@code documentItemsLayout:
+     * chat}) instead of the default editable table.
+     */
+    public boolean isChatItems() {
+        return documentItemsLayout != null && "chat".equalsIgnoreCase(documentItemsLayout.trim());
     }
 
     public CalendarIntent getCalendar() {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/FieldIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/FieldIntent.java
@@ -85,6 +85,19 @@ public class FieldIntent {
     /** Explicit field role selecting a document slot - currently {@code DocumentTitle}. */
     private String function;
     /**
+     * Chat role: marks this field (on a document's line-items child) as the <b>message body</b> when
+     * the master declares {@code documentItemsLayout: chat}. The document view then renders each item
+     * as a chat bubble whose text is this field; the author and timestamp come from the child's audit
+     * columns.
+     */
+    private boolean messageBody;
+    /**
+     * Chat role: an optional boolean field (on the chat items child) flagging an <b>internal</b> memo -
+     * the bubble is tinted distinctly (and hidden from the external partner surface). External by
+     * default.
+     */
+    private boolean messageInternal;
+    /**
      * Whether the field appears as a column in the entity <b>list</b> table (the model's
      * {@code widgetIsMajor}). Defaults to {@code true}; set {@code major: false} to keep the field off
      * the list/table view (it is still shown in forms and the record details pane). {@code Boolean}
@@ -250,6 +263,24 @@ public class FieldIntent {
      */
     public boolean isDocumentTitle() {
         return documentTitle || (function != null && "DocumentTitle".equalsIgnoreCase(function.trim()));
+    }
+
+    /** Whether this field is the chat message body ({@code messageBody: true}). */
+    public boolean isMessageBody() {
+        return messageBody;
+    }
+
+    public void setMessageBody(boolean messageBody) {
+        this.messageBody = messageBody;
+    }
+
+    /** Whether this field is the chat internal/external flag ({@code messageInternal: true}). */
+    public boolean isMessageInternal() {
+        return messageInternal;
+    }
+
+    public void setMessageInternal(boolean messageInternal) {
+        this.messageInternal = messageInternal;
     }
 
     public void setDocumentTitle(boolean documentTitle) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -175,6 +175,7 @@ public final class IntentParser {
         Set<String> entityNames = validateEntities(model, usesAliases, issues);
         validateFunctions(model, issues);
         validateViews(model, issues);
+        validateDocumentItemsLayout(model, issues);
         validateOrders(model, issues);
         validateProcesses(model, entityNames, issues);
         validateForms(model, entityNames, issues);
@@ -296,6 +297,93 @@ public final class IntentParser {
             }
         }
         return flagged || compositionChildren == 1;
+    }
+
+    /**
+     * The document line-items child of {@code master} (the composition child flagged
+     * {@code function: DocumentItem} / named {@code *Item}, else the sole composition child), or
+     * {@code null} when the master has no resolvable items child.
+     */
+    private static EntityIntent itemsChild(IntentModel model, Map<String, String> compositionParent, String master) {
+        EntityIntent flagged = null;
+        EntityIntent sole = null;
+        int compositionChildren = 0;
+        for (EntityIntent entity : model.getEntities()) {
+            String child = entity.getName();
+            if (child == null || !master.equals(compositionParent.get(child))) {
+                continue;
+            }
+            compositionChildren++;
+            sole = entity;
+            if (entity.isDocumentItem() || child.endsWith("Item")) {
+                flagged = entity;
+            }
+        }
+        if (flagged != null) {
+            return flagged;
+        }
+        return compositionChildren == 1 ? sole : null;
+    }
+
+    /**
+     * Validate the optional {@code documentItemsLayout} selector on a document master: the only
+     * supported value is {@code chat}; the entity must resolve a line-items child; and that child must
+     * declare exactly one {@code messageBody} field plus {@code audit: true} (the bubble's author and
+     * timestamp come from the audit columns). An optional {@code messageInternal} field must be
+     * boolean.
+     */
+    private static void validateDocumentItemsLayout(IntentModel model, List<String> issues) {
+        Map<String, String> compositionParent = new HashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() == null) {
+                continue;
+            }
+            for (RelationIntent relation : entity.getRelations()) {
+                boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+                if (toOne && relation.isComposition() && relation.getTo() != null) {
+                    compositionParent.put(entity.getName(), relation.getTo());
+                    break;
+                }
+            }
+        }
+        for (EntityIntent entity : model.getEntities()) {
+            String name = entity.getName();
+            String layout = entity.getDocumentItemsLayout();
+            if (name == null || layout == null || layout.isBlank()) {
+                continue;
+            }
+            if (!"chat".equalsIgnoreCase(layout.trim())) {
+                issues.add("entity [" + name + "] has unknown documentItemsLayout [" + layout + "] (supported: chat)");
+                continue;
+            }
+            if (!hasItemsChild(model, compositionParent, name)) {
+                issues.add("entity [" + name + "] declares documentItemsLayout: chat but is not a document master"
+                        + " (no composition line-items child)");
+                continue;
+            }
+            EntityIntent child = itemsChild(model, compositionParent, name);
+            if (child == null) {
+                continue;
+            }
+            long bodyFields = child.getFields()
+                                   .stream()
+                                   .filter(FieldIntent::isMessageBody)
+                                   .count();
+            if (bodyFields != 1) {
+                issues.add("entity [" + name + "] documentItemsLayout: chat requires its items child [" + child.getName()
+                        + "] to declare exactly one messageBody field (found " + bodyFields + ")");
+            }
+            if (!child.isAudited()) {
+                issues.add("entity [" + name + "] documentItemsLayout: chat requires its items child [" + child.getName()
+                        + "] to declare audit: true (message author and timestamp)");
+            }
+            for (FieldIntent field : child.getFields()) {
+                if (field.isMessageInternal() && !"boolean".equalsIgnoreCase(field.getType())) {
+                    issues.add("entity [" + name + "] items child [" + child.getName() + "] messageInternal field [" + field.getName()
+                            + "] must be boolean");
+                }
+            }
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -412,6 +412,36 @@ renamed and is now REJECTED with a migration message - use `function: EntityStat
 Reserved values for upcoming templates (e.g. `Calendar`) are recognised but rejected with a clear
 "not yet available" message until the template ships.
 
+**`documentItemsLayout: chat` - render the items as a conversation thread.** On a document master, set
+`documentItemsLayout: chat` to render its line-items child as a chat thread (message bubbles + a
+composer to append a message) instead of the editable table - the document header, status pill, process
+tasks and print stay exactly as in a normal document. It is the shape for support cases, ticket
+conversations and comment threads. The items child must declare `audit: true` (the bubble's author and
+timestamp come from the audit `CreatedBy` / `CreatedAt`) and exactly one field with `messageBody: true`
+(the bubble text); an optional boolean field with `messageInternal: true` marks a memo as internal (a
+distinct tint, and hidden from the external partner surface). Own vs other alignment keys on the audit
+author vs the logged-in user.
+
+```yaml
+- name: Case
+  function: Document
+  documentItemsLayout: chat
+  fields:
+    - { name: id,      type: integer, primaryKey: true, generated: true }
+    - { name: subject, type: string, length: 200 }
+  relations:
+    - { name: Status, kind: manyToOne, to: CaseStatus, function: EntityStatus, init: 1 }
+- name: CaseMessage
+  function: DocumentItem
+  audit: true
+  fields:
+    - { name: id,       type: integer, primaryKey: true, generated: true }
+    - { name: body,     type: text,    messageBody: true }
+    - { name: internal, type: boolean, messageInternal: true }
+  relations:
+    - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+```
+
 ### processes - workflows and approvals
 
 **Use when:** a record needs a multi-step flow - approvals, hand-offs, branching, or automated steps.

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -520,6 +520,37 @@ class EdmIntentGeneratorTest {
         assertEquals(null, primary.get("detailCalendar"));
     }
 
+    @Test
+    void chatDocumentMasterCarriesTheChatLayoutAndResolvedMessageProperties() {
+        String yaml = """
+                name: services
+                entities:
+                  - name: Case
+                    function: Document
+                    documentItemsLayout: chat
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: subject, type: string }
+                  - name: CaseMessage
+                    function: DocumentItem
+                    audit: true
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: body, type: text, messageBody: true }
+                      - { name: internal, type: boolean, messageInternal: true }
+                    relations:
+                      - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+                """;
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "services");
+        Map<String, Object> master = entityByName(entities(model), "Case");
+
+        assertEquals("MANAGE_DOCUMENT", master.get("layoutType"));
+        assertEquals("CaseMessage", master.get("documentItemsEntity"));
+        assertEquals("chat", master.get("documentItemsLayout"));
+        assertEquals("Body", master.get("chatBodyProperty"));
+        assertEquals("Internal", master.get("chatInternalProperty"));
+    }
+
     private static List<Map<String, Object>> entities(Map<String, Object> modelJson) {
         return (List<Map<String, Object>>) ((Map<String, Object>) modelJson.get("model")).get("entities");
     }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/parser/IntentParserTest.java
@@ -13,6 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.junit.jupiter.api.Test;
 
@@ -1153,5 +1155,67 @@ class IntentParserTest {
                       .stream()
                       .anyMatch(i -> i.contains("requires a match")),
                 "expected a match issue, got: " + ex2.getIssues());
+    }
+
+    private static final String CHAT_HEAD = """
+            name: services
+            entities:
+              - name: Case
+                function: Document
+                documentItemsLayout: chat
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: subject, type: string }
+              - name: CaseMessage
+                function: DocumentItem
+            """;
+
+    @Test
+    void chatDocumentWithABodyFieldAndAuditParses() {
+        String yaml = CHAT_HEAD + """
+                    audit: true
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: body, type: text, messageBody: true }
+                    relations:
+                      - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+                """;
+        IntentModel model = IntentParser.parse(yaml);
+        assertEquals("chat", model.getEntities()
+                                  .get(0)
+                                  .getDocumentItemsLayout());
+    }
+
+    @Test
+    void chatDocumentRejectsUnknownLayoutAndMissingBodyOrAudit() {
+        // Unknown layout value.
+        String badLayout = CHAT_HEAD.replace("documentItemsLayout: chat", "documentItemsLayout: timeline") + """
+                    audit: true
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: body, type: text, messageBody: true }
+                    relations:
+                      - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+                """;
+        assertTrue(assertThrows(IntentValidationException.class, () -> IntentParser.parse(badLayout)).getIssues()
+                                                                                                     .stream()
+                                                                                                     .anyMatch(i -> i.contains(
+                                                                                                             "unknown documentItemsLayout")));
+
+        // No messageBody field + no audit on the items child.
+        String noBody = CHAT_HEAD + """
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: body, type: text }
+                    relations:
+                      - { name: Case, kind: manyToOne, to: Case, composition: true, required: true }
+                """;
+        List<String> issues = assertThrows(IntentValidationException.class, () -> IntentParser.parse(noBody)).getIssues();
+        assertTrue(issues.stream()
+                         .anyMatch(i -> i.contains("messageBody")),
+                "expected a messageBody issue, got: " + issues);
+        assertTrue(issues.stream()
+                         .anyMatch(i -> i.contains("audit: true")),
+                "expected an audit issue, got: " + issues);
     }
 }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -168,6 +168,11 @@ document.addEventListener('alpine:init', () => {
     items: [],
     itemsState: 'loading',   // loading | error | empty | default
     itemsError: null,
+#if($documentItemsLayout == "chat")
+    // Chat composer state (documentItemsLayout: chat): appends a message as a new child row.
+    chatSending: false,
+    chatInternal: false,
+#end
     itemOptions: {},         // edit-column name -> [{ value, text }] for relationship cells
     // Depends-On-filtered options for the OPEN item dialog only. Kept apart from itemOptions,
     // which the items table uses to resolve labels for ALL rows and must stay the full set.
@@ -565,6 +570,33 @@ document.addEventListener('alpine:init', () => {
       }
       this.refreshIcons();
     },
+#if($documentItemsLayout == "chat")
+
+    // Append a chat message as a new items child (documentItemsLayout: chat). The message body maps to
+    // the messageBody property; the internal flag (if the child declares one) rides the composer toggle;
+    // the master FK is forced server-side by the child controller anyway. Author + timestamp are stamped
+    // by the audit columns. Reloads the thread so the new bubble (and its audit values) appear.
+    async sendMessage(value) {
+      const body = (value || '').trim();
+      if (!body || this.chatSending || !this.itemsDef || this.id == null) return;
+      this.chatSending = true;
+      this.itemsError = null;
+      try {
+        const payload = { '${chatBodyProperty}': body };
+        payload[this.itemsDef.masterEntityId] = this.id;
+#if($chatInternalProperty)
+        payload['${chatInternalProperty}'] = !!this.chatInternal;
+#end
+        await App.services.api.post(this.itemsDef.apiPath, payload);
+        this.chatInternal = false;
+        await this.loadItems();
+      } catch (e) {
+        this.itemsError = App.services.apiErrors.messageFor(e, 'Could not send the message.');
+      } finally {
+        this.chatSending = false;
+      }
+    },
+#end
 
     async loadItemOptions() {
       for (const col of this.editColumns) {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -170,6 +170,7 @@ document.addEventListener('alpine:init', () => {
     itemsError: null,
 #if($documentItemsLayout == "chat")
     // Chat composer state (documentItemsLayout: chat): appends a message as a new child row.
+    chatDraft: '',
     chatSending: false,
     chatInternal: false,
 #end
@@ -588,6 +589,7 @@ document.addEventListener('alpine:init', () => {
         payload['${chatInternalProperty}'] = !!this.chatInternal;
 #end
         await App.services.api.post(this.itemsDef.apiPath, payload);
+        this.chatDraft = '';
         this.chatInternal = false;
         await this.loadItems();
       } catch (e) {

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -186,7 +186,7 @@
               <span x-show="row.${chatInternalProperty}" x-h-badge data-variant="warning" x-text="T('$projectName:${tprefix}.defaults.internal', 'Internal')"></span>
 #end
             </div>
-            <div class="text-sm" style="border-radius: 0.5rem; padding: 0.5rem 0.75rem; white-space: pre-wrap; word-break: break-word"
+            <div class="text-sm" style="border-radius: 0.5rem; padding: 0.5rem 0.75rem; white-space: pre-wrap; overflow-wrap: anywhere"
                  :style="#if($chatInternalProperty)row.${chatInternalProperty} ? 'background:var(--muted);color:var(--foreground)' : (#end(row.CreatedBy === $store.currentUser.name ? 'background:var(--primary);color:var(--primary-foreground)' : 'background:var(--secondary);color:var(--secondary-foreground)')#if($chatInternalProperty))#end"
                  x-text="row.${chatBodyProperty}"></div>
           </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -155,6 +155,47 @@
 
     </form>
 
+#if($documentItemsLayout == "chat")
+    <!-- ===== Conversation thread (chat items) — bubbles + composer, only once the document exists.
+         Own vs other alignment keys on the audit CreatedBy vs the logged-in user; an internal memo is
+         tinted distinctly (data-variant) so it can't be mistaken for a reply shared with the requester. -->
+    <div class="vbox gap-2 w-full" x-show="itemsEnabled">
+      <div x-h-toolbar data-variant="transparent">
+        <span x-h-toolbar-title class="shrink-0" x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></span>
+      </div>
+      <div x-show="itemsError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemsError"></div></div>
+
+      <div x-h-chat="$store.currentUser.name" class="w-full rounded-control border border-input bg-input-inner" style="max-height: 28rem" :data-label="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'">
+        <template x-for="(row, idx) in items" :key="row[itemsDef.primaryKey] != null ? row[itemsDef.primaryKey] : idx">
+          <div x-h-chat-message :data-author="row.CreatedBy"#if($chatInternalProperty) :data-variant="row.${chatInternalProperty} ? 'internal' : 'external'"#end>
+            <div class="hbox items-baseline gap-2">
+              <span x-h-chat-message-author x-text="row.CreatedBy || T('$projectName:${tprefix}.defaults.system', 'System')"></span>
+              <span x-h-chat-message-timestamp x-text="window.HarmoniaFormat.value(row.CreatedAt, true)"></span>
+#if($chatInternalProperty)
+              <span x-show="row.${chatInternalProperty}" x-h-badge data-variant="warning" x-text="T('$projectName:${tprefix}.defaults.internal', 'Internal')"></span>
+#end
+            </div>
+            <div x-h-chat-message-body x-text="row.${chatBodyProperty}"></div>
+          </div>
+        </template>
+        <div x-show="items.length === 0" x-h-text.muted class="p-2" x-text="T('$projectName:${tprefix}.messages.noData', 'No messages yet.')"></div>
+      </div>
+
+      <!-- Composer: Enter sends (Shift+Enter newlines); the send button also submits. -->
+      <div class="vbox gap-2" x-show="!isPreview">
+#if($chatInternalProperty)
+        <label class="hbox items-center gap-2 text-sm">
+          <span x-h-switch data-size="sm"><input type="checkbox" x-model="chatInternal" /></span>
+          <span x-text="T('$projectName:${tprefix}.defaults.internalNote', 'Internal note (not visible to the requester)')"></span>
+        </label>
+#end
+        <div x-h-chat-composer @send="sendMessage($event.detail.value)">
+          <textarea x-h-textarea.group rows="1" :disabled="chatSending" :aria-label="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message')" :placeholder="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message...')"></textarea>
+          <button type="button" x-h-button data-variant="primary" data-slot="chat-composer-send" :disabled="chatSending" :aria-label="T('$projectName:${tprefix}.defaults.send', 'Send')"><i role="img" x-h-lucide data-lucide="send"></i></button>
+        </div>
+      </div>
+    </div>
+#else
     <!-- ===== Line items (read-only table; add/edit via dialog) — only once the document exists ===== -->
     <div class="vbox gap-2 w-full" x-show="itemsEnabled">
       <div x-h-toolbar data-variant="transparent">
@@ -195,6 +236,7 @@
         </tbody>
       </table>
     </div>
+#end
 
     <!-- ===== Totals footer (aggregate fields, read-only, right-aligned) — only once the document exists ===== -->
     <div class="hbox justify-end w-full" x-show="itemsEnabled">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -158,30 +158,44 @@
 #if($documentItemsLayout == "chat")
     <!-- ===== Conversation thread (chat items) — bubbles + composer, only once the document exists.
          Own vs other alignment keys on the audit CreatedBy vs the logged-in user; an internal memo is
-         tinted distinctly (data-variant) so it can't be mistaken for a reply shared with the requester. -->
+         tinted distinctly (bg-muted + an Internal badge) so it can't be mistaken for a reply shared
+         with the requester.
+         TODO(harmonia): once @codbex/harmonia ships the x-h-chat component family (x-h-chat /
+         x-h-chat-message[-author|-timestamp|-body] / x-h-chat-composer), replace this hand-rolled
+         thread + composer with those directives. This version is composed from primitives already in
+         the shipped Harmonia webjar so it works before that component lands. -->
     <div class="vbox gap-2 w-full" x-show="itemsEnabled">
       <div x-h-toolbar data-variant="transparent">
         <span x-h-toolbar-title class="shrink-0" x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></span>
       </div>
       <div x-show="itemsError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemsError"></div></div>
 
-      <div x-h-chat="$store.currentUser.name" class="w-full rounded-control border border-input bg-input-inner" style="max-height: 28rem" :data-label="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'">
+      <!-- Load-bearing visuals (alignment, bubble colours, wrapping, scroll) use inline styles +
+           semantic CSS vars rather than utility classes: the shipped Harmonia webjar's prebuilt CSS
+           only contains classes its own source scanned, so a utility not in that bundle would silently
+           no-op. Inline styles + theme vars (var(--primary) etc., defined in the webjar's globals.css)
+           are robust. The x-h-chat swap-in (TODO above) will own this styling as a real component. -->
+      <div class="vbox gap-3 w-full rounded-control border border-input bg-input-inner p-4" style="max-height: 28rem; overflow-y: auto" role="log" aria-live="polite">
         <template x-for="(row, idx) in items" :key="row[itemsDef.primaryKey] != null ? row[itemsDef.primaryKey] : idx">
-          <div x-h-chat-message :data-author="row.CreatedBy"#if($chatInternalProperty) :data-variant="row.${chatInternalProperty} ? 'internal' : 'external'"#end>
+          <div class="vbox gap-1" style="max-width: 85%"
+               :style="row.CreatedBy === $store.currentUser.name ? 'align-self:flex-end;align-items:flex-end' : 'align-self:flex-start;align-items:flex-start'">
             <div class="hbox items-baseline gap-2">
-              <span x-h-chat-message-author x-text="row.CreatedBy || T('$projectName:${tprefix}.defaults.system', 'System')"></span>
-              <span x-h-chat-message-timestamp x-text="window.HarmoniaFormat.value(row.CreatedAt, true)"></span>
+              <span class="text-foreground text-xs font-medium" x-text="row.CreatedBy || T('$projectName:${tprefix}.defaults.system', 'System')"></span>
+              <span class="text-muted-foreground text-xs" x-text="window.HarmoniaFormat.value(row.CreatedAt, true)"></span>
 #if($chatInternalProperty)
               <span x-show="row.${chatInternalProperty}" x-h-badge data-variant="warning" x-text="T('$projectName:${tprefix}.defaults.internal', 'Internal')"></span>
 #end
             </div>
-            <div x-h-chat-message-body x-text="row.${chatBodyProperty}"></div>
+            <div class="text-sm" style="border-radius: 0.5rem; padding: 0.5rem 0.75rem; white-space: pre-wrap; word-break: break-word"
+                 :style="#if($chatInternalProperty)row.${chatInternalProperty} ? 'background:var(--muted);color:var(--foreground)' : (#end(row.CreatedBy === $store.currentUser.name ? 'background:var(--primary);color:var(--primary-foreground)' : 'background:var(--secondary);color:var(--secondary-foreground)')#if($chatInternalProperty))#end"
+                 x-text="row.${chatBodyProperty}"></div>
           </div>
         </template>
         <div x-show="items.length === 0" x-h-text.muted class="p-2" x-text="T('$projectName:${tprefix}.messages.noData', 'No messages yet.')"></div>
       </div>
 
-      <!-- Composer: Enter sends (Shift+Enter newlines); the send button also submits. -->
+      <!-- Composer: Enter sends; the send button also submits. (x-h-chat-composer will add Shift+Enter
+           newline handling once it ships.) -->
       <div class="vbox gap-2" x-show="!isPreview">
 #if($chatInternalProperty)
         <label class="hbox items-center gap-2 text-sm">
@@ -189,9 +203,9 @@
           <span x-text="T('$projectName:${tprefix}.defaults.internalNote', 'Internal note (not visible to the requester)')"></span>
         </label>
 #end
-        <div x-h-chat-composer @send="sendMessage($event.detail.value)">
-          <textarea x-h-textarea.group rows="1" :disabled="chatSending" :aria-label="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message')" :placeholder="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message...')"></textarea>
-          <button type="button" x-h-button data-variant="primary" data-slot="chat-composer-send" :disabled="chatSending" :aria-label="T('$projectName:${tprefix}.defaults.send', 'Send')"><i role="img" x-h-lucide data-lucide="send"></i></button>
+        <div class="hbox items-end gap-2 w-full">
+          <textarea x-h-textarea rows="1" class="grow" x-model="chatDraft" @keydown.enter.prevent="sendMessage(chatDraft)" :disabled="chatSending" :aria-label="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message')" :placeholder="T('$projectName:${tprefix}.defaults.writeMessage', 'Write a message...')"></textarea>
+          <button type="button" x-h-button data-variant="primary" @click="sendMessage(chatDraft)" :disabled="chatSending || !chatDraft.trim()" :aria-label="T('$projectName:${tprefix}.defaults.send', 'Send')"><i role="img" x-h-lucide data-lucide="send"></i></button>
         </div>
       </div>
     </div>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -361,8 +361,14 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(intentModel.contains("\"chatBodyProperty\": \"Body\""), "the chat body property must be resolved into the .model");
         assertTrue(intentModel.contains("\"chatInternalProperty\": \"Internal\""),
                 "the chat internal-flag property must be resolved into the .model");
+        // The thread is composed from shipped Harmonia primitives (a role="log" bubble list + a
+        // textarea composer bound to chatDraft) - the x-h-chat component is a later swap-in (TODO in
+        // the template), so assert the primitives that render the chat, not that directive.
         String ticketDoc = contentOf("gen/emission/views/Ticket/Ticket-document.html");
-        assertTrue(ticketDoc.contains("x-h-chat"), "documentItemsLayout: chat must emit the x-h-chat thread into the document view");
+        assertTrue(ticketDoc.contains("role=\"log\""),
+                "documentItemsLayout: chat must emit the conversation thread (role=log) into the document view");
+        assertTrue(ticketDoc.contains("x-model=\"chatDraft\""),
+                "documentItemsLayout: chat must emit the message composer into the document view");
         String ticketPage = contentOf("gen/emission/js/components/pages/Ticket/TicketDocumentPage.js");
         assertTrue(ticketPage.contains("sendMessage"), "the chat document page must emit the append-message composer handler");
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -153,6 +153,25 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 relations:
                   - { name: Claim, kind: manyToOne, to: Claim, composition: true }
 
+              # documentItemsLayout: chat - the document master's line-items child renders as a
+              # conversation thread (x-h-chat bubbles + a composer) instead of the editable table;
+              # the body maps to the messageBody field, author/timestamp to the child's audit columns.
+              - name: Ticket
+                function: Document
+                documentItemsLayout: chat
+                fields:
+                  - { name: id,      type: integer, primaryKey: true, generated: true }
+                  - { name: subject, type: string, length: 200 }
+              - name: TicketMessage
+                function: DocumentItem
+                audit: true
+                fields:
+                  - { name: id,       type: integer, primaryKey: true, generated: true }
+                  - { name: body,     type: text, messageBody: true }
+                  - { name: internal, type: boolean, messageInternal: true }
+                relations:
+                  - { name: Ticket, kind: manyToOne, to: Ticket, composition: true, required: true }
+
             # collection-driven generation: the monthly job creates one Claim per Person and,
             # under each, one ClaimLine per working day of the month (amount defaulted).
             schedules:
@@ -333,6 +352,19 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(job.contains("savedTarget"), "the scheduled generation must save the parent and keep its id for the children");
         assertTrue(job.contains("getDayOfWeek"), "a days child must iterate the working days of the month");
         assertTrue(job.contains("ClaimLineRepository"), "the child rows must be saved through the child's repository");
+
+        // documentItemsLayout: chat - the .model marker is resolved (body property from the child's
+        // messageBody field), and the Harmonia document view + page render the items pane as an
+        // x-h-chat thread with an append-message composer instead of the editable table.
+        String intentModel = contentOf("emission.model");
+        assertTrue(intentModel.contains("\"documentItemsLayout\": \"chat\""), "documentItemsLayout: chat must reach the .model");
+        assertTrue(intentModel.contains("\"chatBodyProperty\": \"Body\""), "the chat body property must be resolved into the .model");
+        assertTrue(intentModel.contains("\"chatInternalProperty\": \"Internal\""),
+                "the chat internal-flag property must be resolved into the .model");
+        String ticketDoc = contentOf("gen/emission/views/Ticket/Ticket-document.html");
+        assertTrue(ticketDoc.contains("x-h-chat"), "documentItemsLayout: chat must emit the x-h-chat thread into the document view");
+        String ticketPage = contentOf("gen/emission/js/components/pages/Ticket/TicketDocumentPage.js");
+        assertTrue(ticketPage.contains("sendMessage"), "the chat document page must emit the append-message composer handler");
 
         // label: the repository recomputes the stored display Name on every write path.
         String claimRepository = contentOf("gen/emission/data/claim/ClaimRepository.java");


### PR DESCRIPTION
## What

Adds a new intent DSL capability: a document (header-items) master may declare `documentItemsLayout: chat` to render its composition line-items child as a **chat conversation thread** (message bubbles + a composer) instead of the editable items table. The document header, `DOCUMENT_NUMBER` title, `DOCUMENT_STATUS` pill, inline process tasks and print all stay intact - only the items pane changes.

## How

- **DSL**: `EntityIntent.documentItemsLayout` + `isChatItems()`; `FieldIntent` field roles `messageBody` (the bubble text) and `messageInternal` (an optional boolean flag - internal memo). Author + timestamp come from the child's `audit: true` columns.
- **Parser**: `validateDocumentItemsLayout` - `chat` is the only value; the entity must be a document master; the items child must declare exactly one `messageBody` field + `audit: true`; `messageInternal` must be boolean.
- **Generator** (`EdmIntentGenerator`): emits `documentItemsLayout` + resolved `chatBodyProperty`/`chatInternalProperty` on the master.
- **Harmonia template**: the document view branches the items pane to a `role="log"` bubble thread (own/other alignment by audit author vs the logged-in user; internal memos tinted + badged) + a composer; `sendMessage()` appends a child row via the reused REST path. Rendered from primitives already in the shipped Harmonia webjar (inline styles + semantic CSS vars), with a `TODO(harmonia)` to swap to a dedicated `x-h-chat` component once it ships.
- **Guide** + unit tests (`IntentParserTest`, `EdmIntentGeneratorTest`) + `IntentEmissionCoverageIT` (a `Ticket`/`TicketMessage` chat document asserting the `.model` marker and the generated chat view + composer).

## Verification

engine-intent unit suite green (134); `tests-integrations` compiles; `formatter:validate` + the release-profile javadoc gate clean on the changed modules. `IntentEmissionCoverageIT` extended (the enforced smoke gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)