### PR TITLE
fix(intent-editor): save on Cmd+S instead of triggering browser save-page

### DIFF
--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -99,7 +99,8 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
         });
     };
 
-    $scope.save = () => {
+    $scope.save = (keySet = 'ctrl+s', event) => {
+        event?.preventDefault();
         if (!$scope.changed || $scope.state.error) return;
         $scope.state.isBusy = true;
         WorkspaceService.saveContent($scope.dataParameters.filePath, $scope.text).then(() => {


### PR DESCRIPTION
## What

Fixes an annoying behaviour in the Intent Editor: pressing **Cmd+S / Ctrl+S** did not save the `app.intent` file — instead the browser's native "Save page" dialog appeared.

## Why

Cmd+S is wired through the platform `shortcut` directive on the editor body (`shortcut="'ctrl+s'" shortcut-action="save"`). That directive invokes `shortcut.action(keySet, event)` but **deliberately does not** call `event.preventDefault()` itself — suppressing the browser default is the action's responsibility.

The Intent Editor's `$scope.save` was declared as `() => {…}`: it took no event and never called `preventDefault()`, so the browser default fired. This was most visible right after accepting an AI-assistant proposal, which dirties the buffer without the user typing — the buffer was genuinely dirty, the keydown just wasn't intercepted.

Every sibling blimpKit editor that uses the same directive (`editor-csv`, `editor-csvim`, `editor-integrations`) already does it correctly. The Intent Editor was the lone outlier.

## Change

One-line signature change to the repo-standard pattern:

```js
$scope.save = (keySet = 'ctrl+s', event) => {
    event?.preventDefault();
    ...
```

The defaulted parameters keep the toolbar Save button (`ng-click="save()"`) and the `workspaceHub.onSaveAll` / `onSaveFile` hub handlers (which call `save()` with no args) working unchanged — only the `shortcut` directive passes `(keySet, event)`.

## Testing

Verified locally: open a project's `app.intent`, use the AI assistant, click **Accept** on a proposal (buffer goes dirty), press **Cmd+S** — the file saves silently, no download dialog. Plain typing edits + Cmd+S and the toolbar Save button also confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)