### PR TITLE
feat(harmonia): Export CSV + Print on every list surface

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/pages/basePage.js
@@ -33,5 +33,63 @@ function basePage() {
     formatNumber(value, pattern) {
       return window.HarmoniaFormat.number(value, pattern);
     },
+
+    /**
+     * Translate a column header: columns carry an optional i18next key (tkey) next to the
+     * design-time label, exactly like the table headers render them.
+     */
+    columnHeader(col) {
+      return (window.T && col.tkey) ? window.T(col.tkey, col.label) : col.label;
+    },
+
+    /**
+     * Download rows as a CSV file. Values come from cellText(row, col) - the SAME resolver the
+     * table cells use, so FK columns carry their referenced labels and dates their formatted
+     * form, never raw ids or serialized arrays. The BOM makes Excel decode UTF-8 (Cyrillic
+     * included) without an import wizard.
+     */
+    exportRowsCsv(rows, columns, cellText, filename) {
+      const esc = (v) => {
+        const s = String(v == null ? '' : v);
+        return /[",\n\r]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+      };
+      const head = columns.map((c) => esc(this.columnHeader(c))).join(',');
+      const lines = rows.map((r) => columns.map((c) => esc(cellText(r, c))).join(','));
+      const blob = new Blob(['\ufeff' + [head].concat(lines).join('\r\n')], { type: 'text/csv;charset=utf-8' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(a.href);
+    },
+
+    /**
+     * Print rows as a minimal table document in a new window (the browser dialog covers paper and
+     * Save as PDF). Same data path as the CSV export: the full filtered set through cellText.
+     */
+    printRows(rows, columns, cellText, title) {
+      const esc = (v) => String(v == null ? '' : v)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      const th = columns.map((c) =>
+        '<th class="' + (c.number ? 'text-right' : '') + '">' + esc(this.columnHeader(c)) + '</th>').join('');
+      const body = rows.map((r) => '<tr>' + columns.map((c) =>
+        '<td class="' + (c.number ? 'text-right' : '') + '">' + esc(cellText(r, c)) + '</td>').join('') + '</tr>').join('');
+      const html = '<!doctype html><html><head><title>' + esc(title) + '</title><style>'
+        + 'body{font-family:system-ui,-apple-system,sans-serif;margin:24px;color:#111}'
+        + 'h1{font-size:18px;margin:0 0 4px}'
+        + '.meta{font-size:11px;color:#555;margin:0 0 16px}'
+        + 'table{border-collapse:collapse;width:100%;font-size:12px}'
+        + 'th,td{border:1px solid #999;padding:4px 8px;text-align:left}'
+        + 'th{background:#eee}.text-right{text-align:right}'
+        + '</style></head><body><h1>' + esc(title) + '</h1>'
+        + '<p class="meta">' + rows.length + ' rows - ' + esc(new Date().toLocaleString()) + '</p>'
+        + '<table><thead><tr>' + th + '</tr></thead><tbody>' + body + '</tbody></table></body></html>';
+      const w = window.open('', '_blank');
+      if (!w) return;
+      w.document.write(html);
+      w.document.close();
+      w.focus();
+      w.print();
+    },
   };
 }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-page.js.template
@@ -114,6 +114,20 @@ document.addEventListener('alpine:init', () => {
 #end
     ],
 
+    // ----- Export / print of the own rows: same columns and cell resolution as the table
+    // (FK labels, status text, formatted dates) via the shared basePage helpers.
+    exportCell(row, col) {
+      if (row[col.name] == null || row[col.name] === '') return '';
+      return col.status ? this.statusText(row) : this.display(row, col);
+    },
+    exportCsv() {
+      this.exportRowsCsv(this.items, this.columns, (r, c) => this.exportCell(r, c), '${name}.csv');
+    },
+    printList() {
+      this.printRows(this.items, this.columns, (r, c) => this.exportCell(r, c),
+        'My ' + (window.T ? window.T('$projectName:${tprefix}.t.${dataName}_plural', '${menuLabel}') : '${menuLabel}'));
+    },
+
     newEntity() { this.navigate('/my/${name}/create'); },
     openEntity(row) { this.navigate('/my/${name}/' + row.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end + '/edit'); },
   }));

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-list-view.html.template
@@ -11,6 +11,13 @@
       <i role="img" x-h-lucide data-lucide="plus"></i>
       <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>
     </button>
+    <!-- Export the own rows as CSV / print them (Save as PDF via the browser dialog). -->
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="items.length === 0" @click="exportCsv()">
+      <i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="items.length === 0" @click="printList()">
+      <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+    </button>
   </div>
 
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-list-page.js.template
@@ -86,6 +86,20 @@ document.addEventListener('alpine:init', () => {
 #end
     ],
 
+    // ----- Export / print of the partner's own rows: same columns and cell resolution as the
+    // table (status text, formatted dates) via the shared basePage helpers.
+    exportCell(row, col) {
+      if (row[col.name] == null || row[col.name] === '') return '';
+      return col.status ? this.statusText(row) : this.display(row, col);
+    },
+    exportCsv() {
+      this.exportRowsCsv(this.items, this.columns, (r, c) => this.exportCell(r, c), '${name}.csv');
+    },
+    printList() {
+      this.printRows(this.items, this.columns, (r, c) => this.exportCell(r, c),
+        window.T ? window.T('$projectName:${tprefix}.t.${dataName}_plural', '${menuLabel}') : '${menuLabel}');
+    },
+
     newEntity() { this.navigate('/partner/${name}/create'); },
     openEntity(row) { this.navigate('/partner/${name}/' + row.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end + '/edit'); },
   }));

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-list-view.html.template
@@ -11,6 +11,13 @@
       <i role="img" x-h-lucide data-lucide="plus"></i>
       <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>
     </button>
+    <!-- Export the own rows as CSV / print them (Save as PDF via the browser dialog). -->
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="items.length === 0" @click="exportCsv()">
+      <i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="items.length === 0" @click="printList()">
+      <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+    </button>
   </div>
 
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/page.js.template
@@ -165,5 +165,27 @@ document.addEventListener('alpine:init', () => {
       this.currentPage = Math.max(1, Math.min(n, this.totalPages));
       this.refreshIcons();
     },
+
+    // ----- Export / print: the FULL filtered+sorted set (not the current page), cells resolved
+    // exactly like the table (FK labels, formatted dates) via the shared basePage helpers.
+    exportColumns: [
+#foreach($property in $properties)
+#if(!$property.dataAutoIncrement && $property.widgetIsMajor)
+      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS"), fk: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
+#end
+#end
+    ],
+    exportCell(row, col) {
+      const v = row[col.name];
+      if (v == null || v === '') return '';
+      return col.fk ? this.lookupText(col.name, v) : this.displayValue(v, !!col.date);
+    },
+    exportCsv() {
+      this.exportRowsCsv(this.sortedItems, this.exportColumns, (r, c) => this.exportCell(r, c), '${name}.csv');
+    },
+    printList() {
+      this.printRows(this.sortedItems, this.exportColumns, (r, c) => this.exportCell(r, c),
+        window.T ? window.T('$projectName:${tprefix}.t.${dataName}_plural', '${menuLabel}') : '${menuLabel}');
+    },
   }));
 }, { once: true });

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/list/view.html.template
@@ -15,6 +15,13 @@
         <svg x-h-icon data-icon="search" class="size-4" role="img" aria-label="search"></svg>
       </div>
     </div>
+    <!-- Export the filtered rows as CSV / print them (Save as PDF via the browser dialog). -->
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="filteredItems.length === 0" @click="exportCsv()">
+      <i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="filteredItems.length === 0" @click="printList()">
+      <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+    </button>
     <!-- Developer-contributed page actions for this view (customActions extension point). -->
     <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
       <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-page.js.template
@@ -267,6 +267,28 @@ document.addEventListener('alpine:init', () => {
 
     goPage(n) { this.currentPage = Math.max(1, Math.min(n, this.totalPages)); this.refreshIcons(); },
 
+    // ----- Export / print: the FULL filtered+sorted set (not the current page), cells resolved
+    // exactly like the table (FK labels, formatted dates) via the shared basePage helpers.
+    exportColumns: [
+#foreach($property in $properties)
+#if(!$property.dataAutoIncrement && $property.widgetIsMajor)
+      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS"), fk: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
+#end
+#end
+    ],
+    exportCell(row, col) {
+      const v = row[col.name];
+      if (v == null || v === '') return '';
+      return col.fk ? this.lookupText(col.name, v) : this.displayValue(v, !!col.date);
+    },
+    exportCsv() {
+      this.exportRowsCsv(this.sortedItems, this.exportColumns, (r, c) => this.exportCell(r, c), '${name}.csv');
+    },
+    printList() {
+      this.printRows(this.sortedItems, this.exportColumns, (r, c) => this.exportCell(r, c),
+        window.T ? window.T('$projectName:${tprefix}.t.${dataName}_plural', '${menuLabel}') : '${menuLabel}');
+    },
+
     newEntity()  { window.PineconeRouter.navigate('/${name}/create'); },
     editEntity(row) { window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(row.${primaryKeysString}) + '/edit'); },
     previewEntity(row) { window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(row.${primaryKeysString}) + '/preview'); },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -19,6 +19,13 @@
       <i role="img" x-h-lucide data-lucide="plus"></i>
       <span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span>
     </button>
+    <!-- Export the filtered rows as CSV / print them (Save as PDF via the browser dialog). -->
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="sortedItems.length === 0" @click="exportCsv()">
+      <i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="sortedItems.length === 0" @click="printList()">
+      <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+    </button>
     <!-- Developer-contributed page actions for this view (customActions extension point). -->
     <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
       <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-page.js.template
@@ -144,6 +144,28 @@ document.addEventListener('alpine:init', () => {
       return 'default';
     },
 
+    // ----- Export / print: the FULL filtered set (not the current page), cells resolved exactly
+    // like the table (FK labels, formatted dates) via the shared basePage helpers.
+    exportColumns: [
+#foreach($property in $properties)
+#if(!$property.dataAutoIncrement && $property.widgetIsMajor)
+      { name: '${property.name}', label: '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end', tkey: '$projectName:${tprefix}.t.${property.dataName}'#if($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS"), fk: true#elseif($property.isNumberType), number: true#end#if($property.isDateType), date: true#end },
+#end
+#end
+    ],
+    exportCell(row, col) {
+      const v = row[col.name];
+      if (v == null || v === '') return '';
+      return col.fk ? this.lookupText(col.name, v) : this.displayValue(v, !!col.date);
+    },
+    exportCsv() {
+      this.exportRowsCsv(this.filteredMasters, this.exportColumns, (r, c) => this.exportCell(r, c), '${name}.csv');
+    },
+    printList() {
+      this.printRows(this.filteredMasters, this.exportColumns, (r, c) => this.exportCell(r, c),
+        window.T ? window.T('$projectName:${tprefix}.t.${dataName}_plural', '${menuLabel}') : '${menuLabel}');
+    },
+
     newMaster()  { window.PineconeRouter.navigate('/${name}/create'); },
     editMaster(row) { window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(row.${primaryKeysString}) + '/edit'); },
     previewMaster(row) { window.PineconeRouter.navigate('/${name}/' + encodeURIComponent(row.${primaryKeysString}) + '/preview'); },

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -14,6 +14,13 @@
       <div x-h-input-group-addon data-align="inline-start"><svg x-h-icon data-icon="search" class="size-4" role="img" aria-label="search"></svg></div>
     </div>
     <button x-h-button data-variant="primary" @click="newMaster()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.new', 'New')"></span></button>
+    <!-- Export the filtered rows as CSV / print them (Save as PDF via the browser dialog). -->
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="filteredMasters.length === 0" @click="exportCsv()">
+      <i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span>
+    </button>
+    <button x-h-button data-variant="outline" data-size="sm" :disabled="filteredMasters.length === 0" @click="printList()">
+      <i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span>
+    </button>
     <!-- Developer-contributed page actions for this view (customActions extension point). -->
     <template x-for="action in $store.customActions.getActions(caView, 'page')" :key="action.id">
       <button x-h-button data-variant="outline" data-size="sm" @click="$store.customActions.trigger(action)">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/chart-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/chart-view.html.template
@@ -5,8 +5,8 @@
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title>${name}</span>
     <div x-h-toolbar-spacer></div>
-    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span>Refresh</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="printChart()"><i role="img" x-h-lucide data-lucide="printer"></i><span>Print</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span x-text="T('$projectName:${tprefix}.defaults.refresh', 'Refresh')"></span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="printChart()"><i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span></button>
   </div>
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
   <div x-show="state === 'error'" x-h-alert data-variant="negative" role="alert" class="m-4"><div x-h-alert-description x-text="error"></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/report/table-view.html.template
@@ -3,9 +3,9 @@
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title>${name}</span>
     <div x-h-toolbar-spacer></div>
-    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span>Refresh</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" x-h-lucide data-lucide="download"></i><span>Export</span></button>
-    <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" x-h-lucide data-lucide="printer"></i><span>Print</span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="load()"><i role="img" x-h-lucide data-lucide="refresh-cw"></i><span x-text="T('$projectName:${tprefix}.defaults.refresh', 'Refresh')"></span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="exportCsv()"><i role="img" x-h-lucide data-lucide="download"></i><span x-text="T('$projectName:${tprefix}.defaults.export', 'Export')"></span></button>
+    <button x-h-button data-variant="outline" data-size="sm" @click="printReport()"><i role="img" x-h-lucide data-lucide="printer"></i><span x-text="T('$projectName:${tprefix}.defaults.print', 'Print')"></span></button>
   </div>
   <div x-show="state === 'loading'" class="p-4"><div x-h-spinner></div></div>
   <div x-show="state === 'error'" x-h-alert data-variant="negative" role="alert" class="m-4"><div x-h-alert-description x-text="error"></div></div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/translations.json.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/translations.json.template
@@ -61,6 +61,7 @@
         "from": "From {{text}}",
         "filter": "Filter",
         "print": "Print",
+        "export": "Export",
         "reset": "Reset",
         "create": "Create",
         "edit": "Edit",

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -474,6 +474,21 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(campaignMasterView.contains("statusVariant(lookupText('Status', row.Status))"),
                 "the master table must render the EntityStatus column as a resolved badge, not a raw id");
 
+        // Every list surface exports/prints its rows: the manage list and the master list emit the
+        // column metadata + toolbar actions wired to the shared basePage CSV/print helpers, with
+        // cells resolved like the table (FK labels, formatted dates - never raw ids).
+        String unitManageList = contentOf("gen/emission/js/components/pages/Settings/UnitManageListPage.js");
+        assertTrue(unitManageList.contains("exportRowsCsv(this.sortedItems"),
+                "the manage list must export its filtered+sorted rows as CSV");
+        assertTrue(unitManageList.contains("printRows(this.sortedItems"), "the manage list must print its filtered+sorted rows");
+        String unitManageView = contentOf("gen/emission/views/Settings/Unit-manage-list.html");
+        assertTrue(unitManageView.contains("defaults.export") && unitManageView.contains("printList()"),
+                "the manage list toolbar must carry the Export and Print actions");
+        assertTrue(campaignMasterPage.contains("exportRowsCsv(this.filteredMasters"),
+                "the master list must export its filtered rows as CSV");
+        assertTrue(campaignMasterView.contains("defaults.export") && campaignMasterView.contains("printList()"),
+                "the master toolbar must carry the Export and Print actions");
+
         // personal: the ADDITIONAL scoped controller exists, resolves the current user through the
         // identity entity's repository, and scrubs the sensitive field from responses.
         String claimMy = contentOf("gen/emission/api/claim/ClaimMyController.java");
@@ -535,6 +550,12 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // which is not rendered on the personal surface at all.
         assertTrue(myList.contains("all['Unit']"), "the my list must load the label lookup for a rendered relation column");
         assertTrue(!myList.contains("all['Person']"), "the my list must not fetch a lookup for the personal-owner relation");
+        // The personal list exports/prints the OWN rows through the same shared helpers - the
+        // sensitive/owner columns are already absent from its column set, so they never export.
+        assertTrue(myList.contains("exportRowsCsv(this.items"), "the personal list must export the own rows as CSV");
+        String myListView = contentOf("gen/emission/views/my/Claim-list.html");
+        assertTrue(myListView.contains("defaults.export") && myListView.contains("printList()"),
+                "the personal list toolbar must carry the Export and Print actions");
         String myForm = contentOf("gen/emission/views/my/Claim-form.html");
         assertTrue(!myForm.contains("form.Rate"), "the personal form must not render the sensitive field at all");
         assertTrue(!myForm.contains("form.Person"), "the personal form must not render the owner FK control");
@@ -573,6 +594,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(partnerList.contains("PartnerTicketPartnerController"),
                 "the partner list page must talk to the scoped partner controller");
         assertTrue(spaIndex.contains("/partner/PartnerTicket"), "the SPA must route the partner pages");
+        assertTrue(partnerList.contains("exportRowsCsv(this.items"), "the partner list must export the own rows as CSV");
+        String partnerListView = contentOf("gen/emission/views/partner/PartnerTicket-list.html");
+        assertTrue(partnerListView.contains("defaults.export") && partnerListView.contains("printList()"),
+                "the partner list toolbar must carry the Export and Print actions");
 
         // collection-driven generation: the job creates the parent AND its per-working-day children.
         String job = contentOf("gen/events/MonthlyClaimsJob.java");


### PR DESCRIPTION
## What

Every generated **list surface** - the manage list, plain list, master list, personal (my) list and partner list - gains toolbar **Export** (CSV download) and **Print** (browser print window; Save as PDF via the dialog) actions. Until now only documents (`.print`) and the report pages could produce an output file; entity lists had no export at all.

## How

- **Shared helpers in `basePage.js`** (application-core, one implementation for all shells):
  - `exportRowsCsv(rows, columns, cellText, filename)` - UTF-8 CSV with a BOM (Excel decodes localized text without an import wizard), RFC-quoted cells, headers translated through the column `tkey`;
  - `printRows(rows, columns, cellText, title)` - the report page's minimal print-window pattern, right-aligned number columns.
- **Each list template** emits an `exportColumns` metadata array mirroring its table columns and resolves cells **exactly like the table**: FK columns export their referenced labels, EntityStatus its status text, dates their formatted form - never raw ids or Jackson date arrays.
- Exports cover the **full filtered(+sorted) set**, not the current page; buttons disable on an empty set.
- The personal/partner lists export only the own rows their scoped controller serves - sensitive and owner columns are absent from their column sets by construction, so they can never export.
- New `defaults.export` catalog key; the report table/chart toolbar labels (Refresh/Export/Print) now translate through the same `defaults.*` keys instead of hard-coded English.

## Verification

`IntentEmissionCoverageIT` extended per the engine-intent contract: asserts `exportRowsCsv`/`printRows` wiring in the generated manage/master/personal/partner list pages and the Export/Print buttons in their views. **Ran green locally (1/1).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)