### PR TITLE
feat(harmonia): Print button on the shared manage form for a document master with a custom view

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -308,6 +308,14 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             else if (!dependent && !setting && !compositionParents.containsValue(name)) {
                 entityMap.put("layoutType", "MANAGE");
             }
+            // A document master (owns a *Item / DocumentItem composition child) gets a generated .print
+            // template + feeder, so its edit surface can offer a Print button. Flag it independently of
+            // the layout: the MANAGE_DOCUMENT layout renders Print in the document view already, but a
+            // document master whose UI is overridden to a calendar/slots view reuses the plain manage
+            // form for edit - the flag is what lets that shared form show Print too.
+            if (documentItems.containsKey(name)) {
+                entityMap.put("hasPrint", "true");
+            }
             // multilingual: the entity keeps per-language values in a sibling <TABLE>_LANG table. The
             // schema template generates that table and the Java DAO template overlays translated values
             // on every read for the caller's Accept-Language (same attribute the EDM editor writes).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -111,6 +111,8 @@ class EdmIntentGeneratorTest {
         // render hint (shown in the footer, not the header form).
         assertEquals("MANAGE_DOCUMENT", invoice.get("layoutType"), "a master with an *Item composition child uses the document layout");
         assertEquals("SalesInvoiceItem", invoice.get("documentItemsEntity"), "the document names its line-items entity");
+        assertEquals("true", invoice.get("hasPrint"), "a document master gets a .print template, so it is flagged for a Print action");
+        assertNull(entityByName(entities, "SalesInvoiceItem").get("hasPrint"), "a line-items child is not a document master - no Print");
         assertEquals("Sales Invoice", invoice.get("documentLabel"), "the document header label is the humanized master name");
         assertEquals("Sales Invoice Items", invoice.get("documentItemsLabel"), "the items label is the humanized + pluralized child name");
         assertEquals("true", propertyByName(invoice, "Total").get("aggregate"), "a field marked aggregate carries the footer render hint");
@@ -187,6 +189,38 @@ class EdmIntentGeneratorTest {
         // An independent property carries none of the attributes.
         Map<String, Object> countryFk = propertyByName(entityByName(entities, "Customer"), "Country");
         assertNull(countryFk.get("widgetDependsOnProperty"));
+    }
+
+    @Test
+    void documentMasterWithACalendarViewStillCarriesThePrintFlag() {
+        // A document (header-items) master whose UI is overridden to a range calendar: the layout
+        // becomes MANAGE_CALENDAR (the document page is replaced by the calendar + the shared manage
+        // form for edit), but it still gets a .print template + feeder - so it must keep hasPrint, which
+        // is what lets that reused manage form show a Print button.
+        String yaml = """
+                name: leave
+                entities:
+                  - name: LeaveRequest
+                    view: range
+                    calendar: { start: fromDate, end: toDate }
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: fromDate, type: date }
+                      - { name: toDate, type: date }
+                  - name: LeaveRequestItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: day, type: date }
+                    relations:
+                      - { name: LeaveRequest, kind: manyToOne, to: LeaveRequest, composition: true, required: true }
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "leave");
+        List<Map<String, Object>> entities = entities(model);
+        Map<String, Object> request = entityByName(entities, "LeaveRequest");
+        assertEquals("MANAGE_CALENDAR", request.get("layoutType"), "view: range overrides the document layout with the calendar");
+        assertEquals("true", request.get("hasPrint"),
+                "a document master keeps its Print flag even when the calendar view replaces the document page");
     }
 
     @Test

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -173,6 +173,15 @@ document.addEventListener('alpine:init', () => {
     // Controller path for ${name}, relative to App.config.restBase
     // (the default base api.* prepends): <restBase>/<perspective>/<Entity>Controller.
     apiPath: '/${javaPerspectiveName}/${name}Controller',
+#if($hasPrint == "true")
+
+    // Print (document master rendered through this shared form): renders the CMS-seeded .print
+    // template server-side to PDF, asking for the language when several exist.
+    printLangOpen: false,
+    printLanguages: [],
+    printBusy: false,
+    printError: null,
+#end
 
     async init() {
       // The edit/preview routes are /${name}/{id}/edit|preview — Pinecone exposes the param as `id`.
@@ -501,6 +510,67 @@ document.addEventListener('alpine:init', () => {
 #end
       return payload;
     },
+#if($hasPrint == "true")
+
+    // ===== Print: the .print template lives in the CMS (Templates/${name}/Print/<lang>/), where it
+    // can be customized via the Documents perspective. One language prints directly; several ask.
+    async openPrint() {
+      this.printError = null;
+      this.printBusy = true;
+      let languages = [];
+      try {
+        languages = (await App.services.api.get('/services/print/${name}/languages', { baseUrl: '' })) || [];
+      } catch (e) {
+        console.error('Print languages lookup failed', e);
+      }
+      this.printBusy = false;
+      if (languages.length > 1) {
+        // Several templates: ALWAYS ask (the Region & Language setting only pre-sorts the suggested
+        // default first). Auto-printing the configured language here suppresses the dialog entirely,
+        // since the locale store always resolves to a value.
+        const configured = (Alpine.store('locale') || {}).value;
+        this.printLanguages = languages.slice().sort((a, b) =>
+          (a.code === configured ? -1 : 0) - (b.code === configured ? -1 : 0));
+        this.printLangOpen = true;
+      } else {
+        // zero languages still attempts the default: the server answers with a clear 404
+        await this.printDoc(languages.length === 1 ? languages[0].code : 'en');
+      }
+    },
+
+    async printDoc(lang) {
+      this.printError = null;
+      this.printBusy = true;
+      try {
+        // The generated print feeder (gen/events/${name}PrintFeeder) loads the document + its related
+        // graph through the repositories and returns the { document, items } payload the template binds
+        // - so {{document.<Relation>.<Field>}} resolves. It is called as the logged-in user (auth +
+        // tenant + i18n are the caller's).
+        const payload = await App.services.api.get(
+          '/services/java/${projectName}/gen/events/${name}PrintFeeder/' + encodeURIComponent(this.id), { baseUrl: '' });
+        const response = await fetch('/services/print/${name}?lang=' + encodeURIComponent(lang), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          this.printError = response.status === 404
+            ? 'No print template found. Publish the project or upload one via Documents.'
+            : 'Print failed (' + response.status + ')';
+          return;
+        }
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 60000);
+      } catch (e) {
+        console.error('Print failed', e);
+        this.printError = 'Print failed';
+      } finally {
+        this.printBusy = false;
+      }
+    },
+#end
 
     cancel() {
       // Only when opened as an FK "Add" iframe dialog: ask the parent to close it instead of navigating

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -299,6 +299,16 @@
       </template>
 #end
       <div x-h-toolbar-spacer></div>
+#if($hasPrint == "true")
+      <!-- Print: for a document master rendered through this shared form (a calendar/slots view that
+           replaced the document page), renders the CMS template (Templates/${name}/Print/<lang>/) to
+           PDF; asks for the language when several exist. Existing record only (needs an id to print). -->
+      <span class="text-sm text-secondary-foreground" x-show="printError" x-text="printError"></span>
+      <button type="button" x-h-button data-variant="outline" x-show="(isEdit || isPreview) &amp;&amp; id" :disabled="printBusy" @click="openPrint()">
+        <span x-show="printBusy" x-h-spinner></span>
+        <svg x-h-lucide role="img" data-lucide="printer" x-show="!printBusy"></svg><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+      </button>
+#end
       <!-- Preview footer: Close + Edit instead of Cancel + Save. -->
       <button type="button" x-h-button data-variant="transparent" x-show="isPreview" @click="cancel()" x-text="T('$projectName:${tprefix}.defaults.close', 'Close')"></button>
       <button type="button" x-h-button data-variant="primary" x-show="isPreview" @click="goEdit()">
@@ -343,5 +353,28 @@
     </div>
 #end
   </div>
+#if($hasPrint == "true")
+
+  <!-- Print language picker: shown when more than one template language exists under
+       Templates/${name}/Print/ in the CMS ("English" -> en, "Bulgarian" -> bg, ...) -->
+  <div x-h-dialog-overlay :data-open="printLangOpen">
+    <div x-h-dialog>
+      <div x-h-dialog-header>
+        <h2 x-h-dialog-title>Print</h2>
+        <p x-h-dialog-description>Choose the template language.</p>
+        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"></button>
+      </div>
+      <div x-h-dialog-content>
+        <div class="vbox gap-2">
+          <template x-for="lang in printLanguages" :key="lang.code">
+            <button type="button" x-h-button data-variant="outline" @click="printLangOpen = false; printDoc(lang.code)">
+              <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="lang.name"></span>
+            </button>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+#end
 
 </div>


### PR DESCRIPTION
## Problem

A document (header-items) master can override its UI to a **calendar** (`view: range`) or **slots** view. When it does, it is reclassified `MANAGE_CALENDAR`/`MANAGE_SLOTS` and its create/edit reuses the **shared manage form** instead of the document view — and the manage form had **no Print button**. So a document rendered as a calendar (e.g. a leave-request calendar) silently lost the Print affordance the document view offers, even though its `.print` template and print feeder are still generated. (KeyFolders findings `vacations-F04`.)

## Fix

- `EdmIntentGenerator` flags every **document master** `hasPrint=true`, independent of the layout branch — the `.print` template and `gen/events/<Entity>PrintFeeder` are generated for a document master regardless of the UI view it ends up with.
- The manage `form-view.html.template` / `form-page.js.template` render a **Print button + language picker + `openPrint()`/`printDoc()`** gated on `$hasPrint`, reusing the **exact** proven document-view logic (feeder GET → `POST /services/print/<Entity>` → PDF, language dialog when several template languages exist). Shown for an existing record only (needs an id); a plain non-document manage entity never sets the flag, so it is unaffected.

## Tests

`EdmIntentGeneratorTest` gains: a document master keeps `hasPrint` under `view: range` (layout `MANAGE_CALENDAR`), and a line-items child is **not** flagged. The two manage templates are Velocity-parsed on every generate by the existing `IntentEngineIT`/`IntentEmissionCoverageIT`.

Follow-up (post-merge): regenerate `kf-mod-vacations` to surface the Print button on its leave calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)