### PR TITLE
feat(harmonia): Attachments / Snapshot files panel (function:Attachment UI)

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/cms/Attachments.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/cms/Attachments.java
@@ -11,8 +11,15 @@ package org.eclipse.dirigible.sdk.cms;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.dirigible.components.api.cms.AttachmentsFacade;
+import org.eclipse.dirigible.components.api.http.HttpRequestFacade;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
 
 /**
  * Client SDK for record attachments: store an uploaded file against a master entity (into the
@@ -45,6 +52,36 @@ public final class Attachments {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to store attachment [" + fileName + "] for [" + masterEntity + "]", e);
         }
+    }
+
+    /**
+     * Parse the current multipart request and store every uploaded file as an attachment of the given
+     * master entity. Reads the servlet parts Spring's multipart resolver has already parsed (the
+     * generated controller is served by a Spring {@code @PostMapping}, which consumes the body before
+     * commons-fileupload could), so a generated controller only ever sees {@link Attachment}.
+     *
+     * @param masterEntity the owning entity type name
+     * @return the stored attachments, one per uploaded file (form fields ignored)
+     */
+    public static List<Attachment> storeUploads(String masterEntity) {
+        HttpServletRequest request = HttpRequestFacade.getRequest();
+        if (request == null) {
+            throw new IllegalStateException("No active request to read the upload for [" + masterEntity + "]");
+        }
+        List<Attachment> result = new ArrayList<>();
+        try {
+            for (Part part : request.getParts()) {
+                if (part.getSubmittedFileName() == null) {
+                    continue; // a plain form field, not a file
+                }
+                try (InputStream in = part.getInputStream()) {
+                    result.add(store(masterEntity, part.getSubmittedFileName(), part.getContentType(), in.readAllBytes()));
+                }
+            }
+        } catch (IOException | ServletException e) {
+            throw new IllegalStateException("Failed to read the upload for [" + masterEntity + "]", e);
+        }
+        return result;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -322,6 +322,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (entity.isMultilingual()) {
                 entityMap.put("multilingual", "true");
             }
+            // A file-attachment child: mark it so the generated controller emits the upload/download/
+            // delete verbs and the Harmonia master/document view renders it as an "Attachments" panel
+            // (a composition detail already, so the master-detail wiring is unchanged).
+            if (entity.isAttachment()) {
+                entityMap.put("attachmentEntity", "true");
+            }
             // Custom Java imports for the generated entity Repository (e.g. a calculated-field action's
             // CalculatedField class). Base64-encoded to match the EDM editor's serialization, which the
             // DAO template's parameterUtils decodes before emitting them into the import block.
@@ -336,6 +342,19 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             }
 
             List<Map<String, Object>> properties = new ArrayList<>();
+            // A file-attachment child (function: Attachment) is a first-class entity, but the author
+            // declares no fields at all (the file-metadata columns are injected below), so synthesize
+            // the generated integer primary key it still needs.
+            if (entity.isAttachment() && entity.getFields()
+                                               .stream()
+                                               .noneMatch(FieldIntent::isPrimaryKey)) {
+                FieldIntent id = new FieldIntent();
+                id.setName("id");
+                id.setType("integer");
+                id.setPrimaryKey(true);
+                id.setGenerated(true);
+                properties.add(propertyMap(name, id));
+            }
             for (FieldIntent field : entity.getFields()) {
                 if (field.getName() == null || field.getName()
                                                     .isBlank()) {
@@ -359,8 +378,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (triggerTargets.contains(name)) {
                 properties.add(processIdProperty(name));
             }
+            // A file-attachment child (function: Attachment) gets the standard file-metadata columns
+            // injected (like audit:) - the author never hand-writes plumbing; the upload sets them
+            // server-side. FileName is the row's display title; StoragePath is the CMS reference. The
+            // attachment is implicitly audited (who uploaded when).
+            boolean audited = entity.isAudited();
+            if (entity.isAttachment()) {
+                properties.addAll(attachmentProperties(name));
+                audited = true;
+            }
             // The four standard audit columns, populated by the platform's audit annotations downstream.
-            if (entity.isAudited()) {
+            if (audited) {
                 properties.addAll(auditProperties(name));
             }
             List<Map<String, Object>> relations = new ArrayList<>();
@@ -1434,6 +1462,45 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * The four standard audit columns (populated downstream by the {@code @CreatedAt}/etc.
      * annotations).
      */
+    /**
+     * The standard file-metadata columns injected into a {@code function: Attachment} child. The upload
+     * sets them server-side (so all read-only); FileName is the row's display title, StoragePath is the
+     * CMS reference the download route reads, Uuid is the per-upload folder key.
+     */
+    private static List<Map<String, Object>> attachmentProperties(String entityName) {
+        List<Map<String, Object>> props = new ArrayList<>();
+        props.add(attachmentProperty(entityName, "FileName", "VARCHAR", 255, true));
+        props.add(attachmentProperty(entityName, "ContentType", "VARCHAR", 255, false));
+        props.add(attachmentProperty(entityName, "FileSize", "BIGINT", 0, false));
+        props.add(attachmentProperty(entityName, "StoragePath", "VARCHAR", 1000, false));
+        props.add(attachmentProperty(entityName, "Uuid", "VARCHAR", 36, false));
+        return props;
+    }
+
+    /**
+     * One injected attachment metadata column: read-only (upload-set), {@code auditType=NONE};
+     * {@code major} controls whether it shows on the entity list (FileName does, the rest don't).
+     */
+    private static Map<String, Object> attachmentProperty(String entityName, String fieldName, String dataType, int length, boolean major) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("name", fieldName);
+        p.put("description", "");
+        p.put("tooltip", "");
+        p.put("dataName", IntentNaming.upperSnake(entityName) + "_" + IntentNaming.upperSnake(fieldName));
+        p.put("dataType", dataType);
+        p.put("dataNullable", "true");
+        if (length > 0) {
+            p.put("dataLength", Integer.toString(length));
+        }
+        p.put("auditType", "NONE");
+        p.put("isReadOnlyProperty", "true");
+        p.put("widgetType", widgetForType(dataType));
+        p.put("widgetSize", "");
+        p.put("widgetLength", length > 0 ? Integer.toString(length) : "20");
+        p.put("widgetIsMajor", major ? "true" : "false");
+        return p;
+    }
+
     private static List<Map<String, Object>> auditProperties(String entityName) {
         List<Map<String, Object>> audit = new ArrayList<>();
         audit.add(auditProperty(entityName, "CreatedAt", "TIMESTAMP", "CREATED_AT", 0));

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -290,6 +290,16 @@ public class EntityIntent {
         return functionIs("DocumentItem");
     }
 
+    /**
+     * Whether this entity is a file-attachment child ({@code function: Attachment}) - a composition
+     * detail of its master holding one uploaded file's metadata (the bytes live in the CMS). The EDM
+     * generator injects the standard attachment columns; the generated controller and Harmonia view
+     * render it as an "Attachments" section.
+     */
+    public boolean isAttachment() {
+        return functionIs("Attachment");
+    }
+
     public String getDescription() {
         return description;
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -86,7 +86,7 @@ public final class IntentParser {
     private static final Set<String> RELATION_KINDS = Set.of("oneToMany", "manyToOne", "oneToOne", "manyToMany");
     /** Implemented entity {@code function} values (lower-cased), selecting the entity's UI template. */
     private static final Set<String> ENTITY_FUNCTIONS =
-            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar");
+            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment");
     /**
      * Entity {@code function} values whose template is reserved but not yet shipped (gated with a
      * message).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -123,6 +123,57 @@ class EdmIntentGeneratorTest {
     }
 
     @Test
+    void attachmentChildInjectsFileMetadataAndIsMarked() {
+        String yaml = """
+                name: docs
+                entities:
+                  - name: Company
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: CompanyAttachment
+                    function: Attachment
+                    fields:
+                      - { name: category, type: string, length: 50 }
+                    relations:
+                      - { name: Company, kind: manyToOne, to: Company, composition: true, required: true }
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "docs");
+        List<Map<String, Object>> entities = entities(model);
+        Map<String, Object> att = entityByName(entities, "CompanyAttachment");
+
+        // Marked for the generated controller (upload/download verbs) + the Harmonia Attachments panel;
+        // it stays a composition detail of its master (the master-detail wiring is unchanged).
+        assertEquals("true", att.get("attachmentEntity"));
+        assertEquals("MANAGE_DETAILS", att.get("layoutType"));
+
+        // The standard file-metadata columns are injected (upload-set -> read-only); FileName is the
+        // row's display title (shown on the list), StoragePath is the internal CMS reference.
+        assertEquals("VARCHAR", propertyByName(att, "FileName").get("dataType"));
+        assertEquals("true", propertyByName(att, "FileName").get("isReadOnlyProperty"));
+        assertEquals("true", propertyByName(att, "FileName").get("widgetIsMajor"));
+        assertEquals("BIGINT", propertyByName(att, "FileSize").get("dataType"));
+        assertEquals("false", propertyByName(att, "StoragePath").get("widgetIsMajor"));
+        assertNotNull(propertyByName(att, "ContentType"));
+        assertNotNull(propertyByName(att, "Uuid"));
+        // Implicitly audited - who uploaded when.
+        assertEquals("CREATED_AT", propertyByName(att, "CreatedAt").get("auditType"));
+        // Author-declared domain field preserved alongside the injected ones.
+        assertNotNull(propertyByName(att, "Category"));
+
+        // The author declares no primary key on an attachment child, so a generated integer Id is
+        // synthesized (auto-increment) - otherwise the generated entity/controller would have no PK.
+        Map<String, Object> id = propertyByName(att, "Id");
+        assertEquals("true", id.get("dataPrimaryKey"));
+        assertEquals("INTEGER", id.get("dataType"));
+        assertEquals("true", id.get("dataAutoIncrement"));
+
+        // A plain (non-attachment) entity carries no marker.
+        assertNull(entityByName(entities, "Company").get("attachmentEntity"));
+    }
+
+    @Test
     void dependsOnEmitsWidgetAttributesWithPrimaryKeyDefaults() {
         String yaml = """
                 name: shop

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/components/detailPanel.js
@@ -27,6 +27,14 @@
  * table: the same master-filtered rows become events; event-click edits the child, date-click
  * creates one with the master FK AND the clicked date preset. An empty month is meaningful, so a
  * calendar panel shows the calendar even with zero rows.
+ *
+ * A def carrying `files: { readOnly }` (a composition child declared `function: Attachment` or
+ * `function: Snapshot`) renders as a Files panel instead of the table: the master-filtered rows are
+ * uploaded files, each downloadable via the controller's `/{id}/download` route. Editable (Attachment):
+ * an Upload control adds files (multipart POST to `/upload`) and each row can be removed. Read-only
+ * (Snapshot): download only — no upload, no delete (copies are generated server-side, e.g. on issue).
+ * Like a calendar, a files panel always renders (its empty state is meaningful), never the shared
+ * "no records" line.
  */
 function detailPanel(def, masterId) {
   return {
@@ -39,6 +47,8 @@ function detailPanel(def, masterId) {
     deleteOpen: false,
     deleteTarget: null,
     deleteBusy: false,
+    uploading: false,     // files defs only
+    fileError: null,
     // Reactive config for the embedded x-h-calendar (calendar defs only); rebuilt on every load.
     calCfg: { view: (def.calendar && def.calendar.view) || 'month', events: [] },
 
@@ -111,6 +121,10 @@ function detailPanel(def, masterId) {
         this.rows = await App.services.api.getAll(this.def.apiPath + q);
         if (this.def.calendar) {
           this.calCfg = { view: this.def.calendar.view || 'month', events: this.buildEvents() };
+          this.state = 'default';
+        } else if (this.def.files) {
+          // A files panel always renders (its empty state carries the upload prompt / "generated on
+          // issue" note), so it never falls back to the shared "no records" line.
           this.state = 'default';
         } else {
           this.state = this.rows.length === 0 ? 'empty' : 'default';
@@ -223,6 +237,51 @@ function detailPanel(def, masterId) {
         q += '&' + encodeURIComponent(cal.start) + '=' + encodeURIComponent(val);
       }
       window.PineconeRouter.navigate('/' + this.def.entity + '/create' + q);
+    },
+
+    // --- files panel (files defs only) ----------------------------------------------------------
+    // Read-only (Snapshot): download only. Editable (Attachment): upload + remove.
+    get filesReadOnly() { return !!(this.def.files && this.def.files.readOnly); },
+
+    // Absolute URL of the controller's download route (a plain browser GET, not the fetch client):
+    // apiPath is relative to restBase, so prepend it once. The row's own id keys the file.
+    downloadHref(row) {
+      const base = (App.config && App.config.restBase) || '';
+      return base + this.def.apiPath + '/' + encodeURIComponent(row[this.def.primaryKey]) + '/download';
+    },
+
+    // Human-readable size from the injected FileSize column (bytes).
+    fileSizeText(row) {
+      const n = Number(row.FileSize);
+      if (!isFinite(n) || n <= 0) return '';
+      const units = ['B', 'KB', 'MB', 'GB'];
+      let v = n, i = 0;
+      while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+      return (i === 0 ? v : v.toFixed(1)) + ' ' + units[i];
+    },
+
+    // Multipart upload of the picked files to the controller's /upload route (master FK query),
+    // then reload. FormData bodies are sent as-is by the api client (browser sets the boundary).
+    async uploadFiles(fileList) {
+      const files = Array.from(fileList || []);
+      if (!files.length || this.masterId == null) return;
+      this.uploading = true;
+      this.fileError = null;
+      try {
+        const fd = new FormData();
+        files.forEach(f => fd.append('file', f, f.name));
+        const q = '?' + encodeURIComponent(this.def.masterEntityId) + '=' + encodeURIComponent(this.masterId);
+        await App.services.api.post(this.def.apiPath + '/upload' + q, fd);
+        await this.load();
+      } catch (e) {
+        this.fileError = App.services.apiErrors.messageFor(e, 'Upload failed.');
+      } finally {
+        this.uploading = false;
+      }
+    },
+    onFilePick(e) {
+      this.uploadFiles(e.target.files);
+      e.target.value = ''; // allow re-picking the same file
     },
 
     askDelete(row) { this.deleteTarget = row; this.deleteOpen = true; },

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/api.js
@@ -89,10 +89,15 @@ App.services.api = {
   async request(method, url, body, opts = {}) {
     const baseUrl = this.resolveBaseUrl(opts);
 
+    // A FormData body is a multipart upload: send it as-is and let the browser set the
+    // Content-Type (with its boundary) — never JSON-encode it or override the header.
+    const isForm = (typeof FormData !== 'undefined') && (body instanceof FormData);
+
     // X-Requested-With marks the call as programmatic for browsers without Sec-Fetch-Mode: the
     // server then answers an expired session with a PLAIN 401 (no Basic challenge), so the
     // browser's native login dialog never pops over a background poll.
-    const headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
+    const headers = { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest' };
+    if (!isForm) headers['Content-Type'] = 'application/json';
     const language = this.language();
     if (language) headers['Accept-Language'] = language;
 
@@ -101,7 +106,7 @@ App.services.api = {
       r = await fetch(`${baseUrl}${url}`, {
         method,
         headers,
-        body: body ? JSON.stringify(body) : undefined,
+        body: body ? (isForm ? body : JSON.stringify(body)) : undefined,
         credentials: 'same-origin'
       });
     } catch (e) {

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -132,6 +132,52 @@ public class ${name}Controller {
 #end
         return repository.save(entity);
     }
+#if($attachmentEntity)
+
+    @Post("/upload")
+    @Documentation("Upload one or more files as ${name} attachments (multipart/form-data)")
+    public List<${name}Entity> upload(@QueryParam("${masterEntityId}") Integer ${masterEntityId}) {
+#if($needsRoles)
+        checkPermissions("write");
+#end
+        if (!org.eclipse.dirigible.sdk.http.Upload.isMultipartContent()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The request must be multipart/form-data");
+        }
+        List<${name}Entity> uploaded = new java.util.ArrayList<>();
+        // The SDK parses the multipart request and stores each file in the tenant CMS at
+        // /Attachments/${name}/<yyyy>/<MM>/<uuid>/<file> (the multipart/FileItem handling stays inside
+        // the SDK); we persist one row per file with the returned reference + metadata. Auth above.
+        for (org.eclipse.dirigible.sdk.cms.Attachments.Attachment stored : org.eclipse.dirigible.sdk.cms.Attachments.storeUploads("${name}")) {
+            ${name}Entity entity = new ${name}Entity();
+            entity.FileName = stored.fileName();
+            entity.ContentType = stored.contentType();
+            entity.FileSize = stored.size();
+            entity.StoragePath = stored.path();
+            entity.Uuid = stored.uuid();
+            entity.${masterEntityId} = ${masterEntityId};
+            uploaded.add(repository.save(entity));
+        }
+        return uploaded;
+    }
+
+    @Get("/{id}/download")
+    @Documentation("Download the ${name} attachment file")
+    public void download(@PathParam("id") #foreach($property in $properties)#if($property.dataPrimaryKey)${property.dataTypeJavaClass}#end#end id) {
+#if($needsRoles)
+        checkPermissions("read");
+#end
+        ${name}Entity entity = repository.findOne(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "${name} not found"));
+        org.eclipse.dirigible.sdk.http.Response.setContentType(entity.ContentType != null ? entity.ContentType : "application/octet-stream");
+        org.eclipse.dirigible.sdk.http.Response.setHeader("Content-Disposition", "attachment; filename=\"" + entity.FileName + "\"");
+        try (java.io.InputStream in = org.eclipse.dirigible.sdk.cms.Attachments.open(entity.StoragePath);
+                java.io.OutputStream out = org.eclipse.dirigible.sdk.http.Response.getOutputStream()) {
+            in.transferTo(out);
+        } catch (java.io.IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to stream the attachment", e);
+        }
+    }
+#end
 
     @Put("/{id}")
     @Documentation("Update ${name} by id")
@@ -173,8 +219,18 @@ public class ${name}Controller {
 #if($immutableStatusProperty || $immutableAlways)
         requireMutable(id);
 #end
+#if($attachmentEntity)
+        String storagePath = repository.findOne(id)
+                                       .map(a -> a.StoragePath)
+                                       .orElse(null);
+#end
         try {
             repository.deleteById(id);
+#if($attachmentEntity)
+            if (storagePath != null) {
+                org.eclipse.dirigible.sdk.cms.Attachments.delete(storagePath);
+            }
+#end
         } catch (RuntimeException e) {
             // A foreign-key violation means other records still reference this one - a data-integrity
             // conflict the user can act on, not a server error.

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -290,7 +290,7 @@
       <div x-data="detailPanel({...d, returnTo: '/${name}/' + id + (isPreview ? '/preview' : '/edit')}, id)" x-h-card class="w-full">
         <div x-h-card-header>
           <h3 x-h-card-title x-text="T(d.tkey, d.label)"></h3>
-          <div x-h-card-action x-show="masterId && !isPreview">
+          <div x-h-card-action x-show="masterId && !isPreview && !def.files">
             <button x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
           </div>
         </div>
@@ -306,7 +306,52 @@
               <div x-h-calendar="calCfg" style="height: 420px" @event-click="onEventClick" @date-click="onDateClick"></div>
             </div>
           </template>
-          <template x-if="!def.calendar">
+#set($dollar = '$')
+          <!-- A files detail (function: Attachment / Snapshot): download always; upload + remove only
+               when editable (not preview) and not a read-only Snapshot. ${dollar}refs is escaped so
+               Velocity leaves the Alpine ref alone. -->
+          <template x-if="def.files">
+            <div x-show="state === 'default'" class="vbox gap-3">
+              <div x-show="fileError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="fileError"></div></div>
+              <template x-if="masterId &amp;&amp; !isPreview &amp;&amp; !filesReadOnly">
+                <div class="hbox items-center gap-2">
+                  <input type="file" multiple class="hidden" x-ref="fileInput" @change="onFilePick(${dollar}event)" :disabled="uploading" />
+                  <button type="button" x-h-button data-variant="outline" data-size="sm" :disabled="uploading" @click="${dollar}refs.fileInput.click()">
+                    <span x-show="uploading" x-h-spinner></span>
+                    <i x-show="!uploading" role="img" x-h-lucide data-lucide="upload"></i>
+                    <span x-text="uploading ? T('$projectName:${tprefix}.defaults.uploading', 'Uploading…') : T('$projectName:${tprefix}.defaults.upload', 'Upload')"></span>
+                  </button>
+                </div>
+              </template>
+              <template x-if="rows.length === 0">
+                <div x-h-info-page>
+                  <div x-h-info-page-header>
+                    <div x-h-info-page-media.icon><i role="img" x-h-lucide data-lucide="paperclip"></i></div>
+                    <div x-h-info-page-title x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopies', 'No copies yet') : T('$projectName:${tprefix}.messages.noFiles', 'No attachments')"></div>
+                    <div x-h-info-page-description x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopiesHint', 'A copy is stored automatically when the document is issued.') : T('$projectName:${tprefix}.messages.noFilesHint', 'Upload files to attach them to this document.')"></div>
+                  </div>
+                </div>
+              </template>
+              <template x-if="rows.length > 0">
+                <div class="vbox gap-2">
+                  <template x-for="row in rows" :key="row[def.primaryKey]">
+                    <div x-h-card class="hbox items-center gap-3 p-3">
+                      <i role="img" x-h-lucide data-lucide="file-text" class="shrink-0"></i>
+                      <div class="vbox gap-0 grow min-w-0">
+                        <span class="text-sm truncate" x-text="row.FileName"></span>
+                        <span class="text-xs text-muted-foreground" x-text="fileSizeText(row)"></span>
+                      </div>
+                      <a x-h-button data-variant="transparent" data-size="sm" :href="downloadHref(row)" target="_blank" rel="noopener" aria-label="Download"><i role="img" x-h-lucide data-lucide="download"></i></a>
+                      <template x-if="!isPreview &amp;&amp; !filesReadOnly">
+                        <button type="button" x-h-button data-variant="transparent" data-size="sm" @click="askDelete(row)" aria-label="Remove"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </template>
+            </div>
+          </template>
+          <template x-if="!def.calendar &amp;&amp; !def.files">
           <div x-show="state === 'default'" x-h-table-container.scroll style="max-height: 320px">
             <table x-h-table data-borders="rows">
               <thead x-h-table-header>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -218,7 +218,7 @@
         <div x-data="detailPanel({...d, returnTo: '/${name}/' + id + (isPreview ? '/preview' : '/edit')}, id)" x-h-card>
           <div x-h-card-header>
             <h3 x-h-card-title x-text="d.label"></h3>
-            <div x-h-card-action x-show="!isPreview">
+            <div x-h-card-action x-show="!isPreview && !def.files">
               <button type="button" x-h-button data-variant="primary" data-size="sm" @click="addRow()"><i role="img" x-h-lucide data-lucide="plus"></i><span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span></button>
             </div>
           </div>
@@ -234,7 +234,52 @@
                 <div x-h-calendar="calCfg" style="height: 420px" @event-click="onEventClick" @date-click="onDateClick"></div>
               </div>
             </template>
-            <template x-if="!def.calendar">
+#set($dollar = '$')
+            <!-- A files detail (function: Attachment / Snapshot): download always; upload + remove
+                 only when editable (not preview) and not a read-only Snapshot (copies are generated
+                 server-side). $refs is escaped (${dollar}refs) so Velocity leaves the Alpine ref alone. -->
+            <template x-if="def.files">
+              <div x-show="state === 'default'" class="vbox gap-3">
+                <div x-show="fileError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="fileError"></div></div>
+                <template x-if="!isPreview &amp;&amp; !filesReadOnly">
+                  <div class="hbox items-center gap-2">
+                    <input type="file" multiple class="hidden" x-ref="fileInput" @change="onFilePick(${dollar}event)" :disabled="uploading" />
+                    <button type="button" x-h-button data-variant="outline" data-size="sm" :disabled="uploading" @click="${dollar}refs.fileInput.click()">
+                      <span x-show="uploading" x-h-spinner></span>
+                      <i x-show="!uploading" role="img" x-h-lucide data-lucide="upload"></i>
+                      <span x-text="uploading ? T('$projectName:${tprefix}.defaults.uploading', 'Uploading…') : T('$projectName:${tprefix}.defaults.upload', 'Upload')"></span>
+                    </button>
+                  </div>
+                </template>
+                <template x-if="rows.length === 0">
+                  <div x-h-info-page>
+                    <div x-h-info-page-header>
+                      <div x-h-info-page-media.icon><i role="img" x-h-lucide data-lucide="paperclip"></i></div>
+                      <div x-h-info-page-title x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopies', 'No copies yet') : T('$projectName:${tprefix}.messages.noFiles', 'No attachments')"></div>
+                      <div x-h-info-page-description x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopiesHint', 'A copy is stored automatically when the document is issued.') : T('$projectName:${tprefix}.messages.noFilesHint', 'Upload files to attach them to this record.')"></div>
+                    </div>
+                  </div>
+                </template>
+                <template x-if="rows.length > 0">
+                  <div class="vbox gap-2">
+                    <template x-for="row in rows" :key="row[def.primaryKey]">
+                      <div x-h-card class="hbox items-center gap-3 p-3">
+                        <i role="img" x-h-lucide data-lucide="file-text" class="shrink-0"></i>
+                        <div class="vbox gap-0 grow min-w-0">
+                          <span class="text-sm truncate" x-text="row.FileName"></span>
+                          <span class="text-xs text-muted-foreground" x-text="fileSizeText(row)"></span>
+                        </div>
+                        <a x-h-button data-variant="transparent" data-size="sm" :href="downloadHref(row)" target="_blank" rel="noopener" aria-label="Download"><i role="img" x-h-lucide data-lucide="download"></i></a>
+                        <template x-if="!isPreview &amp;&amp; !filesReadOnly">
+                          <button type="button" x-h-button data-variant="transparent" data-size="sm" @click="askDelete(row)" aria-label="Remove"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
+                        </template>
+                      </div>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+            <template x-if="!def.calendar &amp;&amp; !def.files">
             <div x-show="state === 'default'" x-h-table-container.scroll style="max-height: 320px">
               <table x-h-table data-borders="rows">
                 <thead x-h-table-header>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/detail-register.js.template
@@ -36,6 +36,12 @@ App.registerDetail('${masterEntity}', {
   // composition child); the shared detailPanel maps the rows to events by these properties.
   calendar: { start: '${calendarStartProperty}'#if($calendarEndProperty), end: '${calendarEndProperty}'#end#if($calendarTitleProperty), title: '${calendarTitleProperty}'#end#if($calendarColorProperty), color: '${calendarColorProperty}'#end, view: '${calendarInitialView}', range: #if($calendarRange)true#{else}false#end },
 #end
+#if($attachmentEntity)
+  // Rendered as a Files panel (function: Attachment / Snapshot): the shared detailPanel lists the
+  // uploaded files with download, and — unless read-only — an upload control + per-file remove.
+  // Read-only (a generated Snapshot child) shows download only. See detailPanel `files`.
+  files: { readOnly: #if($attachmentReadOnly)true#{else}false#end },
+#end
   columns: [
 #foreach($property in $properties)
 #if(!$property.dataAutoIncrement && $property.widgetIsMajor && $property.name != $masterEntityId)

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -186,7 +186,36 @@
                   <div x-h-calendar="calCfg" style="height: 420px" @event-click="onEventClick" @date-click="onDateClick"></div>
                 </div>
               </template>
-              <template x-if="!def.calendar">
+              <!-- A files detail (function: Attachment / Snapshot) on the read-only browse pane: the
+                   files are downloadable here; upload/remove happen on the record's Edit form. -->
+              <template x-if="def.files">
+                <div x-show="state === 'default'" class="vbox gap-3">
+                  <template x-if="rows.length === 0">
+                    <div x-h-info-page>
+                      <div x-h-info-page-header>
+                        <div x-h-info-page-media.icon><i role="img" x-h-lucide data-lucide="paperclip"></i></div>
+                        <div x-h-info-page-title x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopies', 'No copies yet') : T('$projectName:${tprefix}.messages.noFiles', 'No attachments')"></div>
+                        <div x-h-info-page-description x-text="filesReadOnly ? T('$projectName:${tprefix}.messages.noCopiesHint', 'A copy is stored automatically when the document is issued.') : T('$projectName:${tprefix}.messages.noFilesHint', 'Files are managed from the record’s Edit form.')"></div>
+                      </div>
+                    </div>
+                  </template>
+                  <template x-if="rows.length > 0">
+                    <div class="vbox gap-2">
+                      <template x-for="row in rows" :key="row[def.primaryKey]">
+                        <div x-h-card class="hbox items-center gap-3 p-3">
+                          <i role="img" x-h-lucide data-lucide="file-text" class="shrink-0"></i>
+                          <div class="vbox gap-0 grow min-w-0">
+                            <span class="text-sm truncate" x-text="row.FileName"></span>
+                            <span class="text-xs text-muted-foreground" x-text="fileSizeText(row)"></span>
+                          </div>
+                          <a x-h-button data-variant="transparent" data-size="sm" :href="downloadHref(row)" target="_blank" rel="noopener" aria-label="Download"><i role="img" x-h-lucide data-lucide="download"></i></a>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </template>
+              <template x-if="!def.calendar &amp;&amp; !def.files">
               <div x-show="state === 'default'" x-h-table-container.scroll style="max-height: 320px">
                 <table x-h-table data-borders="rows">
                   <thead x-h-table-header>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RecordAttachmentIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/RecordAttachmentIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end test for record attachments (the {@code sdk.cms.Attachments} SDK backing the generated
+ * {@code function: Attachment} controllers). Drops a small client-Java {@code @Controller} that
+ * calls {@code Attachments.storeUploads/open/delete} straight into the registry, force-syncs it,
+ * then drives a full HTTP round-trip: multipart upload -> download the stored bytes verbatim ->
+ * delete -> the file is gone. Exercises the real Spring multipart servlet path (the reason
+ * {@code storeUploads} reads the already-parsed {@code getParts()} rather than commons-fileupload)
+ * and the real tenant CMS.
+ */
+class RecordAttachmentIT extends IntegrationTest {
+
+    /** Project segment used for the controller source. */
+    private static final String PROJECT = "attachment-it";
+
+    /** Registry-relative source path. */
+    private static final String SOURCE_LOCATION = "/" + PROJECT + "/api/AttachmentsTestController.java";
+
+    /** Fully-qualified path under the registry root. */
+    private static final String REGISTRY_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + SOURCE_LOCATION;
+
+    /** Base URL of the controller (derived from project + package + class name). */
+    private static final String BASE = "/services/java/" + PROJECT + "/api/AttachmentsTestController";
+
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void upload_download_delete_roundTrip() {
+        writeAndSync(controllerSource());
+        String content = "hello attachment round-trip";
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+
+        restAssuredExecutor.execute(() -> {
+            // Upload a single file -> one stored attachment with its metadata and a CMS storage path.
+            String path = given().multiPart("file", "note.txt", bytes, "text/plain")
+                                 .when()
+                                 .post(BASE + "/upload")
+                                 .then()
+                                 .statusCode(200)
+                                 .body("[0].fileName", equalTo("note.txt"))
+                                 .body("[0].contentType", equalTo("text/plain"))
+                                 .body("[0].size", equalTo(bytes.length))
+                                 .body("[0].path", notNullValue())
+                                 .body("[0].path", startsWith("/Attachments/TestDoc/"))
+                                 .extract()
+                                 .path("[0].path");
+
+            // Download -> the stored bytes come back verbatim.
+            given().queryParam("path", path)
+                   .when()
+                   .get(BASE + "/download")
+                   .then()
+                   .statusCode(200)
+                   .body(equalTo(content));
+
+            // Delete -> the CMS file is removed, so a subsequent open no longer succeeds.
+            given().queryParam("path", path)
+                   .when()
+                   .delete(BASE + "/remove")
+                   .then()
+                   .statusCode(200);
+
+            given().queryParam("path", path)
+                   .when()
+                   .get(BASE + "/download")
+                   .then()
+                   .statusCode(anyOf(equalTo(404), equalTo(500)));
+        }, ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @AfterEach
+    void removeArtefactFromRegistry() {
+        if (repository.hasResource(REGISTRY_PATH)) {
+            repository.removeResource(REGISTRY_PATH);
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private void writeAndSync(String source) {
+        repository.createResource(REGISTRY_PATH, source.getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+    }
+
+    private static String controllerSource() {
+        return """
+                package api;
+
+                import java.io.InputStream;
+                import java.io.OutputStream;
+                import java.util.List;
+
+                import org.eclipse.dirigible.sdk.cms.Attachments;
+                import org.eclipse.dirigible.sdk.http.Controller;
+                import org.eclipse.dirigible.sdk.http.Delete;
+                import org.eclipse.dirigible.sdk.http.Get;
+                import org.eclipse.dirigible.sdk.http.Post;
+                import org.eclipse.dirigible.sdk.http.QueryParam;
+                import org.eclipse.dirigible.sdk.http.Response;
+
+                @Controller
+                public class AttachmentsTestController {
+
+                    @Post("/upload")
+                    public List<Attachments.Attachment> upload() {
+                        return Attachments.storeUploads("TestDoc");
+                    }
+
+                    @Get("/download")
+                    public void download(@QueryParam("path") String path) {
+                        Response.setHeader("Content-Disposition", "attachment");
+                        try (InputStream in = Attachments.open(path); OutputStream out = Response.getOutputStream()) {
+                            in.transferTo(out);
+                        } catch (java.io.IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    @Delete("/remove")
+                    public void remove(@QueryParam("path") String path) {
+                        Attachments.delete(path);
+                    }
+                }
+                """;
+    }
+
+}


### PR DESCRIPTION
UI half of record attachments: a `function: Attachment` (and forthcoming `function: Snapshot`) composition child renders as a Files panel instead of a row table. Backend #6371, SDK #6370 (merged).

> **Stacked on #6371.** Until #6371 merges, this diff also shows its 7 backend files; the PR-4-specific change is the 6 UI files (application-core detailPanel/api + 4 Harmonia templates). Rebase to a clean 6-file diff once #6371 lands.

**Shared runtime (application-core):** detailPanel gains a `files` mode (parallel to `calendar`) — master-filtered list + per-file Download; unless read-only, an Upload control (multipart POST /upload) + per-file Remove (reuses detail delete, which drops the CMS file). api client sends a FormData body as-is (browser sets the boundary) instead of JSON-encoding.

**Harmonia templates:** detail-register emits `files: { readOnly: <attachmentReadOnly> }`; form-view/document-view (editable) + master-view (read-only browse) render an x-h-info-page empty state + file cards gated on `def.files` (row table + Add suppressed). $refs is ${dollar}-escaped for Velocity.

**Verified** end-to-end on a generated CompanyAttachment (upload → master-filtered list → verbatim download → remove). Read-only Snapshot branch in place, activates with the `attachmentReadOnly` marker.

Depends on #6371 + #6370 (merged). Follow-up: `function: Snapshot` + DOCUMENT_VERSION widget + server-side print render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)