### PR TITLE
fix(harmonia): the personal (my) list resolves relation columns to labels, like the power list

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
@@ -40,6 +40,28 @@ document.addEventListener('alpine:init', () => {
       } catch (e) { this.statusOptions = []; }
 #end
       await this.load();
+      this.loadLookups();
+    },
+
+    lookups: {},   // relationship column name -> { fkValue: label }
+    // Resolve every rendered relation column to its label, exactly like the power list - the
+    // personal-owner relation and sensitive fields are not rendered, so no lookup is fetched for
+    // them. Loaded after the rows so the list paints immediately; cells re-render as maps arrive.
+    async loadLookups() {
+      const all = {};
+#foreach($property in $properties)
+#if($property.widgetType == "DROPDOWN" && $property.name != "$!{personalProperty}" && !$property.sensitiveProperty && (!$property.auditType || $property.auditType == "NONE") && $property.widgetIsMajor != "false")
+      try {
+        const opt${property.name} = await App.services.api.getAll('${property.widgetDropdownControllerUrl}', { baseUrl: '' });
+        const map${property.name} = {};
+        (opt${property.name} || []).forEach((e) => { map${property.name}[e.${property.widgetDropDownKey}] = e.${property.widgetDropDownValue}; });
+        all['${property.name}'] = map${property.name};
+      } catch (e) {
+        console.error('[${name}MyListPage] failed to load lookup for ${property.name}', e);
+      }
+#end
+#end
+      this.lookups = all;
     },
 
     async load() {
@@ -56,6 +78,12 @@ document.addEventListener('alpine:init', () => {
     display(row, col) {
       const v = row[col.name];
       if (v == null || v === '') return '—';
+      if (col.fk) {
+        // a relation column shows its referenced label; a dangling/unloaded FK falls back to the id
+        const map = this.lookups[col.name];
+        const text = map ? map[v] : undefined;
+        if (text !== undefined && text !== null && text !== '') return String(text);
+      }
       if (col.date) return window.HarmoniaFormat ? window.HarmoniaFormat.date(v) : String(v);
       if (col.number) return window.HarmoniaFormat ? window.HarmoniaFormat.number(v) : String(v);
       return String(v);
@@ -81,7 +109,7 @@ document.addEventListener('alpine:init', () => {
     columns: [
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "$!{personalProperty}" && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.widgetIsMajor != "false")
-      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DOCUMENT_STATUS"), status: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
+      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DOCUMENT_STATUS"), status: true#elseif($property.widgetType == "DROPDOWN"), fk: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
 #end
 #end
     ],

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -178,6 +178,9 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: rate, type: decimal, sensitive: true }
                 relations:
                   - { name: Person, kind: manyToOne, to: Person, required: true, personal: true }
+                  # a plain dropdown relation: the personal LIST must resolve it to a label (the
+                  # my-list FK-lookup emission), while the owner relation gets no lookup at all
+                  - { name: Unit, kind: manyToOne, to: Unit }
 
               - name: ClaimLine
                 fields:
@@ -522,6 +525,11 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // and the SPA routes + sidebar carry the personal surface.
         String myList = contentOf("gen/emission/js/components/pages/my/ClaimMyListPage.js");
         assertTrue(myList.contains("ClaimMyController"), "the my list page must talk to the scoped controller only");
+        // The personal list must resolve relation columns to labels exactly like the power list
+        // (the raw-FK-id regression class) - and never fetch a lookup for the owner relation,
+        // which is not rendered on the personal surface at all.
+        assertTrue(myList.contains("all['Unit']"), "the my list must load the label lookup for a rendered relation column");
+        assertTrue(!myList.contains("all['Person']"), "the my list must not fetch a lookup for the personal-owner relation");
         String myForm = contentOf("gen/emission/views/my/Claim-form.html");
         assertTrue(!myForm.contains("form.Rate"), "the personal form must not render the sensitive field at all");
         assertTrue(!myForm.contains("form.Person"), "the personal form must not render the owner FK control");


### PR DESCRIPTION
The personal (my) list page loaded a label lookup **only for the EntityStatus badge** — every other relation column rendered its **raw FK id** (the personal-template parity class: the power `ManageListPage` resolves all of them).

This ports the power list's label-lookup loop to `my-list-page.js.template`:

- one lookup per **rendered** `DROPDOWN` relation — the personal-owner relation and sensitive/non-major fields are not rendered on the personal surface, so no lookup is fetched for them;
- the column is marked `fk` and resolved in `display()` with a raw-id fallback for dangling FKs;
- lookups load **after** the rows, so the list paints immediately and cells re-render as maps arrive (the same pattern as the master layout fix in #6325).

**IT**: the `IntentEmissionCoverageIT` personal fixture gains a plain dropdown relation and asserts the generated my list page loads its label lookup (`all['Unit']`) while fetching none for the owner (`all['Person']` absent) — ran green locally (1/1).

**Verified live**: regenerated a module whose personal list had six raw-id columns — the served My list now renders the referenced names (browser-checked: the customer name appears where the id used to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)