### PR TITLE
feat(intent): function: Snapshot — generated read-only versioned record copies

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -322,11 +322,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (entity.isMultilingual()) {
                 entityMap.put("multilingual", "true");
             }
-            // A file-attachment child: mark it so the generated controller emits the upload/download/
-            // delete verbs and the Harmonia master/document view renders it as an "Attachments" panel
-            // (a composition detail already, so the master-detail wiring is unchanged).
-            if (entity.isAttachment()) {
+            // A file-child: mark it so the generated controller emits the download (and, when editable,
+            // upload/delete) verbs and the Harmonia master/document view renders it as a Files panel
+            // (a composition detail already, so the master-detail wiring is unchanged). A Snapshot is
+            // read-only - copies are generated server-side, never uploaded or deleted by the user - so
+            // it also carries attachmentReadOnly, which suppresses the upload verb and the panel's
+            // upload/remove controls (download + list only).
+            if (entity.isFileChild()) {
                 entityMap.put("attachmentEntity", "true");
+                if (entity.isSnapshot()) {
+                    entityMap.put("attachmentReadOnly", "true");
+                }
             }
             // Custom Java imports for the generated entity Repository (e.g. a calculated-field action's
             // CalculatedField class). Base64-encoded to match the EDM editor's serialization, which the
@@ -342,12 +348,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             }
 
             List<Map<String, Object>> properties = new ArrayList<>();
-            // A file-attachment child (function: Attachment) is a first-class entity, but the author
+            // A file-child (function: Attachment or Snapshot) is a first-class entity, but the author
             // declares no fields at all (the file-metadata columns are injected below), so synthesize
             // the generated integer primary key it still needs.
-            if (entity.isAttachment() && entity.getFields()
-                                               .stream()
-                                               .noneMatch(FieldIntent::isPrimaryKey)) {
+            if (entity.isFileChild() && entity.getFields()
+                                              .stream()
+                                              .noneMatch(FieldIntent::isPrimaryKey)) {
                 FieldIntent id = new FieldIntent();
                 id.setName("id");
                 id.setType("integer");
@@ -378,13 +384,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (triggerTargets.contains(name)) {
                 properties.add(processIdProperty(name));
             }
-            // A file-attachment child (function: Attachment) gets the standard file-metadata columns
-            // injected (like audit:) - the author never hand-writes plumbing; the upload sets them
-            // server-side. FileName is the row's display title; StoragePath is the CMS reference. The
-            // attachment is implicitly audited (who uploaded when).
+            // A file-child (function: Attachment or Snapshot) gets the standard file-metadata columns
+            // injected (like audit:) - the author never hand-writes plumbing; the upload (attachment) or
+            // the generator (snapshot) sets them server-side. FileName is the row's display title;
+            // StoragePath is the CMS reference. Implicitly audited (who created it when). A Snapshot also
+            // carries a Version - the copy's sequence within its master (DOCUMENT_VERSION widget).
             boolean audited = entity.isAudited();
-            if (entity.isAttachment()) {
+            if (entity.isFileChild()) {
                 properties.addAll(attachmentProperties(name));
+                if (entity.isSnapshot()) {
+                    properties.add(versionProperty(name));
+                }
                 audited = true;
             }
             // The four standard audit columns, populated by the platform's audit annotations downstream.
@@ -1498,6 +1508,29 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         p.put("widgetSize", "");
         p.put("widgetLength", length > 0 ? Integer.toString(length) : "20");
         p.put("widgetIsMajor", major ? "true" : "false");
+        return p;
+    }
+
+    /**
+     * The {@code Version} column injected into a {@code function: Snapshot} child - the copy's sequence
+     * within its master (1, 2, 3 as a document is re-issued after amendment). Read-only (the generator
+     * sets it), shown on the list/panel (major), and carries the {@code DOCUMENT_VERSION} widget so
+     * forms and print templates can treat it specifically (e.g. a version badge).
+     */
+    private static Map<String, Object> versionProperty(String entityName) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("name", "Version");
+        p.put("description", "");
+        p.put("tooltip", "");
+        p.put("dataName", IntentNaming.upperSnake(entityName) + "_VERSION");
+        p.put("dataType", "INTEGER");
+        p.put("dataNullable", "true");
+        p.put("auditType", "NONE");
+        p.put("isReadOnlyProperty", "true");
+        p.put("widgetType", "DOCUMENT_VERSION");
+        p.put("widgetSize", "");
+        p.put("widgetLength", "20");
+        p.put("widgetIsMajor", "true");
         return p;
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -300,6 +300,24 @@ public class EntityIntent {
         return functionIs("Attachment");
     }
 
+    /**
+     * Whether this entity is a generated-copy child ({@code function: Snapshot}) - a composition detail
+     * holding one system-generated, immutable, versioned file (e.g. the printed invoice stored on
+     * issue). Like an attachment it carries the standard file-metadata columns and renders in the Files
+     * panel, but read-only (download + list only; created server-side, never uploaded or deleted by the
+     * user) and with an added {@code Version} column.
+     */
+    public boolean isSnapshot() {
+        return functionIs("Snapshot");
+    }
+
+    /**
+     * Whether this entity is any file-child kind (attachment or snapshot) - shares metadata injection.
+     */
+    public boolean isFileChild() {
+        return isAttachment() || isSnapshot();
+    }
+
     public String getDescription() {
         return description;
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -86,7 +86,7 @@ public final class IntentParser {
     private static final Set<String> RELATION_KINDS = Set.of("oneToMany", "manyToOne", "oneToOne", "manyToMany");
     /** Implemented entity {@code function} values (lower-cased), selecting the entity's UI template. */
     private static final Set<String> ENTITY_FUNCTIONS =
-            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment");
+            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment", "snapshot");
     /**
      * Entity {@code function} values whose template is reserved but not yet shipped (gated with a
      * message).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -171,6 +171,49 @@ class EdmIntentGeneratorTest {
 
         // A plain (non-attachment) entity carries no marker.
         assertNull(entityByName(entities, "Company").get("attachmentEntity"));
+        // An attachment is editable (not read-only).
+        assertNull(att.get("attachmentReadOnly"));
+    }
+
+    @Test
+    void snapshotChildIsReadOnlyWithVersionAndFileMetadata() {
+        String yaml = """
+                name: docs
+                entities:
+                  - name: SalesInvoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                  - name: SalesInvoiceCopy
+                    function: Snapshot
+                    relations:
+                      - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "docs");
+        List<Map<String, Object>> entities = entities(model);
+        Map<String, Object> snap = entityByName(entities, "SalesInvoiceCopy");
+
+        // Marked as a file child AND read-only (copies are generated server-side, never uploaded/deleted).
+        assertEquals("true", snap.get("attachmentEntity"));
+        assertEquals("true", snap.get("attachmentReadOnly"));
+        assertEquals("MANAGE_DETAILS", snap.get("layoutType"));
+
+        // Same injected file metadata as an attachment...
+        assertEquals("VARCHAR", propertyByName(snap, "FileName").get("dataType"));
+        assertEquals("true", propertyByName(snap, "FileName").get("isReadOnlyProperty"));
+        assertNotNull(propertyByName(snap, "StoragePath"));
+        assertNotNull(propertyByName(snap, "Uuid"));
+        // ...plus the synthesized generated Id...
+        assertEquals("true", propertyByName(snap, "Id").get("dataPrimaryKey"));
+        // ...plus a read-only, major Version carrying the DOCUMENT_VERSION widget.
+        Map<String, Object> version = propertyByName(snap, "Version");
+        assertEquals("INTEGER", version.get("dataType"));
+        assertEquals("DOCUMENT_VERSION", version.get("widgetType"));
+        assertEquals("true", version.get("isReadOnlyProperty"));
+        assertEquals("true", version.get("widgetIsMajor"));
+        // Implicitly audited.
+        assertEquals("CREATED_AT", propertyByName(snap, "CreatedAt").get("auditType"));
     }
 
     @Test

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -133,6 +133,7 @@ public class ${name}Controller {
         return repository.save(entity);
     }
 #if($attachmentEntity)
+#if(!$attachmentReadOnly)
 
     @Post("/upload")
     @Documentation("Upload one or more files as ${name} attachments (multipart/form-data)")
@@ -159,6 +160,7 @@ public class ${name}Controller {
         }
         return uploaded;
     }
+#end
 
     @Get("/{id}/download")
     @Documentation("Download the ${name} attachment file")


### PR DESCRIPTION
## What

A sibling of `function: Attachment` (#6371) for **system-generated** copies — the printed Sales-Invoice stored on issue, vs a user-uploaded Purchase-Invoice scan. Same composition-child + CMS + file-metadata machinery, but **read-only and versioned**.

> **Stacked on #6371.** Until it merges, this diff also shows #6371's backend files; the Snapshot-specific change is 5 files (parser, model, EdmIntentGenerator, controller template, test). Rebase to a clean diff once #6371 lands.

## Changes
- **IntentParser** — `snapshot` added to `ENTITY_FUNCTIONS`.
- **EntityIntent** — `isSnapshot()` + `isFileChild()` (attachment *or* snapshot — shared metadata injection).
- **EdmIntentGenerator** — a file-child gets the injected file-metadata columns + synthesized `Id` PK + audit (now keyed on `isFileChild`). A Snapshot additionally gets a read-only, major **`Version`** column carrying the new **`DOCUMENT_VERSION`** widget (the copy's sequence within its master — for special treatment in forms / print templates), and is marked `attachmentReadOnly="true"` alongside `attachmentEntity`.
- **EntityController template** — the `/upload` verb is gated off when `attachmentReadOnly`; a Snapshot controller exposes **download + list only** (copies are created server-side, never uploaded/deleted by the user). The read-only Harmonia Files panel (#6373) already keys on `attachmentReadOnly`.

## Verified
- `EdmIntentGeneratorTest`: injected metadata + `Id` + `Version`/`DOCUMENT_VERSION` + `attachmentReadOnly`.
- A generated `CompanySnapshotController` has `@Get /{id}/download` and **no** `@Post /upload`; the model carries `Version` (DOCUMENT_VERSION) + `attachmentReadOnly=true`.

## Context
Part **A** of the Sales-Invoice snapshot flow (design in kf-catalog UPSTREAM_PLAN #11). Follow-ups: **C** server-side print render, **D** `generateSnapshot` BPM serviceTask + delegate (mint on issue, number stays / version increments on amend — see #11a first-class document numbering).

Depends on #6371 (+ #6370 merged, #6373 UI panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)