### PR TITLE
[Security] Access constraints are not enforced for Java endpoints

### DIFF
--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/config/SecurityFilterConfig.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/config/SecurityFilterConfig.java
@@ -34,12 +34,14 @@ public class SecurityFilterConfig {
         filterRegistrationBean.addUrlPatterns(//
                 "/services/js/*", //
                 "/services/ts/*", //
+                "/services/java/*", //
                 "/services/public/*", //
                 "/services/web/*", //
                 "/services/wiki/*", //
                 "/services/command/*", //
                 "/public/js/*", //
                 "/public/ts/*", //
+                "/public/java/*", //
                 "/public/public/*", //
                 "/public/web/*", //
                 "/public/wiki/*", //

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/filter/SecurityFilter.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/filter/SecurityFilter.java
@@ -78,10 +78,12 @@ public class SecurityFilter implements Filter {
     public void init(FilterConfig filterConfig) {
         SECURED_PREFIXES.add("/services/js");
         SECURED_PREFIXES.add("/services/ts");
+        SECURED_PREFIXES.add("/services/java");
         SECURED_PREFIXES.add("/services/public");
         SECURED_PREFIXES.add("/services/web");
         SECURED_PREFIXES.add("/services/wiki");
         SECURED_PREFIXES.add("/services/command");
+        SECURED_PREFIXES.add("/public/java");
 
         ALLOWED_PREFIXES.add("/services/web/resources");
         ALLOWED_PREFIXES.add("/services/js/platform");

--- a/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/synchronizer/AccessSynchronizer.java
+++ b/components/engine/engine-security/src/main/java/org/eclipse/dirigible/components/security/synchronizer/AccessSynchronizer.java
@@ -21,6 +21,7 @@ import org.eclipse.dirigible.components.base.synchronizer.SynchronizersOrder;
 import org.eclipse.dirigible.components.security.domain.Access;
 import org.eclipse.dirigible.components.security.domain.Constraints;
 import org.eclipse.dirigible.components.security.service.AccessService;
+import org.eclipse.dirigible.components.security.verifier.AccessVerifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,6 +57,11 @@ public class AccessSynchronizer extends BaseSynchronizer<Access, Long> {
     private final AccessService securityAccessService;
 
     /**
+     * The security access verifier.
+     */
+    private final AccessVerifier securityAccessVerifier;
+
+    /**
      * The synchronization callback.
      */
     private SynchronizerCallback callback;
@@ -64,10 +70,12 @@ public class AccessSynchronizer extends BaseSynchronizer<Access, Long> {
      * Instantiates a new security access synchronizer.
      *
      * @param securityAccessService the security access service
+     * @param securityAccessVerifier the security access verifier
      */
     @Autowired
-    public AccessSynchronizer(AccessService securityAccessService) {
+    public AccessSynchronizer(AccessService securityAccessService, AccessVerifier securityAccessVerifier) {
         this.securityAccessService = securityAccessService;
+        this.securityAccessVerifier = securityAccessVerifier;
     }
 
     /**
@@ -177,6 +185,19 @@ public class AccessSynchronizer extends BaseSynchronizer<Access, Long> {
             callback.addError(e.getMessage());
             callback.registerState(this, access, ArtefactLifecycle.DELETED, e);
         }
+    }
+
+    /**
+     * Called once at the end of every synchronization round. Reloads the {@link AccessVerifier} cache
+     * so that constraints synchronized into the database are enforced as soon as the round completes.
+     * The verifier's scheduled refresh reacts to registry filesystem events only, which never fire on
+     * instances whose registry content is pre-baked into the container image - and even on
+     * publish-driven instances the synchronization round consumes the watcher flag before the
+     * verifier's poll can observe it.
+     */
+    @Override
+    public void finishing() {
+        securityAccessVerifier.refreshCache(true);
     }
 
     /**

--- a/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/restassured/RestAssuredExecutor.java
+++ b/tests/tests-framework/src/main/java/org/eclipse/dirigible/tests/framework/restassured/RestAssuredExecutor.java
@@ -156,4 +156,18 @@ public class RestAssuredExecutor {
         this.execute(callable, "localhost", user, password);
     }
 
+    public void execute(CallableNoResultAndNoException callable, String user, String password, long timeoutSeconds) {
+        await().atMost(timeoutSeconds, TimeUnit.SECONDS)
+               .pollInterval(500, TimeUnit.MILLISECONDS)
+               .until(() -> {
+                   try {
+                       this.execute(callable, user, password);
+                       return true;
+                   } catch (AssertionError err) {
+                       LOGGER.warn("Assertion error. Will try again until timeout is reached.", err);
+                       return false;
+                   }
+               });
+    }
+
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaAccessConstraintsIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/JavaAccessConstraintsIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.base.http.roles.Roles;
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.eclipse.dirigible.tests.framework.security.SecurityUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end test for HTTP access constraints ({@code *.access}) on client Java endpoints served
+ * under {@code /services/java/...}: a role constraint synchronized from the registry must deny a
+ * user without the role (403) and admit a user with it (200) as soon as the synchronization round
+ * completes.
+ */
+class JavaAccessConstraintsIT extends IntegrationTest {
+
+    /** Project segment used for all sources in this IT. */
+    private static final String PROJECT = "java-access-it";
+
+    /** Registry path of the client Java handler. */
+    private static final String SOURCE_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/demo/Hello.java";
+
+    /** Registry path of the access constraint artefact. */
+    private static final String ACCESS_REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + "/" + PROJECT + "/security/demo.access";
+
+    /** Endpoint where the {@code demo.Hello} handler answers. */
+    private static final String ENDPOINT = "/services/java/" + PROJECT + "/demo/Hello";
+
+    private static final String ADMIN_USER = "java-access-it-admin";
+    private static final String NON_ADMIN_USER = "java-access-it-developer";
+    private static final String PASSWORD = "java-access-it-password";
+
+    /**
+     * Wait cap for the first request after the handler is synchronized - the in-process compile +
+     * class-define cycle can finish shortly after {@code forceProcessSynchronizers()} returns.
+     */
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    private static final String HANDLER_SOURCE = """
+            package demo;
+            import jakarta.servlet.http.HttpServletRequest;
+            import jakarta.servlet.http.HttpServletResponse;
+            import org.eclipse.dirigible.engine.java.handler.JavaHandler;
+            public class Hello implements JavaHandler {
+                @Override
+                public void handle(HttpServletRequest request, HttpServletResponse response) throws Exception {
+                    response.setContentType("application/json");
+                    response.getWriter().write("{\\"message\\": \\"hello\\"}");
+                }
+            }
+            """;
+
+    /** The constraint path is registry-relative - the filter strips the /services/java prefix. */
+    private static final String ACCESS_CONSTRAINT = """
+            {
+                "constraints": [
+                    {
+                        "path": "/%s/**",
+                        "method": "*",
+                        "scope": "HTTP",
+                        "roles": [
+                            "%s"
+                        ]
+                    }
+                ]
+            }
+            """.formatted(PROJECT, Roles.RoleNames.ADMINISTRATOR);
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Autowired
+    private SecurityUtil securityUtil;
+
+    @Test
+    void access_constraints_are_enforced_for_java_endpoints() {
+        securityUtil.createUserInDefaultTenant(ADMIN_USER, PASSWORD, Roles.RoleNames.ADMINISTRATOR);
+        securityUtil.createUserInDefaultTenant(NON_ADMIN_USER, PASSWORD, Roles.RoleNames.DEVELOPER);
+
+        // without a constraint any authenticated user can call the handler
+        repository.createResource(SOURCE_REGISTRY_PATH, HANDLER_SOURCE.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+        assertEndpointStatusEventually(NON_ADMIN_USER, 200);
+
+        // the constraint restricts the project to ADMINISTRATOR; it must be enforced as soon as the
+        // forced synchronization returns - no retry window for the 403
+        repository.createResource(ACCESS_REGISTRY_PATH, ACCESS_CONSTRAINT.getBytes(StandardCharsets.UTF_8), false, "application/json",
+                true);
+        synchronizationProcessor.forceProcessSynchronizers();
+        assertEndpointStatus(NON_ADMIN_USER, 403);
+        assertEndpointStatus(ADMIN_USER, 200);
+    }
+
+    private void assertEndpointStatusEventually(String user, int expectedStatus) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT)
+                                                 .then()
+                                                 .statusCode(expectedStatus),
+                user, PASSWORD, ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    private void assertEndpointStatus(String user, int expectedStatus) {
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT)
+                                                 .then()
+                                                 .statusCode(expectedStatus),
+                user, PASSWORD);
+    }
+
+}


### PR DESCRIPTION
## Overview

HTTP access constraints from `*.access` artifacts are now enforced for client Java endpoints (`/services/java/**` and `/public/java/**`), and synchronized constraints take effect as soon as the synchronization round completes — previously they could stay inactive indefinitely on instances whose registry content never changes on the filesystem.

Fixes: #6277.