### PR TITLE
feat(intent): generates.items supports a non-composition FK-referencing source item + decimal item defaults

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -613,13 +613,25 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             if (hasItems) {
                 e.put("fromItemEntity", items.getFrom());
                 e.put("toItemEntity", items.getTo());
+                // The SOURCE item's own perspective: a composition child resolves to its master's
+                // perspective (== fromPerspective, so this is a no-op for the common document-item
+                // case), but a source item that is a SEPARATE primary entity referencing the source
+                // by FK (e.g. an aggregate document whose per-line detail is its own entity) lives in
+                // its OWN package - the template must qualify srcItem with this, not the source
+                // document's perspective. (The TARGET item stays on toPerspective: a create-from
+                // always writes into the target document's own composition-item table.)
+                e.put("fromItemPerspective", IntentEntities.resolvePerspective(items.getFrom(), compositionParents));
                 // A document child's FK back to its master is, by convention, the master entity's name.
                 e.put("srcFkProperty", IntentNaming.pascalCase(g.getFrom()));
                 e.put("toFkProperty", IntentNaming.pascalCase(g.getTo()));
-                e.put("itemFieldAssignments", assignments(items.getMap(), items.getDefaults(), "srcItem"));
+                // childAssignments (not assignments) so a numeric item default renders as BigDecimal -
+                // line-item columns (quantity/price/amount) are decimal, and a bare int literal does
+                // not convert to the generated BigDecimal field.
+                e.put("itemFieldAssignments", childAssignments(items.getMap(), items.getDefaults(), "srcItem"));
             } else {
                 e.put("fromItemEntity", "");
                 e.put("toItemEntity", "");
+                e.put("fromItemPerspective", "");
                 e.put("srcFkProperty", "");
                 e.put("toFkProperty", "");
                 e.put("itemFieldAssignments", new ArrayList<>());

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueGeneratesTest.java
@@ -212,4 +212,67 @@ class GlueGeneratesTest {
         assertTrue(fields.contains(Map.of("targetProp", "Active", "expr", "true")));
         assertFalse(fields.isEmpty());
     }
+
+    /**
+     * The source item may be a SEPARATE primary entity that references the source document by FK (an
+     * aggregate document whose per-line detail is its own entity), not a composition child. Its package
+     * must resolve from its OWN perspective (not the source document's), and a numeric item default
+     * must render as {@code BigDecimal} for the decimal line column.
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    void nonCompositionSourceItemResolvesItsOwnPackageAndDecimalDefaults() {
+        IntentModel model = IntentParser.parse("""
+                name: work
+                uses:
+                  - { model: kf-mod-sales-invoices }
+                entities:
+                  - name: Sheet
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string, documentTitle: true }
+                    relations:
+                      - { name: Customer, kind: manyToOne, to: Customer, model: kf-mod-sales-invoices }
+                  - name: Line
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                      - { name: amount, type: decimal, precision: 18, scale: 2 }
+                    relations:
+                      - { name: Sheet, kind: manyToOne, to: Sheet, required: true }
+                generates:
+                  - name: invoice-from-sheet
+                    from: Sheet
+                    to: SalesInvoice
+                    uses: kf-mod-sales-invoices
+                    forEntity: Sheet
+                    map:
+                      Customer: Customer
+                    items:
+                      from: Line
+                      to: SalesInvoiceItem
+                      map:
+                        name: number
+                        price: amount
+                      defaults:
+                        quantity: 1
+                """);
+        Map<String, Object> g = GlueIntentGenerator.buildGeneratesForTest(model)
+                                                   .get(0);
+        assertEquals(true, g.get("hasItems"));
+        assertEquals("Line", g.get("fromItemEntity"));
+        // The source document's perspective is `Sheet`; the item's OWN perspective is `Line` - the
+        // template must qualify srcItem with the latter (sanitized to the `line` package), or it
+        // references a non-existent class. (For a composition-child item these two coincide.)
+        assertEquals("Sheet", g.get("fromPerspective"));
+        assertEquals("Line", g.get("fromItemPerspective"));
+        // The FK the item loop queries by is the source document entity name.
+        assertEquals("Sheet", g.get("srcFkProperty"));
+
+        List<Map<String, Object>> itemFields = (List<Map<String, Object>>) g.get("itemFieldAssignments");
+        assertTrue(itemFields.contains(Map.of("targetProp", "Name", "expr", "srcItem.Number")));
+        assertTrue(itemFields.contains(Map.of("targetProp", "Price", "expr", "srcItem.Amount")));
+        // The decimal `quantity` default renders as BigDecimal (a bare `1` would not compile).
+        assertTrue(itemFields.contains(Map.of("targetProp", "Quantity", "expr", "new java.math.BigDecimal(\"1\")")));
+    }
 }

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Generate.java.template
@@ -41,8 +41,8 @@ public class ${className}Generate {
         gen.${toGenFolder}.data.${toJavaPerspective}.${toEntity}Entity saved =
                 new gen.${toGenFolder}.data.${toJavaPerspective}.${toEntity}Repository().save(target);
 #if($hasItems)
-        for (gen.${javaGenFolderName}.data.${fromJavaPerspective}.${fromItemEntity}Entity srcItem :
-                new gen.${javaGenFolderName}.data.${fromJavaPerspective}.${fromItemEntity}Repository()
+        for (gen.${javaGenFolderName}.data.${fromItemJavaPerspective}.${fromItemEntity}Entity srcItem :
+                new gen.${javaGenFolderName}.data.${fromItemJavaPerspective}.${fromItemEntity}Repository()
                         .findAll(Criteria.create()
                                          .eq("${srcFkProperty}", req.id))) {
             gen.${toGenFolder}.data.${toJavaPerspective}.${toItemEntity}Entity item =

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -959,6 +959,10 @@ export function generateFiles(model, parameters, templateSources) {
                                 hasItems: g.hasItems,
                                 fromItemEntity: g.fromItemEntity,
                                 toItemEntity: g.toItemEntity,
+                                // The source item's own package (a non-composition primary source item
+                                // lives outside the source document's perspective); the glue resolves
+                                // it (== fromJavaPerspective for the common composition-child case).
+                                fromItemJavaPerspective: sanitizeJavaIdentifier(g.fromItemPerspective || g.fromPerspective),
                                 srcFkProperty: g.srcFkProperty,
                                 toFkProperty: g.toFkProperty,
                                 itemFieldAssignments: g.itemFieldAssignments,


### PR DESCRIPTION
Fixes #6366.

### Problem

An item create-from (`generates` with an `items:` block) assumed the item source is a **composition child** living in the source document's perspective package, and rendered numeric item `defaults:` as bare literals. That breaks when the item source is a **separate primary entity referencing the source document by FK** — an aggregate document whose per-line detail is its own entity (e.g. a period-aggregate document whose per-member detail rows are a standalone entity). The emitted code then references the item type in the wrong package (`cannot find symbol`), and a decimal item default like `quantity: 1` renders as `item.Quantity = 1;` → `incompatible types: int cannot be converted to java.math.BigDecimal`.

### Fix

- The source item's package now resolves from its **own** perspective (`fromItemPerspective`), not the source document's. For a composition-child item this equals `fromPerspective`, so existing create-froms are byte-identical. The template qualifies `srcItem` with it.
- Item defaults use `childAssignments` (numeric → `BigDecimal`), the same path the scheduled-children generation already uses, so a decimal line column gets a compilable value.

Three layers: `GlueIntentGenerator` (glue), `generateUtils.js` (sanitized package var), `Generate.java.template` (uses it).

### Test

`GlueGeneratesTest.nonCompositionSourceItemResolvesItsOwnPackageAndDecimalDefaults` asserts the item resolves its own perspective (distinct from the source document's) and the decimal default renders as `BigDecimal`. Existing generates tests unchanged (composition-child path is a no-op).

Follow-up: extend `IntentEmissionCoverageIT` with a non-composition item-source fixture asserting the emitted controller compiles and serves (the outermost layer); tracked in #6366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
