### PR TITLE
fix(csvim): seed plain-text CLOB/LONGVARCHAR columns without requiring base64

### DIFF
--- a/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvProcessor.java
+++ b/components/data/data-csvim/src/main/java/org/eclipse/dirigible/components/data/csvim/processor/CsvProcessor.java
@@ -427,9 +427,17 @@ public class CsvProcessor {
             preparedStatement.setBinaryStream(paramIdx, new ByteArrayInputStream(bytes), bytes.length);
         } else if (Types.CLOB == DataTypeUtils.getSqlTypeByDataType(dataType)
                 || Types.LONGVARCHAR == DataTypeUtils.getSqlTypeByDataType(dataType)) {
-            byte[] bytes = Base64.getDecoder()
-                                 .decode(value);
-            preparedStatement.setAsciiStream(paramIdx, new ByteArrayInputStream(bytes), bytes.length);
+            // A CLOB/LONGVARCHAR cell may be base64-encoded (binary-safe round-tripping) or plain,
+            // human-authored text. Decode when it is valid base64; otherwise bind the raw string so a
+            // hand-written CSV (spaces, punctuation, Unicode) seeds directly instead of failing with
+            // "Illegal base64 character". setString handles a CLOB and preserves non-ASCII text.
+            try {
+                byte[] bytes = Base64.getDecoder()
+                                     .decode(value);
+                preparedStatement.setAsciiStream(paramIdx, new ByteArrayInputStream(bytes), bytes.length);
+            } catch (IllegalArgumentException notBase64) {
+                preparedStatement.setString(paramIdx, value);
+            }
         } else if (Types.OTHER == DataTypeUtils.getSqlTypeByDataType(dataType)) {
             if (SqlDialectFactory.getDialect(preparedStatement.getConnection()) instanceof PostgresSqlDialect) {
                 if (!value.trim()


### PR DESCRIPTION
## Problem

`CsvProcessor.setValue` base64-decodes **every** `CLOB`/`LONGVARCHAR` cell:

```java
byte[] bytes = Base64.getDecoder().decode(value);
preparedStatement.setAsciiStream(paramIdx, new ByteArrayInputStream(bytes), bytes.length);
```

So a CSVIM importing a **human-authored** CSV into a text column (a `note`, `description`, `conditions`, `reason`, …) fails on the first space/punctuation:

```
java.lang.IllegalArgumentException: Illegal base64 character 20   (0x20 = space)
  at java.base/java.util.Base64$Decoder.decode0(...)
  at ...CsvProcessor.setValue(CsvProcessor.java:431)
```

Only base64-encoded content could ever be seeded into a text column — surprising and undocumented, and it silently fails the whole batch import for that table. This has been the behaviour since #5175 (2025-07-01).

## Fix

In the `CLOB`/`LONGVARCHAR` branch, try base64 first and fall back to binding the **raw string** via `setString` when the value is not valid base64:

```java
try {
    byte[] bytes = Base64.getDecoder().decode(value);
    preparedStatement.setAsciiStream(paramIdx, new ByteArrayInputStream(bytes), bytes.length);
} catch (IllegalArgumentException notBase64) {
    preparedStatement.setString(paramIdx, value);   // handles CLOB + preserves Unicode
}
```

- **Strictly more permissive** — a value that is valid base64 decodes exactly as before (no regression); plain text, previously a hard failure, now seeds correctly.
- `setString` binds fine to a CLOB and preserves non-ASCII/Unicode (unlike the ASCII stream), so multilingual seed data works too.
- Binary types (`BLOB`/`BINARY`) are untouched and still require base64.

## Impact

Any CSVIM seeding a text/CLOB column with authored content now imports instead of failing the batch. Surfaced while seeding the KeyFolders demo data (note/description/conditions columns across ~8 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)