### PR TITLE
fix(apptest): manifest mirrors the rendered UI; runner handles empty/tree/calendar layouts

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -19,6 +19,7 @@ import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext
 import org.eclipse.dirigible.components.intent.generator.IntentNaming;
 import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
 import org.eclipse.dirigible.components.intent.generator.edm.CrossModelSupport;
+import org.eclipse.dirigible.components.intent.model.CheckIntent;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
@@ -167,6 +168,21 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
         if (hasSeed(model, name)) {
             out.put("expectSeedData", true);
         }
+        // exactlyOne checks: exactly one of the named fields may be non-null - a sample record
+        // filling all of them is rejected with 400, so the runner keeps only the first
+        List<List<String>> exactlyOne = new ArrayList<>();
+        for (CheckIntent check : entity.getChecks() == null ? List.<CheckIntent>of() : entity.getChecks()) {
+            if ("exactlyOne".equals(check.getKind()) && check.getFields() != null && !check.getFields()
+                                                                                           .isEmpty()) {
+                exactlyOne.add(check.getFields()
+                                    .stream()
+                                    .map(IntentNaming::pascalCase)
+                                    .toList());
+            }
+        }
+        if (!exactlyOne.isEmpty()) {
+            out.put("exactlyOne", exactlyOne);
+        }
         out.put("fields", fields(entity));
         List<Map<String, Object>> relations = relations(entity, model, context, edmEntities);
         if (!relations.isEmpty()) {
@@ -197,8 +213,10 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             // Read-only must mirror the generated form exactly, or the runner waits forever on an
             // input that is not there: an author-marked field and a uuid render in the read-only
             // details block (no #f_<Name> input), a calculated field renders as a non-editable
-            // input, and an aggregate renders in the document totals footer.
-            if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType()) || field.isCalculated() || field.isAggregate()) {
+            // input, an aggregate renders in the document totals footer, and a dependsOn field is
+            // auto-populated by its trigger relation's watcher (the runner must not fill it).
+            if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType()) || field.isCalculated() || field.isAggregate()
+                    || field.getDependsOn() != null) {
                 out.put("readOnly", true);
             }
             out.put("major", field.isMajor());
@@ -240,6 +258,32 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             out.put("widget", "dropdown");
             if (relation.isEntityStatus()) {
                 out.put("entityStatus", true);
+            }
+            // dependsOn cascade: the option list narrows to target rows whose filterBy equals the
+            // trigger sibling's value - the runner must pick MATCHING samples (the dependent row
+            // first, then its FK as the trigger's sample), not independent first rows.
+            if (relation.getDependsOn() != null) {
+                Map<String, Object> dependsOn = new LinkedHashMap<>();
+                dependsOn.put("relation", IntentNaming.pascalCase(relation.getDependsOn()
+                                                                          .getRelation()));
+                if (relation.getDependsOn()
+                            .getFilterBy() != null) {
+                    dependsOn.put("filterBy", IntentNaming.pascalCase(relation.getDependsOn()
+                                                                              .getFilterBy()));
+                }
+                out.put("dependsOn", dependsOn);
+            }
+            // where: static option filter - only matching target rows are offered as options
+            if (relation.getWhere() != null && relation.getWhere()
+                                                       .size() == 1) {
+                Map.Entry<String, Object> condition = relation.getWhere()
+                                                              .entrySet()
+                                                              .iterator()
+                                                              .next();
+                Map<String, Object> where = new LinkedHashMap<>();
+                where.put("by", IntentNaming.pascalCase(condition.getKey()));
+                where.put("value", condition.getValue());
+                out.put("where", where);
             }
             if (relation.isCrossModel()) {
                 UsesIntent uses = usesByAlias.get(relation.getModel());

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -138,6 +138,12 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
         out.put("api", "/" + sanitizeJavaIdentifier(string(edm.get("perspectiveName"))) + "/" + name + "Controller");
         out.put("table", string(edm.get("dataName")));
 
+        // A hierarchical entity renders its list as a tree (role=treeitem, no table/columnheaders),
+        // so the runner must branch on it.
+        if (entity.getHierarchy() != null && !entity.getHierarchy()
+                                                    .isBlank()) {
+            out.put("hierarchy", true);
+        }
         boolean multilingual = "true".equals(string(edm.get("multilingual")));
         if (multilingual) {
             out.put("multilingual", true);
@@ -176,7 +182,10 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             if (field.getLength() != null) {
                 out.put("length", field.getLength());
             }
-            if (field.isReadOnly()) {
+            // Read-only must mirror the generated form exactly, or the runner waits forever on an
+            // input that is not there: an author-marked field and a uuid render in the read-only
+            // details block (no #f_<Name> input), a calculated field renders as a non-editable input.
+            if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType()) || field.isCalculated()) {
                 out.put("readOnly", true);
             }
             out.put("major", field.isMajor());
@@ -333,6 +342,9 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
     private static String layout(String layoutType) {
         return switch (layoutType == null ? "" : layoutType) {
             case "MANAGE_DOCUMENT" -> "document";
+            // the view family replaces the table page - the runner must not expect columns/rows
+            case "MANAGE_CALENDAR" -> "calendar";
+            case "MANAGE_SLOTS" -> "slots";
             default -> "manage-list";
         };
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -131,14 +131,14 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             if ("MANAGE_DETAILS".equals(string(edm.get("layoutType"))) || "PROJECTION".equals(string(edm.get("type")))) {
                 continue;
             }
-            entities.add(entityManifest(entity, edm, model, context));
+            entities.add(entityManifest(entity, edm, model, context, edmEntities));
         }
         manifest.put("entities", entities);
         return manifest;
     }
 
     private static Map<String, Object> entityManifest(EntityIntent entity, Map<String, Object> edm, IntentModel model,
-            IntentGenerationContext context) {
+            IntentGenerationContext context, Map<String, Map<String, Object>> edmEntities) {
         Map<String, Object> out = new LinkedHashMap<>();
         String name = entity.getName();
         out.put("name", name);
@@ -168,7 +168,7 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             out.put("expectSeedData", true);
         }
         out.put("fields", fields(entity));
-        List<Map<String, Object>> relations = relations(entity, model, context);
+        List<Map<String, Object>> relations = relations(entity, model, context, edmEntities);
         if (!relations.isEmpty()) {
             out.put("relations", relations);
         }
@@ -216,7 +216,8 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
      * inputs by the form templates, and its value comes from the {@code init:} DB default, so the
      * runner must neither pick nor post it.
      */
-    private static List<Map<String, Object>> relations(EntityIntent entity, IntentModel model, IntentGenerationContext context) {
+    private static List<Map<String, Object>> relations(EntityIntent entity, IntentModel model, IntentGenerationContext context,
+            Map<String, Map<String, Object>> edmEntities) {
         Map<String, UsesIntent> usesByAlias = new LinkedHashMap<>();
         for (UsesIntent uses : model.getUses()) {
             if (uses.getModel() != null) {
@@ -261,6 +262,13 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
                         + "/api/" + sanitizeJavaIdentifier(info.perspectiveName()) + "/" + relation.getTo() + "Controller");
                 out.put("labelFrom", info.labelField());
             } else {
+                // relative controller path of the same-model target - resolvable even when the
+                // target is a composition detail (excluded from this manifest's entities list)
+                Map<String, Object> targetEdm = edmEntities.get(relation.getTo());
+                if (targetEdm != null) {
+                    out.put("api",
+                            "/" + sanitizeJavaIdentifier(string(targetEdm.get("perspectiveName"))) + "/" + relation.getTo() + "Controller");
+                }
                 out.put("labelFrom", labelFieldOf(relation.getTo(), model));
             }
             relations.add(out);

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -18,11 +18,13 @@ import java.util.Map;
 import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
 import org.eclipse.dirigible.components.intent.generator.IntentNaming;
 import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
+import org.eclipse.dirigible.components.intent.generator.edm.CrossModelSupport;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.SeedIntent;
+import org.eclipse.dirigible.components.intent.model.UsesIntent;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IResource;
 import org.slf4j.Logger;
@@ -83,7 +85,7 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             return;
         }
 
-        Map<String, Object> manifest = buildManifest(baseName, context.getProjectName(), model, edmEntities);
+        Map<String, Object> manifest = buildManifest(baseName, context.getProjectName(), model, edmEntities, context);
         context.writeModelFile(baseName + ".test", GSON.toJson(manifest) + "\n");
         LOGGER.debug("Generated app-test manifest [{}.test]", baseName);
     }
@@ -102,6 +104,15 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
      */
     public static Map<String, Object> buildManifest(String baseName, String project, IntentModel model,
             Map<String, Map<String, Object>> edmEntities) {
+        return buildManifest(baseName, project, model, edmEntities, null);
+    }
+
+    /**
+     * The full variant carrying the generation context, which cross-model relation resolution needs (a
+     * {@code null} context falls back to the naming-convention target coordinates - unit tests).
+     */
+    public static Map<String, Object> buildManifest(String baseName, String project, IntentModel model,
+            Map<String, Map<String, Object>> edmEntities, IntentGenerationContext context) {
         Map<String, Object> manifest = new LinkedHashMap<>();
         manifest.put("module", baseName);
         manifest.put("standaloneShell", "/services/web/" + project + "/gen/" + baseName + "/index.html");
@@ -120,13 +131,14 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             if ("MANAGE_DETAILS".equals(string(edm.get("layoutType"))) || "PROJECTION".equals(string(edm.get("type")))) {
                 continue;
             }
-            entities.add(entityManifest(entity, edm, model));
+            entities.add(entityManifest(entity, edm, model, context));
         }
         manifest.put("entities", entities);
         return manifest;
     }
 
-    private static Map<String, Object> entityManifest(EntityIntent entity, Map<String, Object> edm, IntentModel model) {
+    private static Map<String, Object> entityManifest(EntityIntent entity, Map<String, Object> edm, IntentModel model,
+            IntentGenerationContext context) {
         Map<String, Object> out = new LinkedHashMap<>();
         String name = entity.getName();
         out.put("name", name);
@@ -156,7 +168,7 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             out.put("expectSeedData", true);
         }
         out.put("fields", fields(entity));
-        List<Map<String, Object>> relations = relations(entity, model);
+        List<Map<String, Object>> relations = relations(entity, model, context);
         if (!relations.isEmpty()) {
             out.put("relations", relations);
         }
@@ -184,8 +196,9 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             }
             // Read-only must mirror the generated form exactly, or the runner waits forever on an
             // input that is not there: an author-marked field and a uuid render in the read-only
-            // details block (no #f_<Name> input), a calculated field renders as a non-editable input.
-            if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType()) || field.isCalculated()) {
+            // details block (no #f_<Name> input), a calculated field renders as a non-editable
+            // input, and an aggregate renders in the document totals footer.
+            if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType()) || field.isCalculated() || field.isAggregate()) {
                 out.put("readOnly", true);
             }
             out.put("major", field.isMajor());
@@ -195,15 +208,25 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
-     * The user-pickable to-one relations rendered as dropdowns. Cross-model relations are omitted —
-     * their target lives in another module's manifest, so a single-module runner cannot resolve a
-     * sample option for them (a phase-2 concern).
+     * The user-pickable to-one relations rendered as dropdowns. A cross-model relation's target lives
+     * in another module — its option rows are resolved through an {@code apiAbsolute} controller URL
+     * (the same owner-project coordinates the generated dropdown uses), so the runner can fill the
+     * required FK without the target being in this manifest. A {@code function: EntityStatus} relation
+     * is marked {@code entityStatus} — it renders as a status pill / is excluded from the editable
+     * inputs by the form templates, and its value comes from the {@code init:} DB default, so the
+     * runner must neither pick nor post it.
      */
-    private static List<Map<String, Object>> relations(EntityIntent entity, IntentModel model) {
+    private static List<Map<String, Object>> relations(EntityIntent entity, IntentModel model, IntentGenerationContext context) {
+        Map<String, UsesIntent> usesByAlias = new LinkedHashMap<>();
+        for (UsesIntent uses : model.getUses()) {
+            if (uses.getModel() != null) {
+                usesByAlias.put(uses.getModel(), uses);
+            }
+        }
         List<Map<String, Object>> relations = new ArrayList<>();
         for (RelationIntent relation : entity.getRelations()) {
             boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
-            if (!toOne || relation.isCrossModel() || relation.getTo() == null) {
+            if (!toOne || relation.getTo() == null) {
                 continue;
             }
             Map<String, Object> out = new LinkedHashMap<>();
@@ -214,7 +237,32 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
                 out.put("required", true);
             }
             out.put("widget", "dropdown");
-            out.put("labelFrom", labelFieldOf(relation.getTo(), model));
+            if (relation.isEntityStatus()) {
+                out.put("entityStatus", true);
+            }
+            if (relation.isCrossModel()) {
+                UsesIntent uses = usesByAlias.get(relation.getModel());
+                if (uses == null) {
+                    continue;
+                }
+                CrossModelSupport.TargetInfo info;
+                try {
+                    info = CrossModelSupport.resolve(context, uses, relation.getTo());
+                } catch (RuntimeException ex) {
+                    // the EDM generator (order 200) fails loudly for a truly unresolvable target;
+                    // reaching here means a degraded context - omit the relation rather than emit a
+                    // guessed URL
+                    LOGGER.warn("Omitting cross-model relation [{}] of [{}] from the app-test manifest - target unresolved",
+                            relation.getName(), entity.getName(), ex);
+                    continue;
+                }
+                out.put("crossModel", true);
+                out.put("apiAbsolute", "/services/java/" + uses.resolveProject() + "/gen/" + sanitizeJavaIdentifier(uses.getModel())
+                        + "/api/" + sanitizeJavaIdentifier(info.perspectiveName()) + "/" + relation.getTo() + "Controller");
+                out.put("labelFrom", info.labelField());
+            } else {
+                out.put("labelFrom", labelFieldOf(relation.getTo(), model));
+            }
             relations.add(out);
         }
         return relations;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -305,6 +305,11 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
                 out.put("apiAbsolute", "/services/java/" + uses.resolveProject() + "/gen/" + sanitizeJavaIdentifier(uses.getModel())
                         + "/api/" + sanitizeJavaIdentifier(info.perspectiveName()) + "/" + relation.getTo() + "Controller");
                 out.put("labelFrom", info.labelField());
+                // leafOnly: the generated validation rejects a non-leaf target - the runner must
+                // pick a row no other row references via the target's hierarchy edge
+                if (relation.isLeafOnly() && info.hierarchyProperty() != null) {
+                    out.put("leafOnly", Map.of("hierarchyProperty", info.hierarchyProperty()));
+                }
             } else {
                 // relative controller path of the same-model target - resolvable even when the
                 // target is a composition detail (excluded from this manifest's entities list)
@@ -314,6 +319,15 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
                             "/" + sanitizeJavaIdentifier(string(targetEdm.get("perspectiveName"))) + "/" + relation.getTo() + "Controller");
                 }
                 out.put("labelFrom", labelFieldOf(relation.getTo(), model));
+                if (relation.isLeafOnly()) {
+                    for (EntityIntent target : model.getEntities()) {
+                        if (relation.getTo()
+                                    .equals(target.getName())
+                                && target.getHierarchy() != null) {
+                            out.put("leafOnly", Map.of("hierarchyProperty", IntentNaming.pascalCase(target.getHierarchy())));
+                        }
+                    }
+                }
             }
             relations.add(out);
         }

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
@@ -179,6 +179,9 @@ class AppTestIntentGeneratorTest {
         assertEquals(Boolean.TRUE, country.get("required"));
         assertEquals("dropdown", country.get("widget"));
         assertEquals("Name", country.get("labelFrom"));
+        // same-model targets carry their relative controller path (resolvable even for a
+        // composition detail excluded from the manifest's entities list)
+        assertEquals("/settings/CountryController", country.get("api"));
         assertNull(country.get("crossModel"));
 
         // the cross-model relation resolves an absolute controller URL in the OWNER module (naming

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
@@ -35,6 +35,8 @@ class AppTestIntentGeneratorTest {
     private static final String INTENT = """
             name: kf-mod-countries
             languages: [en, bg]
+            uses:
+              - { model: kf-mod-currencies }
             entities:
               - name: Country
                 kind: setting
@@ -51,8 +53,10 @@ class AppTestIntentGeneratorTest {
                   - { name: name, type: string, required: true, length: 200 }
                   - { name: uuid, type: uuid }
                   - { name: slug, type: string, calculatedOnCreate: "1" }
+                  - { name: total, type: decimal, aggregate: true }
                 relations:
                   - { name: Country, kind: manyToOne, to: Country, required: true }
+                  - { name: Currency, kind: manyToOne, to: Currency, model: kf-mod-currencies, required: true }
               - name: Account
                 group: master-data
                 hierarchy: Parent
@@ -107,6 +111,11 @@ class AppTestIntentGeneratorTest {
                                          .findFirst()
                                          .orElseThrow();
         assertEquals(Boolean.TRUE, slug.get("readOnly"));
+        Map<String, Object> total = fields.stream()
+                                          .filter(f -> "Total".equals(f.get("name")))
+                                          .findFirst()
+                                          .orElseThrow();
+        assertEquals(Boolean.TRUE, total.get("readOnly"), "an aggregate renders in the totals footer, not as an input");
 
         // a hierarchy entity lists as a tree - the runner branches on the flag
         Map<String, Object> account = entity(manifest, "Account");
@@ -162,7 +171,7 @@ class AppTestIntentGeneratorTest {
                 entity(AppTestIntentGenerator.buildManifest("kf-mod-countries", "kf-mod-countries", model, edm()), "City");
         List<Map<String, Object>> relations = (List<Map<String, Object>>) city.get("relations");
         assertNotNull(relations);
-        assertEquals(1, relations.size());
+        assertEquals(2, relations.size());
         Map<String, Object> country = relations.get(0);
         assertEquals("Country", country.get("name"));
         assertEquals("manyToOne", country.get("kind"));
@@ -170,6 +179,15 @@ class AppTestIntentGeneratorTest {
         assertEquals(Boolean.TRUE, country.get("required"));
         assertEquals("dropdown", country.get("widget"));
         assertEquals("Name", country.get("labelFrom"));
+        assertNull(country.get("crossModel"));
+
+        // the cross-model relation resolves an absolute controller URL in the OWNER module (naming
+        // convention here - no generation context; the real pass resolves against the owner's .model)
+        Map<String, Object> currency = relations.get(1);
+        assertEquals("Currency", currency.get("name"));
+        assertEquals(Boolean.TRUE, currency.get("crossModel"));
+        assertEquals("/services/java/kf-mod-currencies/gen/kf_mod_currencies/api/currency/CurrencyController", currency.get("apiAbsolute"));
+        assertEquals("Name", currency.get("labelFrom"));
     }
 
     @Test

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
@@ -49,8 +49,18 @@ class AppTestIntentGeneratorTest {
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string, required: true, length: 200 }
+                  - { name: uuid, type: uuid }
+                  - { name: slug, type: string, calculatedOnCreate: "1" }
                 relations:
                   - { name: Country, kind: manyToOne, to: Country, required: true }
+              - name: Account
+                group: master-data
+                hierarchy: Parent
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true, length: 200 }
+                relations:
+                  - { name: Parent, kind: manyToOne, to: Account }
             seeds:
               - name: countries
                 entity: Country
@@ -76,7 +86,32 @@ class AppTestIntentGeneratorTest {
         assertEquals("/services/java/kf-mod-countries/gen/kf_mod_countries/api", manifest.get("restBase"));
         assertEquals("Id", manifest.get("idProperty"));
         assertEquals(List.of("en", "bg"), manifest.get("languages"));
-        assertEquals(2, ((List<Object>) manifest.get("entities")).size());
+        assertEquals(3, ((List<Object>) manifest.get("entities")).size());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void marksAutoReadOnlyFieldsAndHierarchyEntities() {
+        Map<String, Object> manifest = AppTestIntentGenerator.buildManifest("kf-mod-countries", "kf-mod-countries", model, edm());
+
+        // a uuid and a calculated field render without an editable input - the runner must not fill them
+        Map<String, Object> city = entity(manifest, "City");
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) city.get("fields");
+        Map<String, Object> uuid = fields.stream()
+                                         .filter(f -> "Uuid".equals(f.get("name")))
+                                         .findFirst()
+                                         .orElseThrow();
+        assertEquals(Boolean.TRUE, uuid.get("readOnly"));
+        Map<String, Object> slug = fields.stream()
+                                         .filter(f -> "Slug".equals(f.get("name")))
+                                         .findFirst()
+                                         .orElseThrow();
+        assertEquals(Boolean.TRUE, slug.get("readOnly"));
+
+        // a hierarchy entity lists as a tree - the runner branches on the flag
+        Map<String, Object> account = entity(manifest, "Account");
+        assertEquals(Boolean.TRUE, account.get("hierarchy"));
+        assertNull(city.get("hierarchy"));
     }
 
     @SuppressWarnings("unchecked")
@@ -141,10 +176,10 @@ class AppTestIntentGeneratorTest {
     void skipsProjectionAndDetailEntities() {
         Map<String, Map<String, Object>> edm = edm();
         edm.put("Extra", edmEntity("Extra", "Extra", "Extras", "MANAGE_DETAILS", "Extras", "master-data", "KF_MOD_COUNTRIES_EXTRA", false));
-        // still only Country + City — the detail child is excluded
+        // still only Country + City + Account — the detail child is excluded
         Map<String, Object> manifest = AppTestIntentGenerator.buildManifest("kf-mod-countries", "kf-mod-countries", model, edm);
         List<?> entities = (List<?>) manifest.get("entities");
-        assertEquals(2, entities.size());
+        assertEquals(3, entities.size());
         assertNull(entityOrNull(manifest, "Extra"));
     }
 
@@ -155,6 +190,8 @@ class AppTestIntentGeneratorTest {
         byName.put("Country",
                 edmEntity("Country", "Country", "Countries", "MANAGE_MASTER", "Settings", "master-data", "KF_MOD_COUNTRIES_COUNTRY", true));
         byName.put("City", edmEntity("City", "City", "Cities", "MANAGE_MASTER", "Settings", "master-data", "KF_MOD_COUNTRIES_CITY", false));
+        byName.put("Account",
+                edmEntity("Account", "Account", "Accounts", "MANAGE_LIST", "Accounts", "master-data", "KF_MOD_COUNTRIES_ACCOUNT", false));
         return byName;
     }
 

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
@@ -57,6 +57,9 @@ class AppTestIntentGeneratorTest {
                 relations:
                   - { name: Country, kind: manyToOne, to: Country, required: true }
                   - { name: Currency, kind: manyToOne, to: Currency, model: kf-mod-currencies, required: true }
+                  - { name: Twin, kind: manyToOne, to: City, dependsOn: { relation: Country, filterBy: Country }, where: { name: Plovdiv } }
+                checks:
+                  - { kind: exactlyOne, fields: [uuid, slug], message: "one of uuid/slug" }
               - name: Account
                 group: master-data
                 hierarchy: Parent
@@ -171,7 +174,7 @@ class AppTestIntentGeneratorTest {
                 entity(AppTestIntentGenerator.buildManifest("kf-mod-countries", "kf-mod-countries", model, edm()), "City");
         List<Map<String, Object>> relations = (List<Map<String, Object>>) city.get("relations");
         assertNotNull(relations);
-        assertEquals(2, relations.size());
+        assertEquals(3, relations.size());
         Map<String, Object> country = relations.get(0);
         assertEquals("Country", country.get("name"));
         assertEquals("manyToOne", country.get("kind"));
@@ -183,6 +186,18 @@ class AppTestIntentGeneratorTest {
         // composition detail excluded from the manifest's entities list)
         assertEquals("/settings/CountryController", country.get("api"));
         assertNull(country.get("crossModel"));
+
+        // dependsOn + where ride into the manifest so the runner picks consistent, offered samples
+        Map<String, Object> twin = relations.get(2);
+        assertEquals("Twin", twin.get("name"));
+        assertEquals("Country", ((Map<String, Object>) twin.get("dependsOn")).get("relation"));
+        assertEquals("Country", ((Map<String, Object>) twin.get("dependsOn")).get("filterBy"));
+        assertEquals("Name", ((Map<String, Object>) twin.get("where")).get("by"));
+        assertEquals("Plovdiv", ((Map<String, Object>) twin.get("where")).get("value"));
+
+        Map<String, Object> cityEntity =
+                entity(AppTestIntentGenerator.buildManifest("kf-mod-countries", "kf-mod-countries", model, edm()), "City");
+        assertEquals(List.of(List.of("Uuid", "Slug")), cityEntity.get("exactlyOne"));
 
         // the cross-model relation resolves an absolute controller URL in the OWNER module (naming
         // convention here - no generation context; the real pass resolves against the owner's .model)

--- a/npm/test/src/api.js
+++ b/npm/test/src/api.js
@@ -13,6 +13,8 @@ export function makeApi(request, manifest) {
 
   return {
     list: (entity, limit = 20) => request.get(url(entity, `?$limit=${limit}`)).then(asJson),
+    // absolute controller path (a cross-model relation target owned by another module)
+    listPath: (path, limit = 20) => request.get(`${path}?$limit=${limit}`).then(asJson),
     count: (entity) => request.get(url(entity, '/count')).then(asJson).then((body) => (typeof body === 'number' ? body : body.count)),
     get: (entity, id) => request.get(url(entity, '/' + id)).then(asJson),
     getResponse: (entity, id) => request.get(url(entity, '/' + id)),

--- a/npm/test/src/api.js
+++ b/npm/test/src/api.js
@@ -15,6 +15,7 @@ export function makeApi(request, manifest) {
     list: (entity, limit = 20) => request.get(url(entity, `?$limit=${limit}`)).then(asJson),
     // absolute controller path (a cross-model relation target owned by another module)
     listPath: (path, limit = 20) => request.get(`${path}?$limit=${limit}`).then(asJson),
+    getPath: (path) => request.get(path).then(asJson),
     count: (entity) => request.get(url(entity, '/count')).then(asJson).then((body) => (typeof body === 'number' ? body : body.count)),
     get: (entity, id) => request.get(url(entity, '/' + id)).then(asJson),
     getResponse: (entity, id) => request.get(url(entity, '/' + id)),

--- a/npm/test/src/api.js
+++ b/npm/test/src/api.js
@@ -4,7 +4,8 @@ export function makeApi(request, manifest) {
 
   async function asJson(response) {
     if (!response.ok()) {
-      throw new Error(`${response.request().method()} ${response.url()} -> ${response.status()} ${await response.text()}`);
+      // APIResponse has no request(); report url + status + body
+      throw new Error(`${response.url()} -> ${response.status()} ${await response.text()}`);
     }
     const text = await response.text();
     return text ? JSON.parse(text) : undefined;

--- a/npm/test/src/flows/crud.js
+++ b/npm/test/src/flows/crud.js
@@ -39,7 +39,8 @@ export function crudFlow(manifest, entity, opts = {}) {
     await fillForm(page, manifest, entity, record, relationSamples, opts);
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     if (entity.layout === 'document') {
-      // a document create lands on the new record's page (line-item editing continues there)
+      // a document create lands on the NEW record's page (line-item editing continues there);
+      // saving an edit is what returns to the list
       await expect(page).toHaveURL(/\/edit$/);
       await page.goto(manifest.standaloneShell + entity.route);
     } else {
@@ -56,15 +57,12 @@ export function crudFlow(manifest, entity, opts = {}) {
       // exact: substring name matching would also hit e.g. a "Credit Notes" sidebar item
       await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
       await expect(page).toHaveURL(/\/edit$/);
+      // the record loads async after the form renders - filling before the fetch completes
+      // gets overwritten by the load and Save persists the OLD value
+      await expect(page.locator('#f_' + handle.name)).toHaveValue(record[handle.name]);
       await fillField(page, handle, updated, opts);
       await page.getByRole('button', { name: 'Save', exact: true }).click();
-      if (entity.layout === 'document') {
-        // a document form stays on the record after save (header-items editing continues)
-        await expect(page).toHaveURL(/\/edit$/);
-        await page.goto(manifest.standaloneShell + entity.route);
-      } else {
-        await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
-      }
+      await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
       await filterBy(page, updated);
       await expect(dataRow(page, updated)).toHaveCount(1);
       record[handle.name] = updated;

--- a/npm/test/src/flows/crud.js
+++ b/npm/test/src/flows/crud.js
@@ -38,7 +38,13 @@ export function crudFlow(manifest, entity, opts = {}) {
     await cfg.beforeCreate?.(page, record);
     await fillForm(page, manifest, entity, record, relationSamples, opts);
     await page.getByRole('button', { name: 'Create', exact: true }).click();
-    await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
+    if (entity.layout === 'document') {
+      // a document create lands on the new record's page (line-item editing continues there)
+      await expect(page).toHaveURL(/\/edit$/);
+      await page.goto(manifest.standaloneShell + entity.route);
+    } else {
+      await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
+    }
     await filterBy(page, record[handle.name]);
     await expect(dataRow(page, record[handle.name])).toHaveCount(1);
     await cfg.afterCreate?.(page, record);

--- a/npm/test/src/flows/crud.js
+++ b/npm/test/src/flows/crud.js
@@ -36,7 +36,7 @@ export function crudFlow(manifest, entity, opts = {}) {
     await expect(page).toHaveURL(/\/create$/);
     await cfg.beforeCreate?.(page, record);
     await fillForm(page, manifest, entity, record, relationSamples, opts);
-    await page.getByRole('button', { name: 'Create' }).click();
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
     await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
     await filterBy(page, record[handle.name]);
     await expect(dataRow(page, record[handle.name])).toHaveCount(1);
@@ -46,10 +46,11 @@ export function crudFlow(manifest, entity, opts = {}) {
     if (!skip.has('edit')) {
       const updated = record[handle.name] + '-UPD';
       await dataRow(page, record[handle.name]).click();
-      await page.getByRole('button', { name: 'Edit' }).first().click();
+      // exact: substring name matching would also hit e.g. a "Credit Notes" sidebar item
+      await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
       await expect(page).toHaveURL(/\/edit$/);
       await fillField(page, handle, updated, opts);
-      await page.getByRole('button', { name: 'Save' }).click();
+      await page.getByRole('button', { name: 'Save', exact: true }).click();
       await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
       await filterBy(page, updated);
       await expect(dataRow(page, updated)).toHaveCount(1);
@@ -61,7 +62,7 @@ export function crudFlow(manifest, entity, opts = {}) {
       await dataRow(page, record[handle.name]).click();
       await page.getByRole('button', { name: 'Delete', exact: true }).first().click();
       const dialog = page.locator('[x-h-dialog-overlay][data-open]');
-      await dialog.getByRole('button', { name: 'Delete' }).click();
+      await dialog.getByRole('button', { name: 'Delete', exact: true }).click();
       await expect(dialog).toHaveCount(0);
       await filterBy(page, record[handle.name]);
       await expect(dataRow(page, record[handle.name])).toHaveCount(0);

--- a/npm/test/src/flows/crud.js
+++ b/npm/test/src/flows/crud.js
@@ -17,6 +17,12 @@ export function crudFlow(manifest, entity, opts = {}) {
   const cfg = opts.extend?.entities?.[entity.name] ?? {};
   const skip = new Set(cfg.skip ?? []);
   if (skip.has('crud')) return;
+  // A hierarchy entity lists as a tree, and a calendar/slots entity replaces the table page
+  // entirely - no filter row / data rows to drive the walk below; create/read/update/delete
+  // stays covered by the REST flow. Same for an entity without a string handle field (nothing
+  // searchable identifies the created row in the table).
+  if (entity.hierarchy || entity.layout === 'calendar' || entity.layout === 'slots') return;
+  if (!handleField(entity)) return;
 
   test(`${entity.name}: create, edit and delete through the UI`, async ({ page, api }) => {
     const record = sampleRecord(entity);
@@ -25,7 +31,8 @@ export function crudFlow(manifest, entity, opts = {}) {
 
     // create
     await page.goto(manifest.standaloneShell + entity.route);
-    await page.getByRole('button', { name: 'New' }).click();
+    // exact: the empty state adds a second "New <Entity>" button that a substring match also hits
+    await page.getByRole('button', { name: 'New', exact: true }).click();
     await expect(page).toHaveURL(/\/create$/);
     await cfg.beforeCreate?.(page, record);
     await fillForm(page, manifest, entity, record, relationSamples, opts);

--- a/npm/test/src/flows/crud.js
+++ b/npm/test/src/flows/crud.js
@@ -2,11 +2,12 @@ import { expect, test } from '../fixtures.js';
 import { fillField, fillForm, resolveRelationSamples } from '../form.js';
 import { handleField, sampleRecord } from '../sample-values.js';
 
-// Server-side per-column filter (the documented POST /search path). The handle field is
-// the first major column, so its filter input is the first one in the filter row.
+// Server-side row lookup via the toolbar "Search <Entity>..." box - present on every list
+// layout (manage-list, master-detail, document) and searching the string columns server-side.
+// The per-column filter row is NOT used: its first input can belong to an FK or date column
+// (hidden or non-text), which made a blind fill hang.
 async function filterBy(page, value) {
-  const filter = page.getByPlaceholder('Filter…').first();
-  await filter.fill(value);
+  await page.getByPlaceholder(/^Search /).first().fill(value);
 }
 
 function dataRow(page, text) {
@@ -51,7 +52,13 @@ export function crudFlow(manifest, entity, opts = {}) {
       await expect(page).toHaveURL(/\/edit$/);
       await fillField(page, handle, updated, opts);
       await page.getByRole('button', { name: 'Save', exact: true }).click();
-      await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
+      if (entity.layout === 'document') {
+        // a document form stays on the record after save (header-items editing continues)
+        await expect(page).toHaveURL(/\/edit$/);
+        await page.goto(manifest.standaloneShell + entity.route);
+      } else {
+        await expect(page).toHaveURL(new RegExp(entity.route.replace(/[#/]/g, '\\$&') + '$'));
+      }
       await filterBy(page, updated);
       await expect(dataRow(page, updated)).toHaveCount(1);
       record[handle.name] = updated;

--- a/npm/test/src/flows/list.js
+++ b/npm/test/src/flows/list.js
@@ -20,8 +20,10 @@ export function listFlow(manifest, entity) {
       await expect(page.locator('[x-h-calendar], [x-h-slot-picker]').first()).toBeVisible();
       return;
     }
-    const firstHeader = page.getByRole('columnheader').first();
-    const emptyState = page.getByText('Get started by creating the first record').first();
+    // filter({ visible: true }): the empty-state markup stays in the DOM (x-show) above the
+    // table, so an unfiltered union's .first() would pick the hidden element and always fail
+    const firstHeader = page.getByRole('columnheader').filter({ visible: true }).first();
+    const emptyState = page.getByText('Get started by creating the first record').filter({ visible: true }).first();
     await expect(firstHeader.or(emptyState).first()).toBeVisible();
     if (entity.expectSeedData || (await firstHeader.isVisible())) {
       for (const field of (entity.fields ?? []).filter((f) => f.major !== false && !f.primaryKey)) {

--- a/npm/test/src/flows/list.js
+++ b/npm/test/src/flows/list.js
@@ -1,16 +1,32 @@
 import { expect, test } from '../fixtures.js';
 import { labelOf } from '../sample-values.js';
 
-// The list page renders: plural title in the toolbar, one column header per major
-// field, and (when seed data is expected) at least one data row.
+// The list page renders: plural title in the toolbar, then one of three bodies -
+// a tree (hierarchy entities render role=treeitem nodes, no table), the table with one
+// column header per major field, or (when the entity has no rows yet) the empty state.
+// When seed data is expected, rows/nodes must actually be there.
 export function listFlow(manifest, entity) {
   test(`${entity.name}: list page renders the declared columns`, async ({ page }) => {
     await page.goto(manifest.standaloneShell + entity.route);
     await expect(page.locator('[x-h-toolbar-title]', { hasText: entity.labelPlural }).first()).toBeVisible();
-    for (const field of (entity.fields ?? []).filter((f) => f.major !== false && !f.primaryKey)) {
-      await expect(page.getByRole('columnheader').filter({ hasText: labelOf(field) }).first()).toBeVisible();
+    if (entity.hierarchy) {
+      if (entity.expectSeedData) {
+        await expect(page.getByRole('treeitem').first()).toBeVisible();
+      }
+      return;
     }
-    if (entity.expectSeedData) {
+    if (entity.layout === 'calendar' || entity.layout === 'slots') {
+      // the view family renders a calendar / slot picker instead of the table
+      await expect(page.locator('[x-h-calendar], [x-h-slot-picker]').first()).toBeVisible();
+      return;
+    }
+    const firstHeader = page.getByRole('columnheader').first();
+    const emptyState = page.getByText('Get started by creating the first record').first();
+    await expect(firstHeader.or(emptyState).first()).toBeVisible();
+    if (entity.expectSeedData || (await firstHeader.isVisible())) {
+      for (const field of (entity.fields ?? []).filter((f) => f.major !== false && !f.primaryKey)) {
+        await expect(page.getByRole('columnheader').filter({ hasText: labelOf(field) }).first()).toBeVisible();
+      }
       await expect(page.locator('tbody tr:visible').first()).toBeVisible();
     }
   });

--- a/npm/test/src/flows/rest.js
+++ b/npm/test/src/flows/rest.js
@@ -1,5 +1,6 @@
 import { makeApi } from '../api.js';
 import { expect, test } from '../fixtures.js';
+import { resolveRelationSamples } from '../form.js';
 import { handleField, sampleRecord } from '../sample-values.js';
 
 // The same contract over the generated REST controllers, no browser: isolates backend
@@ -13,11 +14,10 @@ export function restFlow(manifest, entity, opts = {}) {
     const client = makeApi(api, manifest);
     const payload = sampleRecord(entity);
     const handle = handleField(entity);
-    for (const relation of entity.relations ?? []) {
-      const target = manifest.entities.find((e) => e.name === relation.to);
-      const rows = await client.list(target, 1);
-      expect(rows.length, `${relation.to} must have at least one row`).toBeGreaterThan(0);
-      payload[relation.name] = rows[0][idProperty];
+    // same resolution the UI flow uses: cross-model targets via apiAbsolute, entityStatus
+    // relations left to their init: DB default
+    for (const sample of await resolveRelationSamples(api, manifest, entity)) {
+      payload[sample.relation.name] = sample.id;
     }
 
     const created = await client.create(entity, payload);

--- a/npm/test/src/flows/rest.js
+++ b/npm/test/src/flows/rest.js
@@ -25,12 +25,16 @@ export function restFlow(manifest, entity, opts = {}) {
     expect(id, 'create response carries the generated id').toBeTruthy();
     try {
       const read = await client.get(entity, id);
-      expect(read[handle.name]).toBe(payload[handle.name]);
+      expect(read[idProperty]).toBe(id);
+      // the update round-trip needs a writable string field to flip; skip it when there is none
+      if (handle) {
+        expect(read[handle.name]).toBe(payload[handle.name]);
 
-      const updatedValue = payload[handle.name] + '-UPD';
-      await client.update(entity, id, { ...read, [handle.name]: updatedValue });
-      const reread = await client.get(entity, id);
-      expect(reread[handle.name]).toBe(updatedValue);
+        const updatedValue = payload[handle.name] + '-UPD';
+        await client.update(entity, id, { ...read, [handle.name]: updatedValue });
+        const reread = await client.get(entity, id);
+        expect(reread[handle.name]).toBe(updatedValue);
+      }
     } finally {
       await client.remove(entity, id);
     }

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -8,6 +8,11 @@ export async function fillField(page, field, value, opts = {}) {
   if (custom) return custom(page, field, value);
   const input = page.locator('#f_' + field.name);
   if (field.type === 'boolean') return input.setChecked(!!value);
+  if (field.type === 'timestamp' || field.type === 'datetime') {
+    // the sample is a full ISO instant (what the REST layer binds); a datetime-local input
+    // takes the zone-less YYYY-MM-DDTHH:mm prefix
+    return input.fill(String(value).slice(0, 16));
+  }
   await input.fill(String(value));
 }
 
@@ -38,6 +43,11 @@ export async function resolveRelationSamples(request, manifest, entity) {
     let labelFrom = relation.labelFrom;
     if (relation.apiAbsolute) {
       rows = await api.listPath(relation.apiAbsolute, 1);
+      labelFrom = labelFrom ?? 'Name';
+    } else if (relation.api) {
+      // same-model target via its relative controller path (works even for a composition
+      // detail excluded from the manifest's entities list)
+      rows = await api.listPath(manifest.restBase + relation.api, 1);
       labelFrom = labelFrom ?? 'Name';
     } else {
       const target = manifest.entities.find((e) => e.name === relation.to);

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -28,33 +28,34 @@ export async function pickDropdown(page, relation, optionText) {
   await page.getByRole('option', { name: optionText }).first().click();
 }
 
-// Resolve a live option for each to-one relation: take the first existing row of the
+// Resolve a live option for each to-one relation: take the first suitable row of the
 // target entity and use its label field's value as the visible option text.
 // - an entityStatus relation is skipped: it renders as a status pill (not an editable
 //   input in any form) and its value comes from the init: DB default;
 // - a cross-model relation's rows come from its apiAbsolute controller URL (the target
-//   lives in another module and is not in this manifest).
+//   lives in another module and is not in this manifest);
+// - a where: option filter narrows the candidate rows to matching ones;
+// - a dependsOn cascade forces CONSISTENT samples: the dependent row is chosen first and
+//   its filterBy FK becomes the trigger sibling's sample (independent first rows would
+//   pick e.g. Country=Afghanistan + City=Sofia, and the cascade then offers no options).
 export async function resolveRelationSamples(request, manifest, entity) {
   const api = makeApi(request, manifest);
+  const idProperty = manifest.idProperty ?? 'Id';
+
+  async function fetchRows(relation, limit) {
+    if (relation.apiAbsolute) return { rows: await api.listPath(relation.apiAbsolute, limit), labelFrom: relation.labelFrom ?? 'Name' };
+    if (relation.api) return { rows: await api.listPath(manifest.restBase + relation.api, limit), labelFrom: relation.labelFrom ?? 'Name' };
+    const target = manifest.entities.find((e) => e.name === relation.to);
+    if (!target) throw new Error(`Relation ${entity.name}.${relation.name}: target ${relation.to} not in manifest`);
+    return { rows: await api.list(target, limit), labelFrom: relation.labelFrom ?? handleField(target)?.name ?? 'Name' };
+  }
+
   const samples = [];
   for (const relation of entity.relations ?? []) {
     if (relation.entityStatus) continue;
-    let rows;
-    let labelFrom = relation.labelFrom;
-    if (relation.apiAbsolute) {
-      rows = await api.listPath(relation.apiAbsolute, 1);
-      labelFrom = labelFrom ?? 'Name';
-    } else if (relation.api) {
-      // same-model target via its relative controller path (works even for a composition
-      // detail excluded from the manifest's entities list)
-      rows = await api.listPath(manifest.restBase + relation.api, 1);
-      labelFrom = labelFrom ?? 'Name';
-    } else {
-      const target = manifest.entities.find((e) => e.name === relation.to);
-      if (!target) throw new Error(`Relation ${entity.name}.${relation.name}: target ${relation.to} not in manifest`);
-      rows = await api.list(target, 1);
-      labelFrom = labelFrom ?? handleField(target)?.name ?? 'Name';
-    }
+    // a filtered picker needs a matching candidate, so fetch a page and filter client-side
+    const { rows: fetched, labelFrom } = await fetchRows(relation, relation.where ? 100 : 1);
+    const rows = relation.where ? fetched?.filter((r) => String(r[relation.where.by]) === String(relation.where.value)) : fetched;
     if (!rows?.length) {
       // a required FK cannot be satisfied - fail loudly; an optional one is simply left unset
       if (relation.required) throw new Error(`Relation ${entity.name}.${relation.name}: no ${relation.to} rows to pick from`);
@@ -62,14 +63,38 @@ export async function resolveRelationSamples(request, manifest, entity) {
     }
     samples.push({
       relation,
-      id: rows[0][manifest.idProperty ?? 'Id'],
+      row: rows[0],
+      id: rows[0][idProperty],
       label: rows[0][labelFrom],
     });
+  }
+
+  // cascade consistency: re-point each dependsOn trigger at the row the dependent's choice implies
+  for (const sample of samples) {
+    const dependsOn = sample.relation.dependsOn;
+    if (!dependsOn?.filterBy) continue;
+    const trigger = samples.find((s) => s.relation.name === dependsOn.relation);
+    const impliedId = sample.row[dependsOn.filterBy];
+    if (!trigger || impliedId == null || trigger.id === impliedId) continue;
+    const path = trigger.relation.apiAbsolute ?? (trigger.relation.api ? manifest.restBase + trigger.relation.api : null);
+    if (!path) continue;
+    const row = await api.getPath(`${path}/${impliedId}`);
+    if (!row) continue;
+    trigger.row = row;
+    trigger.id = impliedId;
+    trigger.label = row[trigger.relation.labelFrom ?? 'Name'];
   }
   return samples;
 }
 
 export async function fillForm(page, manifest, entity, record, relationSamples, opts = {}) {
-  for (const field of editableFields(entity)) await fillField(page, field, record[field.name], opts);
-  for (const sample of relationSamples) await pickDropdown(page, sample.relation, sample.label);
+  for (const field of editableFields(entity)) {
+    if (record[field.name] === undefined) continue;
+    await fillField(page, field, record[field.name], opts);
+  }
+  // cascade order: a dependsOn trigger must be picked BEFORE its dependent, so the narrowed
+  // option list is the one the dependent's sample was chosen from
+  const triggers = relationSamples.filter((s) => !s.relation.dependsOn);
+  const dependents = relationSamples.filter((s) => s.relation.dependsOn);
+  for (const sample of [...triggers, ...dependents]) await pickDropdown(page, sample.relation, sample.label);
 }

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -14,8 +14,12 @@ export async function fillField(page, field, value, opts = {}) {
 // The x-h-select directive hides its input and builds a span[role=combobox] trigger
 // labelled by the field label; options carry role=option.
 export async function pickDropdown(page, relation, optionText) {
-  // exact: a substring match collides with longer sibling labels ("Type" vs "Chart Type")
-  await page.getByRole('combobox', { name: relation.label ?? relation.name, exact: true }).click();
+  // Anchored prefix match: the combobox accessible name is the label plus the placeholder or
+  // selected value ("Country Select a Country..."), so exact matching finds nothing - while a
+  // bare substring match collides with longer sibling labels ("Type" also hits "Chart Type").
+  const label = relation.label ?? relation.name;
+  const anchored = new RegExp('^' + label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b');
+  await page.getByRole('combobox', { name: anchored }).first().click();
   await page.getByRole('option', { name: optionText }).first().click();
 }
 

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -14,7 +14,8 @@ export async function fillField(page, field, value, opts = {}) {
 // The x-h-select directive hides its input and builds a span[role=combobox] trigger
 // labelled by the field label; options carry role=option.
 export async function pickDropdown(page, relation, optionText) {
-  await page.getByRole('combobox', { name: relation.label ?? relation.name }).click();
+  // exact: a substring match collides with longer sibling labels ("Type" vs "Chart Type")
+  await page.getByRole('combobox', { name: relation.label ?? relation.name, exact: true }).click();
   await page.getByRole('option', { name: optionText }).first().click();
 }
 

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -25,7 +25,14 @@ export async function pickDropdown(page, relation, optionText) {
   const label = relation.label ?? relation.name;
   const anchored = new RegExp('^' + label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b');
   await page.getByRole('combobox', { name: anchored }).first().click();
-  await page.getByRole('option', { name: optionText }).first().click();
+  const option = page.getByRole('option', { name: optionText }).first();
+  try {
+    await option.click({ timeout: 10_000 });
+  } catch {
+    // the option list re-rendered mid-click (async option load reflow) - reopen and retry
+    await page.getByRole('combobox', { name: anchored }).first().click();
+    await option.click({ force: true });
+  }
 }
 
 // Resolve a live option for each to-one relation: take the first suitable row of the
@@ -54,18 +61,31 @@ export async function resolveRelationSamples(request, manifest, entity) {
   for (const relation of entity.relations ?? []) {
     if (relation.entityStatus) continue;
     // a filtered picker needs a matching candidate, so fetch a page and filter client-side
-    const { rows: fetched, labelFrom } = await fetchRows(relation, relation.where ? 100 : 1);
-    const rows = relation.where ? fetched?.filter((r) => String(r[relation.where.by]) === String(relation.where.value)) : fetched;
+    const wide = relation.where || relation.leafOnly;
+    const { rows: fetched, labelFrom } = await fetchRows(relation, wide ? 200 : 1);
+    let rows = relation.where ? fetched?.filter((r) => String(r[relation.where.by]) === String(relation.where.value)) : fetched;
+    if (relation.leafOnly && rows?.length) {
+      // the generated validation rejects a non-leaf target - pick a row no other row parents
+      const prop = relation.leafOnly.hierarchyProperty;
+      const idProp = manifest.idProperty ?? 'Id';
+      rows = rows.filter((row) => !fetched.some((other) => other[prop] === row[idProp]));
+    }
     if (!rows?.length) {
       // a required FK cannot be satisfied - fail loudly; an optional one is simply left unset
       if (relation.required) throw new Error(`Relation ${entity.name}.${relation.name}: no ${relation.to} rows to pick from`);
+      continue;
+    }
+    const label = rows[0][labelFrom];
+    if (label == null && !relation.required) {
+      // no display label to pick by (the target has no name-like field) - leave the optional
+      // relation unset rather than clicking blind
       continue;
     }
     samples.push({
       relation,
       row: rows[0],
       id: rows[0][idProperty],
-      label: rows[0][labelFrom],
+      label: label ?? String(rows[0][idProperty]),
     });
   }
 

--- a/npm/test/src/form.js
+++ b/npm/test/src/form.js
@@ -25,15 +25,31 @@ export async function pickDropdown(page, relation, optionText) {
 
 // Resolve a live option for each to-one relation: take the first existing row of the
 // target entity and use its label field's value as the visible option text.
+// - an entityStatus relation is skipped: it renders as a status pill (not an editable
+//   input in any form) and its value comes from the init: DB default;
+// - a cross-model relation's rows come from its apiAbsolute controller URL (the target
+//   lives in another module and is not in this manifest).
 export async function resolveRelationSamples(request, manifest, entity) {
   const api = makeApi(request, manifest);
   const samples = [];
   for (const relation of entity.relations ?? []) {
-    const target = manifest.entities.find((e) => e.name === relation.to);
-    if (!target) throw new Error(`Relation ${entity.name}.${relation.name}: target ${relation.to} not in manifest`);
-    const rows = await api.list(target, 1);
-    if (!rows?.length) throw new Error(`Relation ${entity.name}.${relation.name}: no ${relation.to} rows to pick from`);
-    const labelFrom = relation.labelFrom ?? handleField(target).name;
+    if (relation.entityStatus) continue;
+    let rows;
+    let labelFrom = relation.labelFrom;
+    if (relation.apiAbsolute) {
+      rows = await api.listPath(relation.apiAbsolute, 1);
+      labelFrom = labelFrom ?? 'Name';
+    } else {
+      const target = manifest.entities.find((e) => e.name === relation.to);
+      if (!target) throw new Error(`Relation ${entity.name}.${relation.name}: target ${relation.to} not in manifest`);
+      rows = await api.list(target, 1);
+      labelFrom = labelFrom ?? handleField(target)?.name ?? 'Name';
+    }
+    if (!rows?.length) {
+      // a required FK cannot be satisfied - fail loudly; an optional one is simply left unset
+      if (relation.required) throw new Error(`Relation ${entity.name}.${relation.name}: no ${relation.to} rows to pick from`);
+      continue;
+    }
     samples.push({
       relation,
       id: rows[0][manifest.idProperty ?? 'Id'],

--- a/npm/test/src/sample-values.js
+++ b/npm/test/src/sample-values.js
@@ -49,10 +49,10 @@ export function sampleRecord(entity) {
 
 // The searchable "handle" field: the first long string field shown in the list. Its
 // value identifies the record in the table across the create/edit/delete flow.
+// Null when the entity has no such field (all-numeric/date entities) - flows degrade:
+// the UI walk is skipped and the REST flow drops its update-value assertion.
 export function handleField(entity) {
-  const field = editableFields(entity).find((f) => f.type === 'string' && (f.length ?? 64) >= 16 && f.major !== false);
-  if (!field) throw new Error(`Entity ${entity.name} has no string handle field for UI flows`);
-  return field;
+  return editableFields(entity).find((f) => f.type === 'string' && (f.length ?? 64) >= 16 && f.major !== false) ?? null;
 }
 
 export function labelOf(field) {

--- a/npm/test/src/sample-values.js
+++ b/npm/test/src/sample-values.js
@@ -46,6 +46,11 @@ export function editableFields(entity) {
 export function sampleRecord(entity) {
   const record = {};
   for (const field of editableFields(entity)) record[field.name] = sampleValue(field);
+  // an exactlyOne check rejects a record where more than one of the named fields is set -
+  // keep only the first of each declared set
+  for (const set of entity.exactlyOne ?? []) {
+    for (const name of set.slice(1)) delete record[name];
+  }
   return record;
 }
 

--- a/npm/test/src/sample-values.js
+++ b/npm/test/src/sample-values.js
@@ -29,7 +29,9 @@ export function sampleValue(field) {
       return '2026-07-08';
     case 'timestamp':
     case 'datetime':
-      return '2026-07-08T10:00';
+      // full ISO instant: the generated Java entities bind java.time.Instant, which rejects a
+      // zone-less value; the UI fill slices this to the datetime-local shape
+      return '2026-07-08T10:00:00Z';
     default:
       return 'APPTEST-' + rand(ALPHA + DIGITS, 6);
   }


### PR DESCRIPTION
## Summary

Running the generated `<name>.test` manifests across all 28 KeyFolders intent modules (the first fleet-wide consumer of #6289) surfaced **six waves of defect classes** in the AppTest manifest generator and the `@aerokit/test` runner. With this PR the whole 28-module fleet is green (verified against a live instance with every module + data/demo companions published).

### `AppTestIntentGenerator` (manifest must mirror the rendered UI)
- **auto-readOnly**: authored `readOnly:`, `uuid`, calculated, aggregate (totals footer) and `dependsOn` (auto-populated) fields render without an editable input - the runner must not fill them (fillForm hung 60s on `#f_Uuid` across six modules).
- **layouts**: `hierarchy: true` for tree entities (Account renders `role=treeitem`, no columnheaders); `MANAGE_CALENDAR → calendar`, `MANAGE_SLOTS → slots` (a `view: range`/`slots` entity was reported `manage-list`).
- **cross-model relations** are now emitted WITH an `apiAbsolute` owner-module controller URL (resolved via `CrossModelSupport`, the same coordinates the generated dropdowns use) - every transactional document has REQUIRED cross-model FKs (Customer/Employee/Supplier) that previously made both UI and REST create 400.
- **entityStatus** marking (`function: EntityStatus` relations render as a pill, value from the `init:` DB default - never pick/post).
- **same-model relations** carry their relative `api` (a relation to a composition DETAIL - PayrollEntry→Payslip - is not in the manifest's entities).
- **dependsOn** `{relation, filterBy}` + **where** `{by, value}` + **exactlyOne** check sets + **leafOnly** `{hierarchyProperty}` ride into the manifest so the runner picks offered, consistent, valid samples.

### `npm/test` runner
- **empty-state / tree / calendar-slots** list handling; strict seed-row assertion kept.
- **exact / anchored locators**: Playwright's default name match is a case-insensitive substring - `Edit` also matched the "Cr**edit** Notes" sidebar item (navigating away mid-flow), `New` matched the empty-state's "New <Entity>", `Type` matched "Chart Type". Action buttons exact; comboboxes anchored-prefix (their accessible name includes the placeholder).
- **row lookup via the toolbar "Search <Entity>..." box** - the per-column filter row's first input can be a hidden FK filter or a date input.
- **document layout**: CREATE lands on the new record's page (line-item editing continues); SAVE from an edit returns to the list.
- **edit-load wait**: the record loads async after the form renders - filling before the fetch completes was overwritten by the load and Save persisted the OLD value.
- **consistent samples**: dependsOn cascades (dependent row first, its FK re-points the trigger sample; triggers picked before dependents), `where` option filters, leafOnly targets (a row no other row parents), exactlyOne field sets (keep the first), optional relations with no rows / no label left unset.
- **api client**: the error path called `response.request()` (absent on `APIResponse`) - the thrower itself threw and masked every real REST failure. Timestamp samples are full ISO instants (`java.time.Instant` rejects zone-less values); the UI fill slices to the datetime-local shape.

### Found along the way (filed in the KeyFolders upstream plan, not part of this PR)
- the aggregate/rollup recompute is a full-row read-modify-write that can clobber a concurrent user update (live-reproduced on a PayrollRun: PUT 200, change silently reverted) - same lost-update family as #6226/#6306;
- a REQUIRED user-entered `documentTitle` field is un-enterable in the Harmonia document create form (`DOCUMENT_NUMBER` renders only in the title);
- `release.yml` does not publish `@aerokit/test` to npmjs;
- tenant-config resolution logs ERROR-level noise on fresh-instance first requests.

## Testing
- `AppTestIntentGeneratorTest` extended each wave - 6/6 green (readOnly/hierarchy/cross-model/dependsOn/where/exactlyOne/leafOnly emission).
- Live verification: manifests regenerated on this branch's jar for all 28 KeyFolders modules; the full Playwright fleet run is green (documented per-module skips for the platform findings above use the runner's existing `opts.extend` skip mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)