### PR TITLE
test(ui): fix DependsOnHarmoniaIT caption assertion (ORDERS -> Orders) broken by #6361

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/DependsOnHarmoniaTestProject.java
@@ -60,10 +60,11 @@ class DependsOnHarmoniaTestProject extends BaseTestProject {
         // equivalent of the AngularJS "Create" button).
         browser.clickOnElementWithText(HtmlElementType.BUTTON, "New");
 
-        // The form caption is the entity's (uppercased) human label - assert it resolved to a real
-        // value and not the literal "${ENTITYLABEL}" (the depends-on entities are hand-authored, so
-        // they carry no baked entityLabel; the generator must derive it).
-        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "ORDERS");
+        // The form caption is the entity's human label - assert it resolved to a real value and not
+        // the literal "${ENTITYLABEL}" (the depends-on entities are hand-authored, so they carry no
+        // baked entityLabel; the generator must derive it). The caption no longer force-uppercases
+        // (title styling unified with the document layout in #6361), so the resolved label is "Orders".
+        browser.assertElementExistsByTypeAndContainsText(HtmlElementType.SPAN, "Orders");
 
         // Pick Country = Bulgaria. The Harmonia x-h-select hides the bound <input id="f_Country">
         // and renders a visible <span role="combobox"> trigger whose text is the placeholder; click


### PR DESCRIPTION
### Problem

`master` is red — the `Build` workflow's integration-tests (h2 **and** postgresql) fail on:

```
DependsOnHarmoniaIT>PredefinedProjectIT.test:28
  Element by [By.tagName: span] and conditions [[exist, match text "ORDERS"]] cannot be found in any iframe.
Tests run: 203, Failures: 1
```

### Cause

#6361 (*unify page/record title styling*) rewrote the manage form-view caption from

```
x-text="T(..., '${entityLabel}').toUpperCase()"
```

to

```
x-text="T(..., '${entityLabel}')"
```

dropping the force-uppercase so the form caption matches the (non-uppercased) document-title style it was unified with. The rendered DOM text is now `Orders`, but `DependsOnHarmoniaTestProject` still asserted the old all-caps `ORDERS` (Selenide reads DOM text, not CSS), and the test was not updated in #6361. It is the **only** source assertion affected (verified by grep over `tests/**`).

### Fix

Assert the resolved human label `Orders`. The test's documented intent — that the generator *derives a real label* rather than leaving the raw `${ENTITYLABEL}` placeholder — is unchanged; `Orders` still proves resolution. Also refreshed the now-stale "(uppercased)" comment.

### Verification

`tests/tests-integrations` test-compiles. The full Selenide UI suite (~2h) was not re-run locally; the change is a deterministic string-literal correction matching the caption the current template emits (confirmed against the `form-view` and `document-view` templates on `master`).
