### PR TITLE
ci: publish @aerokit/test to npm on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,18 @@ jobs:
 
       #--------------- Publish aerokit/sdk to NPM -----------------#
 
+      #--------------- Publish aerokit/test to NPM -----------------#
+
+      - name: (@aerokit/test) Set the new package version
+        working-directory: ./npm/test
+        run: npm version "${{ github.event.inputs.releaseVersion }}" --no-git-tag-version
+
+      - name: (@aerokit/test) Publish the package to npm
+        working-directory: ./npm/test
+        run: npm publish --access public
+
+      #--------------- Publish aerokit/test to NPM -----------------#
+
       - name: "Git: Push Changes"
         run: |
           git checkout -B ${{ github.event.inputs.releaseVersion }}


### PR DESCRIPTION
The generic Playwright runner for generated `<name>.test` manifests (`npm/test`, added with the AppTest generator wave) has no publish step in the release workflow - only `@dirigiblelabs/dirigible`, `@dirigiblelabs/dirigible-cli` and `@aerokit/sdk` are published, so `@aerokit/test` is unreachable from npmjs and consumers must vendor it via a `file:` dependency.

This mirrors the `@aerokit/sdk` step pair for `./npm/test`: stamp the release version, then `npm publish --access public` (same npmjs token, the `@aerokit` scope already exists). First actual publish happens with the next release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)