### PR TITLE
fix(jobs): make job-log artefact key unique per row (same-millisecond trigger race)

### DIFF
--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/domain/JobLog.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/domain/JobLog.java
@@ -15,6 +15,7 @@ import org.eclipse.dirigible.components.base.artefact.Artefact;
 
 import java.sql.Timestamp;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The JobLogDefinition serialization object.
@@ -25,6 +26,13 @@ public class JobLog extends Artefact {
 
     /** The Constant ARTEFACT_TYPE. */
     public static final String ARTEFACT_TYPE = "job-log";
+
+    /**
+     * Per-JVM monotonic suffix guaranteeing a unique artefact key even when two log rows for the same
+     * job+tenant are created within the same millisecond (the timestamp alone is not unique enough,
+     * which tripped the DIRIGIBLE_JOB_LOGS unique index and silently skipped that job execution).
+     */
+    private static final AtomicLong KEY_SEQUENCE = new AtomicLong();
 
     /** The id. */
     @Id
@@ -259,7 +267,7 @@ public class JobLog extends Artefact {
     @Override
     public void updateKey() {
         super.updateKey();
-        this.key = this.key + KEY_SEPARATOR + tenantId;
+        this.key = this.key + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + KEY_SEQUENCE.incrementAndGet();
     }
 
     /**


### PR DESCRIPTION
## Problem

`DIRIGIBLE_JOB_LOGS.ARTEFACT_KEY` is built as `type:location:name:tenant`, where `location` is a **millisecond-resolution** timestamp (`JobLogService`, `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`). Two log rows for the same job+tenant created within the **same millisecond** produce an identical key and violate the unique index:

```
[ERROR] JobExecutionService - Failed to register job [synchronize] as TRIGGERED.
org.springframework.dao.DataIntegrityViolationException: Unique index or primary key violation:
  UK_DIRIGIBLE_JOB_LOGS_ARTEFACT_KEY ... VALUES ('job-log:2026-07-13T12:56:14.629+03:00:synchronize:default-tenant')
```

`registerTriggered()` swallows the exception and returns `null`, and `executeJobInternal` runs the handler only `if (triggered != null)` — so the colliding tick's job is **silently skipped**. It shows up most under rapid triggering (e.g. right after a Publish All, when `synchronize` fires repeatedly).

## Fix

Job-log rows are append-only and are never looked up by key (queries go through `findByJob`); the key exists only to satisfy the unique constraint. Append a per-JVM monotonic `AtomicLong` suffix in `JobLog.updateKey()`:

```java
this.key = this.key + KEY_SEPARATOR + tenantId + KEY_SEPARATOR + KEY_SEQUENCE.incrementAndGet();
```

Concurrent/same-millisecond rows now get distinct keys, so every trigger logs and **every job runs**. No schema change. Keys remain unique across restarts because the timestamp component always moves forward (a fresh JVM's reset counter can only collide with a past row at an identical millisecond, which time precludes).

## Notes

Minimal, self-contained. An alternative would be dropping the unique constraint (a log table arguably shouldn't have one), but that is a schema migration; the per-row suffix keeps the existing contract and is backward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)