### PR TITLE
fix(intent): task-form button action wins over a stale model action (approve-as-reject)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
@@ -247,9 +247,22 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                                 __notifications.show({ type: 'negative', title: 'Cannot submit', description: 'This form was not opened from a task (no taskId).' });
                                 return;
                             }
+                            // The clicked button's `action` MUST win. The form model can carry a STALE
+                            // `action` (a prior task in the flow set it as a process variable, preloaded
+                            // into the model on open) plus control-only vars (__*) that are not entity
+                            // data; strip both, then set `action` LAST so the gateway branches on the
+                            // button, not the stale value (fixes approve-completing-as-reject).
+                            const __data = {};
+                            const __model = $scope.model || {};
+                            Object.keys(__model).forEach((key) => {
+                                if (key !== 'action' && key.indexOf('__') !== 0) {
+                                    __data[key] = __model[key];
+                                }
+                            });
+                            __data.action = action;
                             $http.post('/services/inbox/tasks/' + __taskId, {
                                 action: 'COMPLETE',
-                                data: Object.assign({ action: action }, $scope.model || {})
+                                data: __data
                             }).then(() => {
                                 __notifications.show({ type: 'positive', title: 'Task submitted', description: 'The task was completed (' + action + ').' });
                                 __dialogs.closeWindow();

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/form.js.template
@@ -127,7 +127,12 @@ document.addEventListener('alpine:init', () => {
         harmoniaHttp.get('/services/inbox/tasks/' + encodeURIComponent(params.taskId) + '/variables')
           .then((res) => {
             const vars = (res && res.variables) || {};
-            Object.keys(vars).forEach((k) => { self.model[k] = vars[k]; });
+            // Never preload the `action` process variable into the model: it is a control value a
+            // PRIOR task in the flow set (e.g. 'submit'), not a form field, and letting it sit in the
+            // model made the next task's completion submit the stale action - a decision gateway then
+            // branched wrong (approve completing as reject). The __* locators DO stay - the runtime
+            // below reads __entityUrl / __<Fk>EntityUrl from the model.
+            Object.keys(vars).forEach((k) => { if (k !== 'action') self.model[k] = vars[k]; });
             // Clear D: the process context holds only a locator (the entity's REST URL + id), so fetch the
             // LIVE entity now and overlay its current fields onto the model. This is what makes the task
             // form show up-to-date values (e.g. a document total updated after the task was created)

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -2174,6 +2174,15 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(body.contains("closeWindow(") && body.contains("window.close("),
                 "on completion the form should close its host (dialog via closeWindow, standalone via window.close)");
         assertFalse(body.contains("TODO: wire"), "the action handlers must no longer be TODO stubs");
+        // The clicked button's action MUST win over a stale `action` in the model (a prior task in a
+        // multi-step flow set it as a process variable, preloaded on open): the completion payload
+        // strips `action` + control vars (__*) from the model and sets `action` LAST. Without this,
+        // an Approve completes down the reject branch (the approve-as-reject bug). The .form code is
+        // Gson-escaped (' -> \\u0027), so match escape-free substrings.
+        assertTrue(body.contains("__data.action") && body.contains(".indexOf(") && body.contains("__data"),
+                "the completion payload must be rebuilt with the button action winning, not Object.assign with the model last");
+        assertFalse(body.contains("Object.assign({ action: action }, $scope.model"),
+                "the buggy merge (stale model action overwrites the button) must be gone");
     }
 
     private void assertReport() {


### PR DESCRIPTION
In a multi-step `submit -> approve` flow, the second task's form completed down the **reject** branch no matter which button was clicked.

**Cause (two spots):** a prior task set an `action` process variable; `form.js.template` preloaded *all* process vars (incl. `action='submit'`) into the model on open; and `FormIntentGenerator`'s completion handler did `Object.assign({ action: action }, $scope.model)` — model **last**, so the stale `action` overwrote the clicked button. The `${action == 'approve'}` gateway then saw `submit` → reject. Both buttons effectively sent `submit`; approve was impossible.

**Fix:**
- `FormIntentGenerator`: rebuild the COMPLETE payload — copy the model minus `action` and control vars (`__*`, which are locators not entity data), then set `action` **last** (button wins).
- `form.js.template`: don't preload the bare `action` process var into the model (the `__*` locators still load — the runtime uses them).

**Test:** the bug is in emitted client JS (the browser builds the payload), so the HTTP-only ITs — which construct the payload themselves — can't reach it. `IntentEngineIT.assertForm` now asserts the generated form code rebuilds the payload with the button action winning and no longer uses the buggy `Object.assign`. Runtime proof is a browser `submit→approve` flow (this bug was blocking the KF vacations approve path — verified on regeneration there).

Surfaced by a KeyFolders module review (vacations approve completing as reject).

🤖 Generated with [Claude Code](https://claude.com/claude-code)