### PR TITLE
feat(intent): function: Attachment — file-attachment composition child (end-to-end)

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/cms/Attachments.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/cms/Attachments.java
@@ -11,8 +11,15 @@ package org.eclipse.dirigible.sdk.cms;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.dirigible.components.api.cms.AttachmentsFacade;
+import org.eclipse.dirigible.components.api.http.HttpRequestFacade;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
 
 /**
  * Client SDK for record attachments: store an uploaded file against a master entity (into the
@@ -45,6 +52,36 @@ public final class Attachments {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to store attachment [" + fileName + "] for [" + masterEntity + "]", e);
         }
+    }
+
+    /**
+     * Parse the current multipart request and store every uploaded file as an attachment of the given
+     * master entity. Reads the servlet parts Spring's multipart resolver has already parsed (the
+     * generated controller is served by a Spring {@code @PostMapping}, which consumes the body before
+     * commons-fileupload could), so a generated controller only ever sees {@link Attachment}.
+     *
+     * @param masterEntity the owning entity type name
+     * @return the stored attachments, one per uploaded file (form fields ignored)
+     */
+    public static List<Attachment> storeUploads(String masterEntity) {
+        HttpServletRequest request = HttpRequestFacade.getRequest();
+        if (request == null) {
+            throw new IllegalStateException("No active request to read the upload for [" + masterEntity + "]");
+        }
+        List<Attachment> result = new ArrayList<>();
+        try {
+            for (Part part : request.getParts()) {
+                if (part.getSubmittedFileName() == null) {
+                    continue; // a plain form field, not a file
+                }
+                try (InputStream in = part.getInputStream()) {
+                    result.add(store(masterEntity, part.getSubmittedFileName(), part.getContentType(), in.readAllBytes()));
+                }
+            }
+        } catch (IOException | ServletException e) {
+            throw new IllegalStateException("Failed to read the upload for [" + masterEntity + "]", e);
+        }
+        return result;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -322,6 +322,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (entity.isMultilingual()) {
                 entityMap.put("multilingual", "true");
             }
+            // A file-attachment child: mark it so the generated controller emits the upload/download/
+            // delete verbs and the Harmonia master/document view renders it as an "Attachments" panel
+            // (a composition detail already, so the master-detail wiring is unchanged).
+            if (entity.isAttachment()) {
+                entityMap.put("attachmentEntity", "true");
+            }
             // Custom Java imports for the generated entity Repository (e.g. a calculated-field action's
             // CalculatedField class). Base64-encoded to match the EDM editor's serialization, which the
             // DAO template's parameterUtils decodes before emitting them into the import block.
@@ -336,6 +342,19 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             }
 
             List<Map<String, Object>> properties = new ArrayList<>();
+            // A file-attachment child (function: Attachment) is a first-class entity, but the author
+            // declares no fields at all (the file-metadata columns are injected below), so synthesize
+            // the generated integer primary key it still needs.
+            if (entity.isAttachment() && entity.getFields()
+                                               .stream()
+                                               .noneMatch(FieldIntent::isPrimaryKey)) {
+                FieldIntent id = new FieldIntent();
+                id.setName("id");
+                id.setType("integer");
+                id.setPrimaryKey(true);
+                id.setGenerated(true);
+                properties.add(propertyMap(name, id));
+            }
             for (FieldIntent field : entity.getFields()) {
                 if (field.getName() == null || field.getName()
                                                     .isBlank()) {
@@ -359,8 +378,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (triggerTargets.contains(name)) {
                 properties.add(processIdProperty(name));
             }
+            // A file-attachment child (function: Attachment) gets the standard file-metadata columns
+            // injected (like audit:) - the author never hand-writes plumbing; the upload sets them
+            // server-side. FileName is the row's display title; StoragePath is the CMS reference. The
+            // attachment is implicitly audited (who uploaded when).
+            boolean audited = entity.isAudited();
+            if (entity.isAttachment()) {
+                properties.addAll(attachmentProperties(name));
+                audited = true;
+            }
             // The four standard audit columns, populated by the platform's audit annotations downstream.
-            if (entity.isAudited()) {
+            if (audited) {
                 properties.addAll(auditProperties(name));
             }
             List<Map<String, Object>> relations = new ArrayList<>();
@@ -1434,6 +1462,45 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * The four standard audit columns (populated downstream by the {@code @CreatedAt}/etc.
      * annotations).
      */
+    /**
+     * The standard file-metadata columns injected into a {@code function: Attachment} child. The upload
+     * sets them server-side (so all read-only); FileName is the row's display title, StoragePath is the
+     * CMS reference the download route reads, Uuid is the per-upload folder key.
+     */
+    private static List<Map<String, Object>> attachmentProperties(String entityName) {
+        List<Map<String, Object>> props = new ArrayList<>();
+        props.add(attachmentProperty(entityName, "FileName", "VARCHAR", 255, true));
+        props.add(attachmentProperty(entityName, "ContentType", "VARCHAR", 255, false));
+        props.add(attachmentProperty(entityName, "FileSize", "BIGINT", 0, false));
+        props.add(attachmentProperty(entityName, "StoragePath", "VARCHAR", 1000, false));
+        props.add(attachmentProperty(entityName, "Uuid", "VARCHAR", 36, false));
+        return props;
+    }
+
+    /**
+     * One injected attachment metadata column: read-only (upload-set), {@code auditType=NONE};
+     * {@code major} controls whether it shows on the entity list (FileName does, the rest don't).
+     */
+    private static Map<String, Object> attachmentProperty(String entityName, String fieldName, String dataType, int length, boolean major) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("name", fieldName);
+        p.put("description", "");
+        p.put("tooltip", "");
+        p.put("dataName", IntentNaming.upperSnake(entityName) + "_" + IntentNaming.upperSnake(fieldName));
+        p.put("dataType", dataType);
+        p.put("dataNullable", "true");
+        if (length > 0) {
+            p.put("dataLength", Integer.toString(length));
+        }
+        p.put("auditType", "NONE");
+        p.put("isReadOnlyProperty", "true");
+        p.put("widgetType", widgetForType(dataType));
+        p.put("widgetSize", "");
+        p.put("widgetLength", length > 0 ? Integer.toString(length) : "20");
+        p.put("widgetIsMajor", major ? "true" : "false");
+        return p;
+    }
+
     private static List<Map<String, Object>> auditProperties(String entityName) {
         List<Map<String, Object>> audit = new ArrayList<>();
         audit.add(auditProperty(entityName, "CreatedAt", "TIMESTAMP", "CREATED_AT", 0));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -290,6 +290,16 @@ public class EntityIntent {
         return functionIs("DocumentItem");
     }
 
+    /**
+     * Whether this entity is a file-attachment child ({@code function: Attachment}) - a composition
+     * detail of its master holding one uploaded file's metadata (the bytes live in the CMS). The EDM
+     * generator injects the standard attachment columns; the generated controller and Harmonia view
+     * render it as an "Attachments" section.
+     */
+    public boolean isAttachment() {
+        return functionIs("Attachment");
+    }
+
     public String getDescription() {
         return description;
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -86,7 +86,7 @@ public final class IntentParser {
     private static final Set<String> RELATION_KINDS = Set.of("oneToMany", "manyToOne", "oneToOne", "manyToMany");
     /** Implemented entity {@code function} values (lower-cased), selecting the entity's UI template. */
     private static final Set<String> ENTITY_FUNCTIONS =
-            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar");
+            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment");
     /**
      * Entity {@code function} values whose template is reserved but not yet shipped (gated with a
      * message).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -123,6 +123,57 @@ class EdmIntentGeneratorTest {
     }
 
     @Test
+    void attachmentChildInjectsFileMetadataAndIsMarked() {
+        String yaml = """
+                name: docs
+                entities:
+                  - name: Company
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: CompanyAttachment
+                    function: Attachment
+                    fields:
+                      - { name: category, type: string, length: 50 }
+                    relations:
+                      - { name: Company, kind: manyToOne, to: Company, composition: true, required: true }
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "docs");
+        List<Map<String, Object>> entities = entities(model);
+        Map<String, Object> att = entityByName(entities, "CompanyAttachment");
+
+        // Marked for the generated controller (upload/download verbs) + the Harmonia Attachments panel;
+        // it stays a composition detail of its master (the master-detail wiring is unchanged).
+        assertEquals("true", att.get("attachmentEntity"));
+        assertEquals("MANAGE_DETAILS", att.get("layoutType"));
+
+        // The standard file-metadata columns are injected (upload-set -> read-only); FileName is the
+        // row's display title (shown on the list), StoragePath is the internal CMS reference.
+        assertEquals("VARCHAR", propertyByName(att, "FileName").get("dataType"));
+        assertEquals("true", propertyByName(att, "FileName").get("isReadOnlyProperty"));
+        assertEquals("true", propertyByName(att, "FileName").get("widgetIsMajor"));
+        assertEquals("BIGINT", propertyByName(att, "FileSize").get("dataType"));
+        assertEquals("false", propertyByName(att, "StoragePath").get("widgetIsMajor"));
+        assertNotNull(propertyByName(att, "ContentType"));
+        assertNotNull(propertyByName(att, "Uuid"));
+        // Implicitly audited - who uploaded when.
+        assertEquals("CREATED_AT", propertyByName(att, "CreatedAt").get("auditType"));
+        // Author-declared domain field preserved alongside the injected ones.
+        assertNotNull(propertyByName(att, "Category"));
+
+        // The author declares no primary key on an attachment child, so a generated integer Id is
+        // synthesized (auto-increment) - otherwise the generated entity/controller would have no PK.
+        Map<String, Object> id = propertyByName(att, "Id");
+        assertEquals("true", id.get("dataPrimaryKey"));
+        assertEquals("INTEGER", id.get("dataType"));
+        assertEquals("true", id.get("dataAutoIncrement"));
+
+        // A plain (non-attachment) entity carries no marker.
+        assertNull(entityByName(entities, "Company").get("attachmentEntity"));
+    }
+
+    @Test
     void dependsOnEmitsWidgetAttributesWithPrimaryKeyDefaults() {
         String yaml = """
                 name: shop

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -132,6 +132,52 @@ public class ${name}Controller {
 #end
         return repository.save(entity);
     }
+#if($attachmentEntity)
+
+    @Post("/upload")
+    @Documentation("Upload one or more files as ${name} attachments (multipart/form-data)")
+    public List<${name}Entity> upload(@QueryParam("${masterEntityId}") Integer ${masterEntityId}) {
+#if($needsRoles)
+        checkPermissions("write");
+#end
+        if (!org.eclipse.dirigible.sdk.http.Upload.isMultipartContent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The request must be multipart/form-data");
+        }
+        List<${name}Entity> uploaded = new java.util.ArrayList<>();
+        // The SDK parses the multipart request and stores each file in the tenant CMS at
+        // /Attachments/${name}/<yyyy>/<MM>/<uuid>/<file> (the multipart/FileItem handling stays inside
+        // the SDK); we persist one row per file with the returned reference + metadata. Auth above.
+        for (org.eclipse.dirigible.sdk.cms.Attachments.Attachment stored : org.eclipse.dirigible.sdk.cms.Attachments.storeUploads("${name}")) {
+            ${name}Entity entity = new ${name}Entity();
+            entity.FileName = stored.fileName();
+            entity.ContentType = stored.contentType();
+            entity.FileSize = stored.size();
+            entity.StoragePath = stored.path();
+            entity.Uuid = stored.uuid();
+            entity.${masterEntityId} = ${masterEntityId};
+            uploaded.add(repository.save(entity));
+        }
+        return uploaded;
+    }
+
+    @Get("/{id}/download")
+    @Documentation("Download the ${name} attachment file")
+    public void download(@PathParam("id") #foreach($property in $properties)#if($property.dataPrimaryKey)${property.dataTypeJavaClass}#end#end id) {
+#if($needsRoles)
+        checkPermissions("read");
+#end
+        ${name}Entity entity = repository.findOne(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "${name} not found"));
+        org.eclipse.dirigible.sdk.http.Response.setContentType(entity.ContentType != null ? entity.ContentType : "application/octet-stream");
+        org.eclipse.dirigible.sdk.http.Response.setHeader("Content-Disposition", "attachment; filename=\"" + entity.FileName + "\"");
+        try (java.io.InputStream in = org.eclipse.dirigible.sdk.cms.Attachments.open(entity.StoragePath);
+                java.io.OutputStream out = org.eclipse.dirigible.sdk.http.Response.getOutputStream()) {
+            in.transferTo(out);
+        } catch (java.io.IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to stream the attachment", e);
+        }
+    }
+#end
 
     @Put("/{id}")
     @Documentation("Update ${name} by id")
@@ -173,8 +219,18 @@ public class ${name}Controller {
 #if($immutableStatusProperty || $immutableAlways)
         requireMutable(id);
 #end
+#if($attachmentEntity)
+        String storagePath = repository.findOne(id)
+                                       .map(a -> a.StoragePath)
+                                       .orElse(null);
+#end
         try {
             repository.deleteById(id);
+#if($attachmentEntity)
+            if (storagePath != null) {
+                org.eclipse.dirigible.sdk.cms.Attachments.delete(storagePath);
+            }
+#end
         } catch (RuntimeException e) {
             // A foreign-key violation means other records still reference this one - a data-integrity
             // conflict the user can act on, not a server error.

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RecordAttachmentIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RecordAttachmentIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end test for record attachments (the {@code sdk.cms.Attachments} SDK backing the generated
+ * {@code function: Attachment} controllers). Drops a small client-Java {@code @Controller} that
+ * calls {@code Attachments.storeUploads/open/delete} straight into the registry, force-syncs it,
+ * then drives a full HTTP round-trip: multipart upload -> download the stored bytes verbatim ->
+ * delete -> the file is gone. Exercises the real Spring multipart servlet path (the reason
+ * {@code storeUploads} reads the already-parsed {@code getParts()} rather than commons-fileupload)
+ * and the real tenant CMS.
+ */
+class RecordAttachmentIT extends IntegrationTest {
+
+    /** Project segment used for the controller source. */
+    private static final String PROJECT = "attachment-it";
+
+    /** Registry-relative source path. */
+    private static final String SOURCE_LOCATION = "/" + PROJECT + "/api/AttachmentsTestController.java";
+
+    /** Fully-qualified path under the registry root. */
+    private static final String REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + SOURCE_LOCATION;
+
+    /** Base URL of the controller (derived from project + package + class name). */
+    private static final String BASE = "/services/java/" + PROJECT + "/api/AttachmentsTestController";
+
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void upload_download_delete_roundTrip() {
+        writeAndSync(controllerSource());
+        String content = "hello attachment round-trip";
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+
+        restAssuredExecutor.execute(() -> {
+            // Upload a single file -> one stored attachment with its metadata and a CMS storage path.
+            String path = given().multiPart("file", "note.txt", bytes, "text/plain")
+                                 .when()
+                                 .post(BASE + "/upload")
+                                 .then()
+                                 .statusCode(200)
+                                 .body("[0].fileName", equalTo("note.txt"))
+                                 .body("[0].contentType", equalTo("text/plain"))
+                                 .body("[0].size", equalTo(bytes.length))
+                                 .body("[0].path", notNullValue())
+                                 .body("[0].path", startsWith("/Attachments/TestDoc/"))
+                                 .extract()
+                                 .path("[0].path");
+
+            // Download -> the stored bytes come back verbatim.
+            given().queryParam("path", path)
+                   .when()
+                   .get(BASE + "/download")
+                   .then()
+                   .statusCode(200)
+                   .body(equalTo(content));
+
+            // Delete -> the CMS file is removed, so a subsequent open no longer succeeds.
+            given().queryParam("path", path)
+                   .when()
+                   .delete(BASE + "/remove")
+                   .then()
+                   .statusCode(200);
+
+            given().queryParam("path", path)
+                   .when()
+                   .get(BASE + "/download")
+                   .then()
+                   .statusCode(anyOf(equalTo(404), equalTo(500)));
+        }, ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @AfterEach
+    void removeArtefactFromRegistry() {
+        if (repository.hasResource(REGISTRY_PATH)) {
+            repository.removeResource(REGISTRY_PATH);
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private void writeAndSync(String source) {
+        repository.createResource(REGISTRY_PATH, source.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    private static String controllerSource() {
+        return """
+                package api;
+
+                import java.io.InputStream;
+                import java.io.OutputStream;
+                import java.util.List;
+
+                import org.eclipse.dirigible.sdk.cms.Attachments;
+                import org.eclipse.dirigible.sdk.http.Controller;
+                import org.eclipse.dirigible.sdk.http.Delete;
+                import org.eclipse.dirigible.sdk.http.Get;
+                import org.eclipse.dirigible.sdk.http.Post;
+                import org.eclipse.dirigible.sdk.http.QueryParam;
+                import org.eclipse.dirigible.sdk.http.Response;
+
+                @Controller
+                public class AttachmentsTestController {
+
+                    @Post("/upload")
+                    public List<Attachments.Attachment> upload() {
+                        return Attachments.storeUploads("TestDoc");
+                    }
+
+                    @Get("/download")
+                    public void download(@QueryParam("path") String path) {
+                        Response.setHeader("Content-Disposition", "attachment");
+                        try (InputStream in = Attachments.open(path); OutputStream out = Response.getOutputStream()) {
+                            in.transferTo(out);
+                        } catch (java.io.IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    @Delete("/remove")
+                    public void remove(@QueryParam("path") String path) {
+                        Attachments.delete(path);
+                    }
+                }
+                """;
+    }
+
+}


### PR DESCRIPTION
## What

Turns file attachments into a **modeled, type-safe composition child** rather than a bespoke subsystem: an entity declared `function: Attachment` becomes a first-class 1:n detail of its master (existing master-detail wiring unchanged), with the whole upload/download/delete path generated. Builds on the merged CMS Attachments SDK (#6370).

## Layers

**Intent / EDM** (`engine-intent`)
- `attachment` added to `IntentParser.ENTITY_FUNCTIONS`; `EntityIntent.isAttachment()`.
- `EdmIntentGenerator` injects the standard file-metadata columns — `FileName` (major), `ContentType`, `FileSize` (BIGINT), `StoragePath`, `Uuid` — all read-only / upload-set, plus implicit `audit`, and marks the entity `attachmentEntity="true"`. The author declares no primary key on an attachment child, so a **generated integer `Id` is synthesized** (otherwise the entity/controller would have no PK).

**Controller** (`template-application-rest-java`) — gated on `attachmentEntity`
- `POST /upload` — multipart; stores each file in the tenant CMS at `/Attachments/<Master>/<yyyy>/<MM>/<uuid>/<file>`, persists one row per file with the reference + metadata.
- `GET /{id}/download` — permission-scoped stream (never a raw `documents?path=`).
- `deleteById` also removes the CMS file.

**SDK** (`api-modules-java`)
- `Attachments.storeUploads(master)` reads the servlet parts Spring's multipart resolver has **already parsed** — the controller is served by a Spring `@PostMapping`, which consumes the body before commons-fileupload could — so the generated controller only ever sees `Attachment`.

## Tests
- `EdmIntentGeneratorTest` asserts the injected metadata columns + the synthesized `Id` PK.
- `RecordAttachmentIT` drives the full HTTP round-trip (multipart upload → verbatim download → delete → gone) through the real multipart servlet path and tenant CMS.

## Depends on
- #6370 (CMS Attachments SDK) — **merged**.

Follow-up: Harmonia "Attachments" panel (`x-h-info-page` empty-state + file rows) rendering the `attachmentEntity` child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)