### PR TITLE
ci: ship the test runner as the @aerokit/sdk './test' subpath instead of a standalone package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,16 @@ jobs:
 
       #--------------- Publish aerokit/sdk to NPM -----------------#
 
+      # The Playwright test runner (npm/test) ships as the @aerokit/sdk `./test` subpath export -
+      # publishing it as its own @aerokit/test package needs new-package creation rights the npm
+      # token does not have. The copy is release-runner-local only (the jar was built before this
+      # step), and the nested package.json marks the subtree ESM (the sdk root has no "type").
+      - name: (@aerokit/sdk) Bundle the test runner as the ./test subpath
+        run: |
+          mkdir -p ./components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/test
+          cp -R ./npm/test/src/. ./components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/test/
+          printf '{\n  "type": "module"\n}\n' > ./components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/test/package.json
+
       - name: (@aerokit/sdk) Set the new package version
         working-directory: ./components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules
         run: npm version "${{ github.event.inputs.releaseVersion }}" --no-git-tag-version
@@ -255,18 +265,6 @@ jobs:
         run: npm publish --access public
 
       #--------------- Publish aerokit/sdk to NPM -----------------#
-
-      #--------------- Publish aerokit/test to NPM -----------------#
-
-      - name: (@aerokit/test) Set the new package version
-        working-directory: ./npm/test
-        run: npm version "${{ github.event.inputs.releaseVersion }}" --no-git-tag-version
-
-      - name: (@aerokit/test) Publish the package to npm
-        working-directory: ./npm/test
-        run: npm publish --access public
-
-      #--------------- Publish aerokit/test to NPM -----------------#
 
       - name: "Git: Push Changes"
         run: |

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/package.json
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/package.json
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist",
+    "test",
     "LICENSE",
     "README.md",
     "package.json"
@@ -42,6 +43,8 @@
       "require": "./dist/cjs/index.js",
       "types": "./dist/dts/index.d.ts"
     },
+    "./test": "./test/index.js",
+    "./test/fixtures": "./test/fixtures.js",
     "./*": {
       "import": "./dist/esm/*/index.mjs",
       "require": "./dist/cjs/*/index.js",
@@ -53,6 +56,14 @@
       "*": [
         "dist/dts/*/index.d.ts"
       ]
+    }
+  },
+  "peerDependencies": {
+    "@playwright/test": ">=1.45"
+  },
+  "peerDependenciesMeta": {
+    "@playwright/test": {
+      "optional": true
     }
   }
 }

--- a/npm/test/README.md
+++ b/npm/test/README.md
@@ -24,9 +24,9 @@ it never enters the registry or the npm package):
 ```js
 // test/app.spec.js
 import { fileURLToPath } from 'node:url';
-import { runAppTest } from '@aerokit/test';
+import { runTest } from '@aerokit/sdk/test';
 
-runAppTest(fileURLToPath(new URL('../<project>/<name>.test', import.meta.url)));
+runTest(fileURLToPath(new URL('../<project>/<name>.test', import.meta.url)));
 ```
 
 ```json
@@ -59,7 +59,7 @@ Test records carry an `APPTEST-` prefix and are removed in teardown; seed data i
 
 ## Custom UI hooks
 
-`runAppTest(manifest, { extend })`:
+`runTest(manifest, { extend })` (`runAppTest` remains a deprecated alias):
 
 - `widgets: { '<widget>': async (page, field, value) => ... }` — custom widget fillers.
 - `entities: { <Entity>: { skip: ['delete'], beforeCreate, afterCreate } }` — per-entity hooks.

--- a/npm/test/README.md
+++ b/npm/test/README.md
@@ -1,4 +1,10 @@
-# @aerokit/test
+# @aerokit/test (published as the `@aerokit/sdk/test` subpath)
+
+> **Publishing note:** this package is NOT published standalone - the release workflow bundles
+> `src/` into the `@aerokit/sdk` npm package as its `./test` subpath export (the npm token cannot
+> create new packages in the scope). Consumers depend on `@aerokit/sdk` and import
+> `@aerokit/sdk/test` / `@aerokit/sdk/test/fixtures`; this folder stays the source of truth and the
+> local-development identity (`file:` installs during development resolve `@aerokit/test` directly).
 
 Generic [Playwright](https://playwright.dev) runner that executes an intent module's generated
 `<name>.test` manifest against a running Eclipse Dirigible instance. The manifest (emitted by the

--- a/npm/test/src/index.js
+++ b/npm/test/src/index.js
@@ -8,8 +8,8 @@ import { shellFlow } from './flows/shell.js';
 
 // Entry point: execute a module's generated <name>.test manifest. Accepts the parsed
 // manifest object or a path to the file. opts.extend hosts the custom-UI hooks (widget
-// fillers, per-entity skip lists, before/afterCreate) - see kf-catalog PROPOSAL_APPTEST.md.
-export function runAppTest(manifestRef, opts = {}) {
+// fillers, per-entity skip lists, before/afterCreate).
+export function runTest(manifestRef, opts = {}) {
   const manifest = typeof manifestRef === 'string' ? JSON.parse(fs.readFileSync(manifestRef, 'utf8')) : manifestRef;
   for (const entity of manifest.entities ?? []) {
     test.describe(`${manifest.module} / ${entity.name}`, () => {
@@ -21,3 +21,6 @@ export function runAppTest(manifestRef, opts = {}) {
     });
   }
 }
+
+// Deprecated alias - the pre-subpath name; use runTest.
+export const runAppTest = runTest;


### PR DESCRIPTION
The 14.1.0 release failed at `(@aerokit/test) Publish the package to npm`: a **first-time publish of a new package** in the scope returns `E404` (npm's masked 403) — the automation token can publish the existing packages (`@dirigiblelabs/dirigible`, `dirigible-cli`, `@aerokit/sdk` all succeeded in the same run) but cannot **create** new ones, and no available account has scope-owner rights to change that. So: ship the runner inside the package the token can publish.

- **`@aerokit/sdk` package.json**: exact subpath exports `./test` → `./test/index.js` and `./test/fixtures` (exact entries take precedence over the `./*` dist pattern), `test` added to `files`, and `@playwright/test` as an **optional** peer dependency (`peerDependenciesMeta`) so plain sdk consumers are not forced to install it.
- **release.yml**: the two standalone `(@aerokit/test)` steps are replaced by a bundle step that copies `npm/test/src` into the sdk package dir before its publish and drops a nested `{"type":"module"}` package.json (the runner is ESM; the sdk root declares no `type`). The copy is release-runner-local — the jar is built earlier in the job, so the served modules resources never gain the folder.
- **API rename**: `runAppTest` → **`runTest`** (the natural name under `@aerokit/sdk/test`); `runAppTest` stays as a deprecated alias.
- **npm/test/README.md** documents the packaging; `npm/test` stays the source of truth and the `file:`-install identity during development.

**Verified locally**: `npm pack` of the bundled sdk + a scratch consumer — `import('@aerokit/sdk/test')` resolves `runTest` (+ the alias), `import('@aerokit/sdk/test/fixtures')` resolves `test`/`expect`.

Consumers then use `@aerokit/sdk` (dev-dep) with `import { runTest } from '@aerokit/sdk/test'` from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)