### PR TITLE
fix(harmonia): add HarmoniaFormat.toPayload + date used by My/Partner surfaces

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
@@ -172,6 +172,14 @@
     },
 
     /**
+     * DISPLAY-format a date/date-time value against the active date pattern. Convenience alias for
+     * value(v, true) - a backend LocalDate array, epoch number, or ISO string renders as a date.
+     */
+    date(v) {
+      return this.value(v, true);
+    },
+
+    /**
      * Convert a date/datetime value to the FIXED shape an HTML <input> requires — NOT pattern-driven.
      * `widget` is one of DATE, DATETIME-LOCAL, TIME, MONTH (case-insensitive). Empty -> ''.
      */
@@ -201,6 +209,20 @@
         case 'MONTH': return y + '-' + pad(mo);
         default: return date;
       }
+    },
+
+    /**
+     * Inverse of toDateInput: convert an HTML <input> value to the payload value the backend expects.
+     * DATE / DATETIME-LOCAL / MONTH -> a full ISO instant (…Z) so a Jackson java.time.* field binds;
+     * TIME -> passes through unchanged; empty -> null. An unparseable value is returned unchanged.
+     * `widget` is one of DATE, DATETIME-LOCAL, TIME, MONTH (case-insensitive).
+     */
+    toPayload(value, widget) {
+      if (value === null || value === undefined || value === '') return null;
+      const w = String(widget || 'DATE').toUpperCase();
+      if (w === 'TIME') return value;
+      const d = new Date(value);
+      return isNaN(d.getTime()) ? value : d.toISOString();
     },
   };
 


### PR DESCRIPTION
## Problem

Every generated **My** (personal) and **Partner** surface throws `window.HarmoniaFormat.toPayload is not a function` on create/save, and would also throw `HarmoniaFormat.date is not a function` when rendering a date cell.

The my/partner form/list templates (`template-application-ui-harmonia-java/ui/my/*`, `ui/partner/*`) call:
- `window.HarmoniaFormat.toPayload(value, widget)` in their `toPayload()`
- `window.HarmoniaFormat.date(value)` in their list cell formatter

Neither existed in the shared shell `format.js`. The **regular** surfaces don't hit this because their templates inline the payload conversion (`new Date(v).toISOString()`) and use `HarmoniaFormat.value(v, true)` for date display.

## Fix

Adds both methods to the shared `HarmoniaFormat` (`components/resources/application-core/.../shell/js/services/format.js`):

- **`toPayload(value, widget)`** — inverse of the existing `toDateInput`: `DATE`/`DATETIME-LOCAL`/`MONTH` → a full ISO instant (`…Z`) so a Jackson `java.time.*` field binds; `TIME` passes through unchanged; empty → `null`; an unparseable value is returned unchanged.
- **`date(v)`** — convenience alias for `value(v, true)` (display-format a date value).

Because `format.js` is the **shared, model-independent runtime**, this single file fixes every generated My/Partner surface across all modules with **no regeneration**. `HarmoniaFormat` now exposes: `defaults, number, value, date, toDateInput, toPayload`, covering every call the generated pages make.

## Verified

- Reproduced live on a My VacationRequest create form (`toPayload is not a function`); the chat/edit flows and REST binding all work once the function exists.
- `node --check` clean; the served bundle requires an `application-core` + `build/application` rebuild (webjar, no hot-reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)