### PR TITLE
feat(intent): auto-sensitive derived fields - rollup/aggregate targets of a sensitive source

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -172,6 +172,7 @@ public final class IntentParser {
      */
     private static void validate(IntentModel model) {
         List<String> issues = new ArrayList<>();
+        propagateSensitiveDerivations(model);
         Set<String> usesAliases = validateUses(model, issues);
         Set<String> entityNames = validateEntities(model, usesAliases, issues);
         validateFunctions(model, issues);
@@ -888,6 +889,83 @@ public final class IntentParser {
                 }
             }
         }
+    }
+
+    /**
+     * A derived field that sums or copies a {@code sensitive:} child field re-exposes on its target
+     * exactly what the child hides whenever the target entity has a personal (my) surface - the leak
+     * class where the leaf value is scrubbed from the personal wire but its total still travels it.
+     * Close it by construction: before validation, every rollup target field ({@code op: sum} /
+     * {@code latest}) and every {@code aggregate: true} master field fed by a sensitive source becomes
+     * {@code sensitive} automatically when the target entity is personal-surfaced (an own personal
+     * owner relation, or the scope inherited through a composition parent chain). A target without a
+     * personal surface keeps the authored visibility - there is nothing to leak there.
+     */
+    private static void propagateSensitiveDerivations(IntentModel model) {
+        java.util.Map<String, EntityIntent> byName = new java.util.HashMap<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (entity.getName() != null) {
+                byName.put(entity.getName(), entity);
+            }
+        }
+        // rollups: the child's `of` field feeds the parent's `field`
+        for (RollupIntent rollup : model.getRollups()) {
+            EntityIntent child = byName.get(rollup.getEntity());
+            if (child == null) {
+                continue;
+            }
+            RelationIntent via = toOneRelationByName(child, rollup.getVia());
+            EntityIntent parent = via == null ? null : byName.get(via.getTo());
+            FieldIntent of = rollup.getOf() == null || parent == null ? null : fieldByName(child, rollup.getOf());
+            FieldIntent target = parent == null ? null : fieldByName(parent, rollup.getField());
+            if (of != null && target != null && of.isSensitive() && !target.isSensitive()
+                    && hasPersonalSurface(byName, parent, new HashSet<>())) {
+                target.setSensitive(true);
+            }
+        }
+        // aggregate: true master fields recomputed from the same-named field of a composition child
+        for (EntityIntent parent : model.getEntities()) {
+            if (!hasPersonalSurface(byName, parent, new HashSet<>())) {
+                continue;
+            }
+            for (FieldIntent target : parent.getFields()) {
+                if (!target.isAggregate() || target.isSensitive()) {
+                    continue;
+                }
+                for (EntityIntent child : model.getEntities()) {
+                    for (RelationIntent relation : child.getRelations()) {
+                        if (relation.isComposition() && parent.getName() != null && parent.getName()
+                                                                                          .equals(relation.getTo())) {
+                            FieldIntent source = fieldByName(child, target.getName());
+                            if (source != null && source.isSensitive()) {
+                                target.setSensitive(true);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether the entity gets a personal (my) surface: it declares a personal owner relation of its
+     * own, or inherits the scope through a composition parent chain (cycle-guarded).
+     */
+    private static boolean hasPersonalSurface(java.util.Map<String, EntityIntent> byName, EntityIntent entity, Set<String> seen) {
+        if (entity == null || entity.getName() == null || !seen.add(entity.getName())) {
+            return false;
+        }
+        for (RelationIntent relation : entity.getRelations()) {
+            if (relation.isPersonal()) {
+                return true;
+            }
+        }
+        for (RelationIntent relation : entity.getRelations()) {
+            if (relation.isComposition() && hasPersonalSurface(byName, byName.get(relation.getTo()), seen)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -291,7 +291,12 @@ scoped to the logged-in user: reads filtered to the mapped identity record, the 
 server-side on writes, foreign records 404. A field marked `sensitive: true` (not the PK, the
 identity field, or the owner FK) is stripped from personal responses and ignored on personal
 writes - use it for billing rates and amounts the person must not see. The regular controller is
-unaffected.
+unaffected. Sensitivity propagates to derived fields automatically: a rollup target (`op: sum` /
+`latest`) whose `of:` child field is sensitive, and an `aggregate: true` master field fed by a
+same-named sensitive item field, are treated as sensitive whenever their entity has a personal
+surface (own `personal:` relation, or scope inherited through a composition parent chain) - the
+total of a hidden value never travels the personal wire, without the author having to remember to
+mark it.
 
 **Partner surfaces (`partner: true`):** the exact mirror of `personal:` for EXTERNAL parties
 (customers, suppliers) on the Partner shell (`/services/web/partner/`). A record-owning to-one

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -176,6 +176,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: note, type: string, length: 200 }
                   - { name: rate, type: decimal, sensitive: true }
+                  - { name: totalCost, type: decimal }
                 relations:
                   - { name: Person, kind: manyToOne, to: Person, required: true, personal: true }
                   # a plain dropdown relation: the personal LIST must resolve it to a label (the
@@ -186,6 +187,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 fields:
                   - { name: id,     type: integer, primaryKey: true, generated: true }
                   - { name: amount, type: decimal }
+                  - { name: cost,   type: decimal, sensitive: true }
                   - { name: day,    type: date }
                 relations:
                   - { name: Claim, kind: manyToOne, to: Claim, composition: true }
@@ -264,6 +266,13 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: note, type: string, length: 200 }
                 relations:
                   - { name: Status, kind: manyToOne, to: EntryStatus, function: EntityStatus, init: 1 }
+
+            # auto-sensitive derivation: totalCost sums the SENSITIVE ClaimLine.cost into the
+            # personal-rooted Claim - the parser must mark the target sensitive automatically
+            # (the leak class where the leaf is scrubbed but its total travels the my wire).
+            # totalCost is NOT authored sensitive on purpose.
+            rollups:
+              - { name: claimCost, entity: ClaimLine, via: Claim, field: totalCost, op: sum, of: cost }
 
             # collection-driven generation: the monthly job creates one Claim per Person and,
             # under each, one ClaimLine per working day of the month (amount defaulted).
@@ -507,9 +516,16 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(claimMy.contains("eq(\"Email\", username)"), "personal must emit the identity match against the logged-in username");
         assertTrue(claimMy.contains("entity.Rate = null"), "sensitive must emit the response scrub in the personal controller");
         assertTrue(claimMy.contains("entity.Person = me"), "personal must force the owner FK server-side on create");
+        // Auto-sensitive derivation (U5 class): totalCost is NOT authored sensitive, but it sums the
+        // sensitive ClaimLine.cost into the personal-rooted Claim - the parser must propagate the
+        // flag so the total is scrubbed from the personal wire exactly like the leaf value.
+        assertTrue(claimMy.contains("entity.TotalCost = null"),
+                "a rollup target summing a sensitive child field into a personal-rooted entity must be auto-scrubbed");
         String lineMy = contentOf("gen/emission/api/claim/ClaimLineMyController.java");
         assertTrue(lineMy.contains("requireMyParent"),
                 "a composition child must inherit the personal scope as an ancestor-ownership guard");
+        assertTrue(lineMy.contains("entity.Cost = null"),
+                "a sensitive field on a scope-inheriting child must be scrubbed from its personal controller");
 
         // assignee: personal - the BPMN assigns the task to the start-time-resolved owner and the
         // trigger listener seeds that variable from the identity mapping.


### PR DESCRIPTION
## What

A derived field that sums or copies a `sensitive:` child field re-exposes on its target exactly what the child hides, whenever the target entity has a personal (my) surface: the leaf value is scrubbed from the personal wire but its **total** still travels it. Today the author has to remember to mark the target field sensitive too - a silent leak when they don't.

This closes the class **by construction** in the parser (before validation):

- a **rollup** target field (`op: sum` / `latest`) whose `of:` child field is sensitive becomes sensitive automatically when the target entity is personal-surfaced (an own `personal:` owner relation, or the scope inherited through a composition parent chain, cycle-guarded);
- an **`aggregate: true`** master field fed by a same-named sensitive field of a composition child is treated the same way;
- a target **without** a personal surface keeps the authored visibility - there is nothing to leak there, and a power-only roll-up of a hidden leaf stays the manager-facing number it was authored to be.

Downstream (the `.model`, the personal controller scrub allow-list, the my pages) needs no changes - the flag propagates through the existing `sensitive` pipeline.

## Verification

`IntentEmissionCoverageIT`: the fixture now rolls the **sensitive** `ClaimLine.cost` into `Claim.totalCost` (deliberately NOT authored sensitive) and asserts the generated personal controller scrubs `TotalCost` exactly like an authored sensitive field (and the child's personal controller scrubs the leaf). **Ran green locally (1/1).** Documented in the intent guide's personal-surfaces section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)