### PR TITLE
feat(apptest): my flow wave 2 - UI parity walk of the personal page

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/apptest/AppTestIntentGenerator.java
@@ -188,6 +188,31 @@ public class AppTestIntentGenerator implements IntentTargetGenerator {
             if (!sensitive.isEmpty()) {
                 personal.put("sensitive", sensitive);
             }
+            // UI parity (wave 2): what the personal PAGE renders, so the runner can drive it live -
+            // the /my route, the layout family the page belongs to, and the relation columns the
+            // personal list shows (each must resolve to its referenced label, never a raw FK id).
+            personal.put("route", "#/my/" + name);
+            String layout = "list";
+            if (entity.isCalendar() || entity.isRange()) {
+                layout = "calendar";
+            } else if (entity.isSlots()) {
+                layout = "slots";
+            } else if (entity.isDocument()) {
+                layout = entity.isChatItems() ? "document-chat" : "document";
+            }
+            personal.put("layout", layout);
+            if ("list".equals(layout)) {
+                List<String> fkColumns = new ArrayList<>();
+                for (RelationIntent column : entity.getRelations()) {
+                    boolean toOne = "manyToOne".equals(column.getKind()) || "oneToOne".equals(column.getKind());
+                    if (toOne && !column.isPersonal()) {
+                        fkColumns.add(IntentNaming.pascalCase(column.getName()));
+                    }
+                }
+                if (!fkColumns.isEmpty()) {
+                    personal.put("fkColumns", fkColumns);
+                }
+            }
             out.put("personal", personal);
             break;
         }

--- a/npm/test/src/flows/my.js
+++ b/npm/test/src/flows/my.js
@@ -3,6 +3,65 @@ import { expect, test } from '../fixtures.js';
 import { resolveRelationSamples } from '../form.js';
 import { sampleRecord } from '../sample-values.js';
 
+// Wave 2 (UI parity): the personal PAGE renders what the wire serves. Driven by the same
+// own-row lifecycle as the wire test (created through the scoped controller, removed in the
+// finally); skips without an identity mapping, exactly like the wire flow.
+// - layout 'list': every relation column of the own row shows its referenced LABEL - the
+//   raw-FK-id regression class the personal templates fixed;
+// - layout 'calendar'/'slots': the personal route renders the calendar / slot picker, never a
+//   plain form+list downgrade;
+// - layout 'document-chat': the composer accepts a message and the bubble renders (the my
+//   document chat parity class). A plain 'document' asserts the page serves.
+function myUiTest(manifest, entity, mine, buildContext, idProperty) {
+  test(`${entity.name}: the My page renders the own record with resolved labels (UI parity)`, async ({ api, page }) => {
+    const { payload, samples } = await buildContext(api);
+    const createdResponse = await api.post(manifest.restBase + mine.api, { data: payload });
+    test.skip(
+      !createdResponse.ok(),
+      `personal create returned ${createdResponse.status()} - the test user has no identity mapping; ` +
+        `seed the dev identity row (an owner-target record whose identity field equals the login user)`
+    );
+    const created = JSON.parse(await createdResponse.text());
+    const id = created?.[idProperty];
+    const client = makeApi(api, manifest);
+    try {
+      const layout = entity.personal.layout ?? 'list';
+      if (layout === 'calendar' || layout === 'slots') {
+        await page.goto(manifest.standaloneShell + entity.personal.route);
+        await expect(page.locator('[x-h-calendar], [x-h-slot-picker]').first()).toBeVisible();
+        return;
+      }
+      if (layout === 'document-chat' || layout === 'document') {
+        await page.goto(manifest.standaloneShell + entity.personal.route + '/' + id + '/edit');
+        if (layout === 'document-chat') {
+          const message = `UI parity probe ${id}`;
+          const composer = page.getByRole('textbox', { name: /write a message/i }).first();
+          await composer.fill(message);
+          await page.getByRole('button', { name: /send/i }).first().click();
+          await expect(page.getByText(message).first(), 'the sent message must render as a bubble').toBeVisible();
+        } else {
+          await expect(page.locator('[x-h-toolbar-title]').first()).toBeVisible();
+        }
+        return;
+      }
+      // list: the own rows are the only rows - every asserted relation column of the created
+      // row must surface its referenced label somewhere in the table body
+      await page.goto(manifest.standaloneShell + entity.personal.route);
+      await expect(page.locator('tbody tr:visible').first()).toBeVisible();
+      const fkColumns = new Set(entity.personal.fkColumns ?? []);
+      for (const sample of samples) {
+        if (!fkColumns.has(sample.relation.name) || sample.label == null) continue;
+        await expect(
+          page.locator('tbody').getByText(String(sample.label)).first(),
+          `${sample.relation.name} must render its referenced label ("${sample.label}"), not the raw id ${sample.id}`
+        ).toBeVisible();
+      }
+    } finally {
+      await client.remove(mine, id);
+    }
+  });
+}
+
 // The personal (my) surface WIRE contract, driven when the manifest marks an entity `personal`:
 // the scoped <Entity>MyController filters reads to the identity-mapped user, forces the owner FK
 // server-side on create (whatever the client sends is ignored), strips every `sensitive` field
@@ -12,9 +71,8 @@ import { sampleRecord } from '../sample-values.js';
 // Prerequisite: the DEV IDENTITY mapping - a row of the owner relation's target whose identity
 // field equals the test user (e.g. an Employee with email 'admin'). Without it the personal
 // surface is EMPTY by design (never an error), so the flow SKIPS with a pointer instead of
-// failing. The personal UI parity assertions (resolved labels, chat layout, calendar views on
-// the My shell) are deliberately NOT asserted yet - they track the platform's personal-template
-// parity fixes; this flow pins down the wire contract those pages consume.
+// failing. Wave 2 (myUiTest below) walks the personal PAGE over the same own-row lifecycle:
+// resolved relation labels on the list, calendar/slots rendering, the chat composer round-trip.
 export function myFlow(manifest, entity, opts = {}) {
   const cfg = opts.extend?.entities?.[entity.name] ?? {};
   if (!entity.personal || new Set(cfg.skip ?? []).has('my')) return;
@@ -22,14 +80,19 @@ export function myFlow(manifest, entity, opts = {}) {
   // the same entity through the scoped controller
   const mine = { ...entity, api: entity.personal.api };
 
-  async function buildPayload(api) {
+  async function buildContext(api) {
     const payload = sampleRecord(entity);
-    for (const sample of await resolveRelationSamples(api, manifest, entity)) {
+    const samples = await resolveRelationSamples(api, manifest, entity);
+    for (const sample of samples) {
       payload[sample.relation.name] = sample.id;
     }
     // the owner FK is server-forced on the personal surface; sending a value must be pointless
     delete payload[entity.personal.owner];
-    return payload;
+    return { payload, samples };
+  }
+
+  async function buildPayload(api) {
+    return (await buildContext(api)).payload;
   }
 
   test(`${entity.name}: personal (my) surface scopes rows, forces the owner and strips sensitive fields`, async ({ api }) => {
@@ -76,4 +139,10 @@ export function myFlow(manifest, entity, opts = {}) {
     const gone = await api.get(manifest.restBase + mine.api + '/' + id);
     expect(gone.status()).toBe(404);
   });
+
+  // wave 2: the UI-parity walk over the same personal surface (older manifests without the
+  // route/layout metadata regenerate to get it - skip quietly until then)
+  if (entity.personal.route) {
+    myUiTest(manifest, entity, mine, buildContext, idProperty);
+  }
 }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -657,6 +657,18 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(shellIndex.contains("x-template.target.app=\"./views/my/Leave-calendar.html\""),
                 "/my/<Entity> must land on the personal calendar for a calendar root");
 
+        // The app-test manifest carries the personal UI-parity metadata the runner's my flow
+        // drives (wave 2): the /my route, the layout family the personal page belongs to, and
+        // the relation columns that must resolve to labels on the personal list.
+        String testManifest = contentOf("emission.test");
+        assertTrue(testManifest.contains("\"route\": \"#/my/Claim\""),
+                "the manifest's personal block must carry the /my route for the UI-parity walk");
+        assertTrue(testManifest.contains("\"fkColumns\"") && testManifest.contains("\"Unit\""),
+                "the manifest must name the personal list's relation columns (label resolution targets)");
+        assertTrue(testManifest.contains("\"layout\": \"document-chat\""),
+                "a personal chat document must be flagged so the runner drives the composer round-trip");
+        assertTrue(testManifest.contains("\"route\": \"#/my/Leave\""), "the calendar root's personal block must carry its /my route");
+
         // transitions: the server half is a controller that guards the source status + the when
         // guard (409) and flips ONLY the status column via the targeted updateProperty; the client
         // half is a custom-action contribution carrying the endpoint.


### PR DESCRIPTION
## What

Wave 1 of the runner's `my` flow pinned down the personal **wire** contract; the UI above it had no functional coverage - exactly where the raw-FK-id columns, layout downgrades and dead-composer regressions accumulated silently.

- **`@aerokit/sdk/test`**: `myUiTest` drives the personal page over the same own-row lifecycle as the wire test (record created through the scoped controller, removed in the `finally`; skips without an identity mapping):
  - **list**: every relation column of the own row renders its referenced **label** - asserted positively against the sampled target row's label, never the raw FK id;
  - **calendar/slots**: the `/my` route renders the calendar / slot picker, never a plain form+list downgrade;
  - **document-chat**: the composer accepts a message and the bubble renders; a plain document asserts the page serves.
- **`AppTestIntentGenerator`**: the manifest's `personal` block gains `route` (`#/my/<Entity>`), `layout` (`list | calendar | slots | document | document-chat`) and `fkColumns` (the personal list's relation columns - the label-resolution targets). Manifests generated before this change carry no `route`, so the UI walk skips quietly until the module regenerates.

## Verification

`IntentEmissionCoverageIT` asserts the new manifest metadata for the personal list, chat document and calendar fixtures. **Ran green locally (1/1).** `node --check` clean on the runner. The live end-to-end exercise follows with the module-side manifest regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)