### PR TITLE
fix(harmonia): master layout resolves the EntityStatus FK - lookup + badge, like the list layout

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
@@ -107,10 +107,12 @@ document.addEventListener('alpine:init', () => {
 
     lookups: {},   // relationship property name -> { fkValue: label }
     // Fetch the referenced rows for each relationship (DROPDOWN) property once, mapping FK -> label.
+    // The EntityStatus FK (DOCUMENT_STATUS) is included too - the table column and the detail pane
+    // render it as a resolved badge, exactly like the list layout.
     async loadLookups() {
       const all = {};
 #foreach($property in $properties)
-#if($property.widgetType == "DROPDOWN")
+#if($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS")
       try {
         const opt${property.name} = await App.services.api.getAll('${property.widgetDropdownControllerUrl}', { baseUrl: '' });
         const map${property.name} = {};

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -49,7 +49,10 @@
               <tr x-h-table-row data-hoverable="true" :data-state="isSelected(row) ? 'selected' : ''" @click="selectRow(row)">
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.widgetIsMajor)
-#if($property.widgetType == "DROPDOWN")
+#if($property.widgetType == "DOCUMENT_STATUS")
+                <!-- EntityStatus column: the resolved status name as a coloured badge pill. -->
+                <td x-h-table-cell><span x-h-badge :data-variant="statusVariant(lookupText('${property.name}', row.${property.name}))" x-show="lookupText('${property.name}', row.${property.name})" x-text="lookupText('${property.name}', row.${property.name})"></span></td>
+#elseif($property.widgetType == "DROPDOWN")
                 <td x-h-table-cell x-text="lookupText('${property.name}', row.${property.name})"></td>
 #elseif($property.isDateType)
                 <td x-h-table-cell x-text="displayValue(row.${property.name}, true)"></td>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -143,6 +143,23 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: Entry, kind: manyToOne, to: Entry, composition: true, required: true }
                   - { name: Unit,  kind: manyToOne, to: Unit }
 
+              # A master-detail (MANAGE_MASTER) entity carrying an EntityStatus: the master
+              # layout must resolve the status FK to a label lookup and render it as a badge in
+              # the table column and the detail pane, exactly like the list layout does.
+              - name: Campaign
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string, required: true, length: 100 }
+                relations:
+                  - { name: Status, kind: manyToOne, to: EntryStatus, function: EntityStatus, init: 1 }
+
+              - name: CampaignNote
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: note, type: string, length: 200 }
+                relations:
+                  - { name: Campaign, kind: manyToOne, to: Campaign, composition: true, required: true }
+
               # identity/personal/sensitive: Person maps the logged-in user (the IT runs as
               # admin - the seed below maps it); Claim is the personal entity with a sensitive
               # field; ClaimLine inherits the personal scope through its composition parent.
@@ -376,6 +393,16 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(accountsCsv.contains("ACCOUNT_PARENT"), "a seed row's relation key must emit the FK column into the seed CSV");
         assertTrue(entryRepository.contains("EntryLineRepository"),
                 "aggregate: true must make the master repository recompute totals from its items child");
+
+        // The master (MANAGE_MASTER) layout must resolve an EntityStatus FK exactly like the list
+        // layout: a label lookup loaded on the page and a badge cell in the table (the raw-id
+        // regression class: the lookup loop skipped DOCUMENT_STATUS widgets).
+        String campaignMasterPage = contentOf("gen/emission/js/components/pages/Campaign/CampaignMasterPage.js");
+        assertTrue(campaignMasterPage.contains("all['Status']"),
+                "the master page must load the EntityStatus label lookup like any dropdown relation");
+        String campaignMasterView = contentOf("gen/emission/views/Campaign/Campaign-master.html");
+        assertTrue(campaignMasterView.contains("statusVariant(lookupText('Status', row.Status))"),
+                "the master table must render the EntityStatus column as a resolved badge, not a raw id");
 
         // personal: the ADDITIONAL scoped controller exists, resolves the current user through the
         // identity entity's repository, and scrubs the sensitive field from responses.


### PR DESCRIPTION
The master (MANAGE_MASTER) page template's lookup loop only covered `DROPDOWN` widgets, so an `EntityStatus` relation on a master-detail entity rendered as a **raw FK id** in the table column and the detail pane — the detail pane already had the badge markup but no lookup map to resolve from. The list layout already handles this (`DROPDOWN || DOCUMENT_STATUS`).

This aligns the master layout with the list layout:
- `master-page.js.template`: include `DOCUMENT_STATUS` in the lookup loop;
- `master-view.html.template`: render the status column as the resolved coloured badge (same markup as the list view).

**IT**: `IntentEmissionCoverageIT` gains a master-detail fixture carrying an `EntityStatus` (`Campaign`/`CampaignNote`) and asserts the generated master page loads the status lookup (`all['Status']`) and the master view renders the badge cell — the raw-id regression class is caught at emission level.

Found live: the first master-layout entity with a true `function: EntityStatus` showed status ids instead of names; regenerating it on the fixed template renders the resolved badge (verified against a running instance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)