### PR TITLE
fix(intent): rollup glue resolves setting-entity child/parent to the Settings perspective

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -422,9 +422,17 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             String fkProperty = IntentNaming.pascalCase(rollup.getVia());
             Map<String, Object> base = new LinkedHashMap<>();
             base.put("childEntity", rollup.getEntity());
-            base.put("childPerspective", IntentEntities.resolvePerspective(rollup.getEntity(), compositionParents));
+            // A setting entity's generated code lives under the shared "Settings" perspective, not its
+            // own name - so a roll-up whose child/parent is `kind: setting` must resolve there, like
+            // the relation-link / personal-assignee builders do. Without this the generated handler
+            // imports gen.<mod>.data.<entityname> (which does not exist) instead of ...data.settings
+            // and the whole client-Java batch fails to compile (a setting-entity roll-up, e.g.
+            // Currency <- CurrencyRate, is the case that exposed it).
+            base.put("childPerspective",
+                    child.isSetting() ? "Settings" : IntentEntities.resolvePerspective(rollup.getEntity(), compositionParents));
             base.put("parentEntity", via.getTo());
-            base.put("parentPerspective", IntentEntities.resolvePerspective(via.getTo(), compositionParents));
+            base.put("parentPerspective",
+                    parent.isSetting() ? "Settings" : IntentEntities.resolvePerspective(via.getTo(), compositionParents));
             base.put("fkProperty", fkProperty);
             base.put("countField", IntentNaming.pascalCase(rollup.getField()));
             base.put("op", op);

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueRollupLatestTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueRollupLatestTest.java
@@ -39,12 +39,13 @@ class GlueRollupLatestTest {
                 relations:
                   - { name: rates, kind: oneToMany, to: CurrencyRate }
               - name: CurrencyRate
+                kind: setting
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
                   - { name: date, type: date, required: true }
                   - { name: rate, type: decimal, precision: 18, scale: 6, required: true }
                 relations:
-                  - { name: Currency, kind: manyToOne, to: Currency, composition: true, required: true }
+                  - { name: Currency, kind: manyToOne, to: Currency, required: true }
             rollups:
               - { name: latestRate, entity: CurrencyRate, via: Currency, field: rate, op: latest, of: rate, by: date }
             """;
@@ -63,6 +64,11 @@ class GlueRollupLatestTest {
         assertEquals("Currency", create.get("fkProperty"));
         assertEquals("CurrencyRate", create.get("childEntity"));
         assertEquals("Currency", create.get("parentEntity"));
+        // Both entities are kind: setting, so their generated code lives under the shared "Settings"
+        // perspective - the roll-up glue must resolve there (data.settings), not data.<entityname>,
+        // or the generated handler's imports fail to compile.
+        assertEquals("Settings", create.get("childPerspective"));
+        assertEquals("Settings", create.get("parentPerspective"));
         assertTrue(rollups.stream()
                           .anyMatch(r -> String.valueOf(r.get("topicSuffix"))
                                                .equals("-updated")),


### PR DESCRIPTION
`buildRollups` resolved `childPerspective`/`parentPerspective` with plain `resolvePerspective`, missing the `isSetting() -> "Settings"` special-case that `buildRelationLinks` and `putPersonalAssignee` already apply. A roll-up whose child or parent is `kind: setting` therefore generated a handler importing `gen.<mod>.data.<entityname>` (nonexistent) instead of `gen.<mod>.data.settings` — failing javac, and since the client-Java batch is all-or-nothing, taking down **every** controller in the app.

Latent until the first setting-entity roll-up: a `Currency` (setting) ← `CurrencyRate` (setting) `op: latest` roll-up (the currencies `Currency.rate` adoption) exposed it.

`GlueRollupLatestTest` extended — both fixture entities are `kind: setting`; the child/parent perspectives now assert `"Settings"`.

Follow-up to #6350; unblocks the KeyFolders currencies `Currency.rate` latest-rollup adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)