### PR TITLE
fix(harmonia): calendar event titles from a relation resolve to labels, not raw FK ids

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-calendar-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-calendar-page.js.template
@@ -10,6 +10,14 @@
  * ${name}MyController - foreign rows and sensitive fields never arrive). date-click / event-click
  * route to the personal form.
  */
+## When the calendar title property is a RELATION, resolve the FK to its referenced label exactly
+## like the list columns do - otherwise every event would carry a raw id as its title.
+#set($titleRelation = false)
+#foreach($property in $properties)
+#if($property.name == "$!{calendarTitleProperty}" && ($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS"))
+#set($titleRelation = $property)
+#end
+#end
 document.addEventListener('alpine:init', () => {
   Alpine.data('${name}MyCalendarPage', () => ({
     ...basePage(),
@@ -24,7 +32,24 @@ document.addEventListener('alpine:init', () => {
 
     async init() {
       await this.load();
+#if($titleRelation)
+      this.loadTitleLookup();
+#end
     },
+#if($titleRelation)
+
+    titleLookup: {},   // title relation FK -> referenced label
+    // Loaded after the rows so the calendar paints immediately; events re-render as the map arrives.
+    async loadTitleLookup() {
+      try {
+        const rows = await App.services.api.getAll('${titleRelation.widgetDropdownControllerUrl}', { baseUrl: '' });
+        const map = {};
+        (rows || []).forEach((r) => { map[r.${titleRelation.widgetDropDownKey}] = r.${titleRelation.widgetDropDownValue}; });
+        this.titleLookup = map;
+        this.calCfg = { view: this.calCfg.view, events: this.buildEvents() };
+      } catch (e) { /* fail-soft: the raw value stays the title fallback */ }
+    },
+#end
 
     async load() {
       this.state = 'loading';
@@ -65,6 +90,10 @@ document.addEventListener('alpine:init', () => {
     titleFor(row) {
 #if($calendarTitleProperty)
       const t = row.${calendarTitleProperty};
+#if($titleRelation)
+      const resolved = this.titleLookup[t];
+      if (resolved !== undefined && resolved !== null && String(resolved) !== '') return String(resolved);
+#end
       if (t !== undefined && t !== null && String(t) !== '') return String(t);
 #end
       return '${menuLabel} #' + row.${primaryKeysString};

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/calendar/calendar-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/calendar/calendar-page.js.template
@@ -9,6 +9,14 @@
  * Fetches through the same generated controller as the manage list; create/edit reuse the shared
  * ${name}FormPage (date-click -> /create, event-click -> /{id}/edit).
  */
+## When the calendar title property is a RELATION, resolve the FK to its referenced label exactly
+## like the list columns do - otherwise every event would carry a raw id as its title.
+#set($titleRelation = false)
+#foreach($property in $properties)
+#if($property.name == "$!{calendarTitleProperty}" && ($property.widgetType == "DROPDOWN" || $property.widgetType == "DOCUMENT_STATUS"))
+#set($titleRelation = $property)
+#end
+#end
 document.addEventListener('alpine:init', () => {
   Alpine.data('${name}CalendarPage', () => ({
     ...basePage(),
@@ -43,7 +51,24 @@ document.addEventListener('alpine:init', () => {
       this.readScope();
 #end
       await this.load();
+#if($titleRelation)
+      this.loadTitleLookup();
+#end
     },
+#if($titleRelation)
+
+    titleLookup: {},   // title relation FK -> referenced label
+    // Loaded after the rows so the calendar paints immediately; events re-render as the map arrives.
+    async loadTitleLookup() {
+      try {
+        const rows = await App.services.api.getAll('${titleRelation.widgetDropdownControllerUrl}', { baseUrl: '' });
+        const map = {};
+        (rows || []).forEach((r) => { map[r.${titleRelation.widgetDropDownKey}] = r.${titleRelation.widgetDropDownValue}; });
+        this.titleLookup = map;
+        this.calCfg = { view: this.calCfg.view, events: this.buildEvents() };
+      } catch (e) { /* fail-soft: the raw value stays the title fallback */ }
+    },
+#end
 
     async load() {
       this.state = 'loading';
@@ -90,6 +115,10 @@ document.addEventListener('alpine:init', () => {
     titleFor(row) {
 #if($calendarTitleProperty)
       const t = row.${calendarTitleProperty};
+#if($titleRelation)
+      const resolved = this.titleLookup[t];
+      if (resolved !== undefined && resolved !== null && String(resolved) !== '') return String(resolved);
+#end
       if (t !== undefined && t !== null && String(t) !== '') return String(t);
 #end
       return '${menuLabel} #' + row.${primaryKeysString};

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -218,7 +218,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
               # calendar (never the plain form+list), scoped to the MyController (U3 parity).
               - name: Leave
                 view: range
-                calendar: { start: fromDate, end: toDate }
+                calendar: { start: fromDate, end: toDate, title: Person }
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
                   - { name: fromDate, type: date, required: true }
@@ -656,6 +656,11 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         String shellIndex = contentOf("gen/emission/index.html");
         assertTrue(shellIndex.contains("x-template.target.app=\"./views/my/Leave-calendar.html\""),
                 "/my/<Entity> must land on the personal calendar for a calendar root");
+        // A calendar title that names a RELATION must resolve to the referenced label like the
+        // list columns do - never render the raw FK id as the event title (power and my alike).
+        String leaveCalendar = contentOf("gen/emission/js/components/pages/Leave/LeaveCalendarPage.js");
+        assertTrue(leaveCalendar.contains("titleLookup"), "the power calendar must resolve a relation title through a label lookup");
+        assertTrue(myLeaveCalendar.contains("titleLookup"), "the personal calendar must resolve a relation title through a label lookup");
 
         // transitions: the server half is a controller that guards the source status + the when
         // guard (409) and flips ONLY the status column via the targeted updateProperty; the client


### PR DESCRIPTION
## What

A `calendar: { title: <property> }` naming a **to-one relation** rendered the raw FK id as every event's title (e.g. each leave bar titled `7`). The power calendar page and the personal (my) calendar page now resolve a relation title through the **same label lookup the list columns use**: the referenced controller is fetched once after the rows load - the calendar paints immediately and titles refine when the map arrives - with the raw value as the fail-soft fallback (dangling FK, denied lookup).

A title naming a plain field is untouched.

## Not in this PR

The **embedded** calendar panels (shared `detailPanel` on the master page, the my-form child panels) share the raw-title behavior; they are addressed together with the document-surface calendar work, where those code paths change anyway.

## Verification

`IntentEmissionCoverageIT`: the range fixture's calendar now declares `title: Person` (a relation) and asserts the `titleLookup` resolution in both the generated power and personal calendar pages. **Ran green locally (1/1).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)