### PR TITLE
feat(apptest): personal (my) surface contract - manifest metadata + the runner's my flow

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -168,6 +168,29 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
         if (hasSeed(model, name)) {
             out.put("expectSeedData", true);
         }
+        // personal (my) surface: a `personal: true` to-one relation makes the entity a personal
+        // root - the generator emits an ADDITIONAL scoped <Entity>MyController whose contract the
+        // runner's my flow drives: reads filtered to the identity-mapped user, the owner FK forced
+        // server-side, sensitive fields stripped from the wire, foreign rows 404.
+        for (RelationIntent relation : entity.getRelations()) {
+            if (!relation.isPersonal()) {
+                continue;
+            }
+            Map<String, Object> personal = new LinkedHashMap<>();
+            personal.put("api", "/" + sanitizeJavaIdentifier(string(edm.get("perspectiveName"))) + "/" + name + "MyController");
+            personal.put("owner", IntentNaming.pascalCase(relation.getName()));
+            List<String> sensitive = new ArrayList<>();
+            for (FieldIntent field : entity.getFields()) {
+                if (field.isSensitive()) {
+                    sensitive.add(IntentNaming.pascalCase(field.getName()));
+                }
+            }
+            if (!sensitive.isEmpty()) {
+                personal.put("sensitive", sensitive);
+            }
+            out.put("personal", personal);
+            break;
+        }
         // exactlyOne checks: exactly one of the named fields may be non-null - a sample record
         // filling all of them is rejected with 400, so the runner keeps only the first
         List<List<String>> exactlyOne = new ArrayList<>();

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGeneratorTest.java
@@ -219,6 +219,43 @@ class AppTestIntentGeneratorTest {
         assertNull(entityOrNull(manifest, "Extra"));
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void emitsThePersonalSurfaceContract() {
+        String intent = """
+                name: kf-mod-claims
+                entities:
+                  - name: Person
+                    identity: email
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string, required: true, length: 200 }
+                      - { name: email, type: string, required: true, unique: true, length: 320 }
+                  - name: Claim
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: note, type: string, length: 200 }
+                      - { name: rate, type: decimal, sensitive: true }
+                    relations:
+                      - { name: Person, kind: manyToOne, to: Person, required: true, personal: true }
+                """;
+        Map<String, Map<String, Object>> edm = new LinkedHashMap<>();
+        edm.put("Person", edmEntity("Person", "Person", "Persons", "MANAGE_LIST", "People", "hr", "KF_MOD_CLAIMS_PERSON", false));
+        edm.put("Claim", edmEntity("Claim", "Claim", "Claims", "MANAGE_LIST", "Claims", "hr", "KF_MOD_CLAIMS_CLAIM", false));
+
+        Map<String, Object> manifest =
+                AppTestIntentGenerator.buildManifest("kf-mod-claims", "kf-mod-claims", IntentParser.parse(intent), edm);
+
+        Map<String, Object> claim = entity(manifest, "Claim");
+        Map<String, Object> personal = (Map<String, Object>) claim.get("personal");
+        assertTrue(personal != null, "a personal: relation must emit the personal surface contract");
+        assertEquals("/claims/ClaimMyController", personal.get("api"));
+        assertEquals("Person", personal.get("owner"));
+        assertEquals(List.of("Rate"), personal.get("sensitive"));
+        // the identity entity itself has no personal relation - no personal block
+        assertNull(entity(manifest, "Person").get("personal"));
+    }
+
     // ---- helpers: a minimal .model-shaped metadata map -------------------------------------------
 
     private static Map<String, Map<String, Object>> edm() {

--- a/npm/test/README.md
+++ b/npm/test/README.md
@@ -53,6 +53,13 @@ Env: `BASE_URL` (default `http://localhost:8080`), `APPTEST_USERNAME`/`APPTEST_P
 - **rest** — the same CRUD over the generated Java controllers via `APIRequestContext` (isolates
   backend vs UI failures), asserting the manifest's field names bind and delete yields 404.
 - **multilingual** — switch the shared language key, reload, a seeded row shows its translated name.
+- **my** — the personal (my) surface WIRE contract, when the manifest marks an entity `personal`:
+  create through the scoped `<Entity>MyController` (owner FK forced server-side), every `sensitive`
+  field null on the personal wire, the own row in the personal list, foreign rows 404 (when the
+  owner relation is optional), own-row delete. Skips with a pointer when the test user has no
+  identity mapping (seed the dev identity row). Personal *UI* parity (resolved labels, chat,
+  calendar on the My shell) is deliberately not asserted yet — it tracks the personal-template
+  parity fixes.
 - **shell** (opt-in) — the shared application shell's nav item opens the module SPA in its iframe.
 
 Test records carry an `APPTEST-` prefix and are removed in teardown; seed data is never mutated.

--- a/npm/test/src/flows/my.js
+++ b/npm/test/src/flows/my.js
@@ -1,0 +1,79 @@
+import { makeApi } from '../api.js';
+import { expect, test } from '../fixtures.js';
+import { resolveRelationSamples } from '../form.js';
+import { sampleRecord } from '../sample-values.js';
+
+// The personal (my) surface WIRE contract, driven when the manifest marks an entity `personal`:
+// the scoped <Entity>MyController filters reads to the identity-mapped user, forces the owner FK
+// server-side on create (whatever the client sends is ignored), strips every `sensitive` field
+// from its responses (the allow-list is the security boundary - UI hiding alone is cosmetic),
+// serves foreign rows as 404, and deletes only own rows.
+//
+// Prerequisite: the DEV IDENTITY mapping - a row of the owner relation's target whose identity
+// field equals the test user (e.g. an Employee with email 'admin'). Without it the personal
+// surface is EMPTY by design (never an error), so the flow SKIPS with a pointer instead of
+// failing. The personal UI parity assertions (resolved labels, chat layout, calendar views on
+// the My shell) are deliberately NOT asserted yet - they track the platform's personal-template
+// parity fixes; this flow pins down the wire contract those pages consume.
+export function myFlow(manifest, entity, opts = {}) {
+  const cfg = opts.extend?.entities?.[entity.name] ?? {};
+  if (!entity.personal || new Set(cfg.skip ?? []).has('my')) return;
+  const idProperty = manifest.idProperty ?? 'Id';
+  // the same entity through the scoped controller
+  const mine = { ...entity, api: entity.personal.api };
+
+  async function buildPayload(api) {
+    const payload = sampleRecord(entity);
+    for (const sample of await resolveRelationSamples(api, manifest, entity)) {
+      payload[sample.relation.name] = sample.id;
+    }
+    // the owner FK is server-forced on the personal surface; sending a value must be pointless
+    delete payload[entity.personal.owner];
+    return payload;
+  }
+
+  test(`${entity.name}: personal (my) surface scopes rows, forces the owner and strips sensitive fields`, async ({ api }) => {
+    const client = makeApi(api, manifest);
+
+    const createdResponse = await api.post(manifest.restBase + mine.api, { data: await buildPayload(api) });
+    test.skip(
+      !createdResponse.ok(),
+      `personal create returned ${createdResponse.status()} - the test user has no identity mapping; ` +
+        `seed the dev identity row (an owner-target record whose identity field equals the login user)`
+    );
+    const created = JSON.parse(await createdResponse.text());
+    const id = created?.[idProperty];
+    expect(id, 'personal create carries the generated id').toBeTruthy();
+    let foreignId;
+    try {
+      const own = await client.get(mine, id);
+      expect(own[entity.personal.owner], 'the owner FK is forced server-side on a personal create').toBeTruthy();
+      for (const field of entity.personal.sensitive ?? []) {
+        expect(own[field], `sensitive field ${field} must never reach the personal wire`).toBeFalsy();
+      }
+      const rows = await client.list(mine, 1000);
+      expect(rows.some((row) => row[idProperty] === id), 'the own row appears in the personal list').toBe(true);
+
+      // the power surface still serves the full record
+      const power = await client.get(entity, id);
+      expect(power[idProperty]).toBe(id);
+
+      // a row with no owner is foreign to everyone: the personal controller must 404 it and the
+      // personal list must not include it (only checkable when the owner relation is optional)
+      const ownerRelation = (entity.relations ?? []).find((relation) => relation.name === entity.personal.owner);
+      if (ownerRelation && !ownerRelation.required) {
+        const foreign = await client.create(entity, await buildPayload(api));
+        foreignId = foreign?.[idProperty];
+        const foreignThroughMine = await api.get(manifest.restBase + mine.api + '/' + foreignId);
+        expect(foreignThroughMine.status(), 'a foreign row must 404 through the personal controller').toBe(404);
+        const rowsAfter = await client.list(mine, 1000);
+        expect(rowsAfter.some((row) => row[idProperty] === foreignId), 'a foreign row must not appear in the personal list').toBe(false);
+      }
+    } finally {
+      await client.remove(mine, id); // deleting the OWN row through the personal controller works
+      if (foreignId) await client.remove(entity, foreignId);
+    }
+    const gone = await api.get(manifest.restBase + mine.api + '/' + id);
+    expect(gone.status()).toBe(404);
+  });
+}

--- a/npm/test/src/index.js
+++ b/npm/test/src/index.js
@@ -3,6 +3,7 @@ import { test } from './fixtures.js';
 import { crudFlow } from './flows/crud.js';
 import { listFlow } from './flows/list.js';
 import { multilingualFlow } from './flows/multilingual.js';
+import { myFlow } from './flows/my.js';
 import { restFlow } from './flows/rest.js';
 import { shellFlow } from './flows/shell.js';
 
@@ -16,6 +17,7 @@ export function runTest(manifestRef, opts = {}) {
       listFlow(manifest, entity, opts);
       crudFlow(manifest, entity, opts);
       restFlow(manifest, entity, opts);
+      myFlow(manifest, entity, opts);
       multilingualFlow(manifest, entity, opts);
       shellFlow(manifest, entity, opts);
     });


### PR DESCRIPTION
The `<name>.test` manifest now carries a **`personal`** block for every entity with a `personal: true` relation — the scoped `<Entity>MyController` path, the owner relation name, and the `sensitive` field list (`AppTestIntentGenerator`, unit-tested).

The runner gains **`flows/my.js`**, always-on when the manifest marks an entity personal, driving the personal surface's **wire contract**:

- create through the scoped controller — the **owner FK is forced server-side** (the payload never sends it, the response must carry it);
- every **`sensitive` field asserted null** on the personal wire (the allow-list serialization is the security boundary — UI hiding alone is cosmetic);
- the own row present in the personal **list**;
- a **foreign** (ownerless) row **404s** through the personal controller and never appears in the personal list (exercised when the owner relation is optional);
- own-row **delete** through the personal controller; 404 after.

No identity mapping → the flow **skips** with a pointer (the personal surface is empty by design, never an error).

Personal **UI** parity (resolved labels, chat layout, calendar views on the My shell) is deliberately not asserted yet — it tracks the known personal-template parity gaps; this flow pins down the wire contract those pages consume, so the parity fixes can land against a stable base.

**Verified live** against a running instance via hand-injected manifest blocks matching the new emission: a required-owner document entity (sensitive aggregate stripped from the wire while the power surface keeps it) and an optional-owner entity (the foreign-row 404 branch) — both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)