### PR TITLE
fix(intent-editor): keep Generate clickable after a cross-model failure

### DIFF
--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/editor.html
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/editor.html
@@ -158,7 +158,7 @@
             <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="transparent" glyph="sap-icon--save" title="Save" aria-label="Save" ng-click="save()" ng-disabled="!changed || state.isBusy"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>
-            <bk-button state="emphasized" glyph="sap-icon--generate-shortcut" label="Generate" title="Generate the model files into the project" aria-label="Generate" ng-click="generate()" ng-disabled="state.isBusy || issues.length"></bk-button>
+            <bk-button state="emphasized" glyph="sap-icon--generate-shortcut" label="Generate" title="Generate the model files into the project" aria-label="Generate" ng-click="generate()" ng-disabled="state.isBusy"></bk-button>
             <bk-toolbar-separator></bk-toolbar-separator>
             <bk-button state="{{chat.open ? 'emphasized' : 'transparent'}}" glyph="sap-icon--discussion" title="AI assistant" aria-label="AI assistant" ng-click="toggleChat()"></bk-button>
         </bk-toolbar>

--- a/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
+++ b/components/ui/editor-intent/src/main/resources/META-INF/dirigible/editor-intent/js/editor.js
@@ -248,9 +248,9 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
 
     // Re-parse and re-validate the current buffer on demand. Generate resolves cross-model
     // dependencies against other projects' already-generated .model files; when one is missing it
-    // fails with issues that stay pinned (blocking Generate) until the buffer is re-parsed. After
-    // generating the dependency project, Refresh clears those stale issues and re-renders — no browser
-    // reload needed.
+    // fails with issues that stay pinned in the strip until the buffer is re-parsed (Generate itself
+    // stays clickable — it re-validates server-side). After generating the dependency project,
+    // Refresh clears those stale issues and re-renders — no browser reload needed.
     $scope.refresh = () => {
         refreshPreview().then(() => {
             statusBarHub.showMessage('Re-validated the intent');
@@ -319,6 +319,7 @@ editorView.controller('IntentEditorController', ($scope, $http, ViewParameters, 
         dialogHub.showBusyDialog('Generating model files');
         $http.post(`${GENERATE_URL}?workspace=${encodeURIComponent(location.workspace)}&project=${encodeURIComponent(location.project)}&path=${encodeURIComponent(location.path)}`)
              .then((response) => {
+                 $scope.issues = []; // a successful generate clears any pinned cross-model issue from a prior attempt
                  const written = (response.data.written || []).length;
                  const scrubbed = (response.data.scrubbed || []).length;
                  const plan = response.data.codeGenerations || [];


### PR DESCRIPTION
### Problem

In the Intent Editor, generating a model that references another model cross-model (e.g. `products.intent` → `uoms`) before the dependency exists fails — correctly — with:

> Cross-model relation target [UoM] (model alias [uoms], project [uoms]) cannot be resolved: no model found ... Generate the [uoms] model first ...

The error is expected. The bug is that the **Generate button then becomes permanently disabled**: after the user generates the `uoms` model, they can't retry `products` without closing and reopening the file (or discovering the non-obvious Refresh button).

### Root cause

The button was gated on `ng-disabled="state.isBusy || issues.length"`. The cross-model "cannot be resolved" message is a **generate-time** error (thrown by `CrossModelSupport` in the `/generate` path); the `/parse` endpoint never does cross-model resolution, so the live/debounced parse never re-produces the issue. It stayed pinned in `$scope.issues` and kept the button dead until something cleared it.

### Fix

- Drop the issues gate — the button is now `ng-disabled="state.isBusy"`. The backend re-parses and re-validates on every `/generate` call and returns `422` + the issues on failure, so the frontend gate was UX polish, not a safety guard: clicking Generate on a bad buffer just fails gracefully and re-shows the issues (still displayed in the strip).
- Clear `$scope.issues` on a successful generate, so a stale cross-model message disappears once the retry succeeds.

Frontend-only (`editor.html` + `editor.js`); no backend or test changes. `IntentEditorLoadsIT` still exercises the Generate flow.

### Verification

Verified locally against `dirigiblelabs/sample-intent-multi-model`: open `products.intent` → Generate shows the cross-model error but the button stays enabled → open `uoms.intent` → Generate succeeds → back on `products.intent`, Generate succeeds and the error clears from the strip. No close/reopen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)