### PR TITLE
feat(jobs): client-Java @Scheduled/JobHandler jobs on the shared Quartz scheduler — visible in the Jobs perspective + cluster-safe

### DIFF
--- a/components/engine/engine-java/pom.xml
+++ b/components/engine/engine-java/pom.xml
@@ -103,6 +103,18 @@
         </dependency>
 
         <!--
+          The jobs engine: client-Java @Scheduled/JobHandler beans register as real Job definitions on
+          the shared clustered Quartz scheduler (ScheduledClassConsumer -> JobsManager), so they are
+          visible + monitored in the Jobs perspective and fire once cluster-wide - not on a private
+          in-JVM scheduler. The Java job body is invoked back through the JavaJobExecutor SPI.
+        -->
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-jobs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--
           Extension metadata persistence used by ExtensionClassConsumer to register @Extension
           contributions in the Dirigible extension registry.
         -->

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/component/ComponentContainer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/component/ComponentContainer.java
@@ -318,6 +318,25 @@ public class ComponentContainer implements ClientBeanResolver {
         return Optional.ofNullable(instancesByType.get(type));
     }
 
+    /**
+     * Resolve the current singleton by its class's fully-qualified name - the runtime lookup a
+     * scheduled Java job needs, which only carries the handler FQN (not the {@link Class}, which may
+     * have been reloaded since registration).
+     *
+     * @param fqn the fully-qualified class name
+     * @return the current instance, or empty if no such bean is loaded
+     */
+    public Optional<Object> instanceOfClassName(String fqn) {
+        for (Map.Entry<Class<?>, Object> entry : instancesByType.entrySet()) {
+            if (entry.getKey()
+                     .getName()
+                     .equals(fqn)) {
+                return Optional.of(entry.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
     @Override
     public <T> Optional<T> get(Class<T> type) {
         List<T> all = getAll(type);

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/JavaJobExecutorImpl.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/JavaJobExecutorImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.engine.java.scheduled;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.dirigible.components.jobs.handler.JavaJobExecutor;
+import org.eclipse.dirigible.engine.java.component.ComponentContainer;
+import org.eclipse.dirigible.sdk.job.JobHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * The {@link JavaJobExecutor} SPI implementation: invoked by the jobs engine (through the Quartz
+ * {@code JobHandler} + {@code JobExecutionService}) when a scheduled job's engine is
+ * {@value JavaJobExecutor#ENGINE_JAVA}. It resolves the CURRENT client bean by the handler FQN from
+ * the {@link ComponentContainer} (so a hot-reloaded class is picked up) and runs it - either
+ * {@link JobHandler#run()} for the interface style, or the named {@code @Scheduled} method for the
+ * method style (handler {@code <fqn>#<method>}). Failures propagate so the jobs engine records the
+ * run as FAILED in the job log.
+ */
+@Component
+public class JavaJobExecutorImpl implements JavaJobExecutor {
+
+    private final ComponentContainer componentContainer;
+
+    JavaJobExecutorImpl(ComponentContainer componentContainer) {
+        this.componentContainer = componentContainer;
+    }
+
+    @Override
+    public void execute(String handler) throws Exception {
+        int hash = handler.indexOf('#');
+        String fqn = hash < 0 ? handler : handler.substring(0, hash);
+        String methodName = hash < 0 ? null : handler.substring(hash + 1);
+
+        Object bean = componentContainer.instanceOfClassName(fqn)
+                                        .orElseThrow(() -> new IllegalStateException(
+                                                "No loaded client bean [" + fqn + "] for scheduled Java job [" + handler + "]"));
+
+        if (methodName == null) {
+            if (!(bean instanceof JobHandler job)) {
+                throw new IllegalStateException("Scheduled Java job bean [" + fqn + "] does not implement JobHandler");
+            }
+            job.run();
+            return;
+        }
+        Method method = bean.getClass()
+                            .getDeclaredMethod(methodName);
+        method.setAccessible(true);
+        method.invoke(bean);
+    }
+}

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
@@ -15,8 +15,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ScheduledFuture;
 
+import org.eclipse.dirigible.components.jobs.domain.Job;
+import org.eclipse.dirigible.components.jobs.handler.JavaJobExecutor;
+import org.eclipse.dirigible.components.jobs.manager.JobsManager;
+import org.eclipse.dirigible.components.jobs.service.JobService;
 import org.eclipse.dirigible.engine.java.component.ComponentContainer;
 import org.eclipse.dirigible.engine.java.spi.JavaClassConsumer;
 import org.eclipse.dirigible.engine.java.spi.LoadedClass;
@@ -27,27 +30,29 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
 /**
- * {@link JavaClassConsumer} that schedules client jobs on a cron trigger. Two styles, never mixed
- * on one class:
+ * {@link JavaClassConsumer} that registers client-Java jobs on the platform's SHARED Quartz
+ * scheduler as first-class {@link Job} definitions - exactly like a JS {@code .job} /
+ * {@code scheduled.ts} artefact. Two styles, never mixed on one class:
  * <ul>
- * <li><b>self-describing interface</b> — a {@code @Component} bean implementing {@link JobHandler},
+ * <li><b>self-describing interface</b> - a {@code @Component} bean implementing {@link JobHandler},
  * which supplies its own {@code cron()} and {@code run()};</li>
- * <li><b>method level</b> — public no-arg methods annotated {@link Scheduled @Scheduled} on a
- * client bean, Spring's {@code @Scheduled}-on-a-method style.</li>
+ * <li><b>method level</b> - public no-arg methods annotated {@link Scheduled @Scheduled}.</li>
  * </ul>
- * The bean instance is built (with constructor + field injection) by the
- * {@link ComponentContainer}; this consumer only fetches it and wires the cron schedule. Hot-reload
- * cancels the old schedule(s) and re-registers from the updated class.
+ * Each becomes a {@code Job} row (engine {@value JavaJobExecutor#ENGINE_JAVA}, handler = the client
+ * FQN, optionally {@code #method}) persisted via {@link JobService} and scheduled through
+ * {@link JobsManager}. Consequences, matching the JS jobs: the job is <b>visible and monitored in
+ * the Jobs perspective</b> (a real row + a job-log entry per run), and it fires <b>once
+ * cluster-wide</b> (the shared clustered Quartz JDBC store), not once per JVM as the previous
+ * private {@code ThreadPoolTaskScheduler} did. At cron time the jobs engine dispatches back to
+ * {@link JavaJobExecutorImpl} through the {@link JavaJobExecutor} SPI to run the client bean.
  *
  * <p>
- * A dedicated {@link ThreadPoolTaskScheduler} is owned by this consumer so {@code @Scheduled}
- * support does not require {@code @EnableScheduling} in the host application.
+ * The {@code Job} row is registered under the {@link JavaJobExecutor#RUNTIME_LOCATION_PREFIX}
+ * synthetic location so the job synchronizer does not reap it as a registry orphan. Hot-reload
+ * re-registers the schedule; a genuinely unloaded class unschedules and removes its rows.
  */
 @Component
 @Order(400)
@@ -55,21 +60,21 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledClassConsumer.class);
 
+    /** The user-defined job group (the only group routed through the handler/engine dispatch). */
+    private static final String JOB_GROUP = "defined";
+
     private final ComponentContainer componentContainer;
+    private final JobsManager jobsManager;
+    private final JobService jobService;
 
-    private final TaskScheduler taskScheduler;
-
-    /** fqn → active ScheduledFutures (one class may register several method-level schedules). */
-    private final ConcurrentMap<String, List<ScheduledFuture<?>>> futures = new ConcurrentHashMap<>();
+    /** fqn -> the job names it registered (a class may declare several @Scheduled methods). */
+    private final ConcurrentMap<String, List<String>> registered = new ConcurrentHashMap<>();
 
     @Autowired
-    public ScheduledClassConsumer(ComponentContainer componentContainer) {
+    public ScheduledClassConsumer(ComponentContainer componentContainer, JobsManager jobsManager, JobService jobService) {
         this.componentContainer = componentContainer;
-        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(2);
-        scheduler.setThreadNamePrefix("java-scheduled-");
-        scheduler.initialize();
-        this.taskScheduler = scheduler;
+        this.jobsManager = jobsManager;
+        this.jobService = jobService;
     }
 
     @Override
@@ -83,7 +88,7 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         Object instance = componentContainer.instanceOf(type)
                                             .orElse(null);
         if (instance == null) {
-            LOGGER.error("Scheduled job [{}] was not instantiated as a bean — a JobHandler and a @Scheduled method both require "
+            LOGGER.error("Scheduled job [{}] was not instantiated as a bean - a JobHandler and a @Scheduled method both require "
                     + "the class to be a @Component; skipped.", info.fqn());
             return;
         }
@@ -91,17 +96,17 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         boolean jobHandler = instance instanceof JobHandler;
         boolean methodLevel = hasScheduledMethod(type);
         if (jobHandler && methodLevel) {
-            LOGGER.error("[{}] mixes scheduling styles — it implements JobHandler and also declares @Scheduled methods. "
+            LOGGER.error("[{}] mixes scheduling styles - it implements JobHandler and also declares @Scheduled methods. "
                     + "Use one style or the other; skipped.", info.fqn());
             return;
         }
 
-        cancelExisting(info.fqn());
-        List<ScheduledFuture<?>> scheduled = new ArrayList<>();
+        unregister(info.fqn());
+        List<String> names = new ArrayList<>();
 
         if (jobHandler) {
             JobHandler job = (JobHandler) instance;
-            schedule(scheduled, () -> runJob(job, info.fqn()), job.cron(), info.fqn());
+            register(names, info.fqn(), info.fqn(), job.cron());
         } else {
             for (Method method : type.getDeclaredMethods()) {
                 Scheduled annotation = method.getAnnotation(Scheduled.class);
@@ -112,59 +117,84 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
                     LOGGER.error("@Scheduled method [{}#{}] must be public and take no parameters; skipped.", info.fqn(), method.getName());
                     continue;
                 }
-                method.setAccessible(true);
-                String label = info.fqn() + "#" + method.getName();
-                schedule(scheduled, () -> invoke(method, instance, label), annotation.expression(), label);
+                register(names, info.fqn(), info.fqn() + "#" + method.getName(), annotation.expression());
             }
         }
 
-        if (scheduled.isEmpty()) {
+        if (names.isEmpty()) {
             LOGGER.warn("Scheduled job [{}] produced no schedule.", info.fqn());
             return;
         }
-        futures.put(info.fqn(), scheduled);
+        registered.put(info.fqn(), names);
     }
 
     @Override
     public void onClassUnloaded(LoadedClass info) {
-        cancelExisting(info.fqn());
+        unregister(info.fqn());
         LOGGER.info("Unscheduled Java class [{}].", info.fqn());
     }
 
     @Override
     public void destroy() {
-        futures.values()
-               .forEach(list -> list.forEach(f -> f.cancel(false)));
-        futures.clear();
-        if (taskScheduler instanceof ThreadPoolTaskScheduler tpts) {
-            tpts.shutdown();
+        // The Job rows + Quartz triggers are the persistent, cluster-shared definition - leave them on
+        // shutdown (other nodes keep running them; a restart re-registers idempotently). Just drop the
+        // local tracking.
+        registered.clear();
+    }
+
+    /**
+     * Register one job (a JobHandler class or a single @Scheduled method) as a Job on the shared
+     * scheduler.
+     */
+    private void register(List<String> sink, String fqn, String handler, String expression) {
+        String name = handler.replace('#', '.');
+        try {
+            Job job = jobService.findByName(name);
+            if (job == null) {
+                job = new Job();
+            }
+            job.setName(name);
+            job.setGroup(JOB_GROUP);
+            job.setClazz("");
+            job.setHandler(handler);
+            job.setEngine(JavaJobExecutor.ENGINE_JAVA);
+            job.setExpression(expression);
+            job.setSingleton(false);
+            job.setEnabled(true);
+            job.setDescription("Client-Java scheduled job [" + handler + "]");
+            job.setType(Job.ARTEFACT_TYPE);
+            job.setLocation(JavaJobExecutor.RUNTIME_LOCATION_PREFIX + handler);
+            job.updateKey();
+            jobService.save(job);
+            jobsManager.scheduleJob(job);
+            sink.add(name);
+            LOGGER.info("Registered client-Java job [{}] (handler [{}]) with cron '{}' on the shared scheduler.", name, handler,
+                    expression);
+        } catch (Exception e) {
+            LOGGER.error("Failed to register client-Java job [{}] with cron '{}': {}", handler, expression, e.getMessage(), e);
         }
     }
 
-    private static void runJob(JobHandler job, String fqn) {
-        try {
-            job.run();
-        } catch (RuntimeException ex) {
-            LOGGER.error("Job [{}] run() threw: {}", fqn, ex.getMessage(), ex);
-        }
-    }
-
-    private void schedule(List<ScheduledFuture<?>> sink, Runnable task, String expression, String label) {
-        CronTrigger trigger;
-        try {
-            trigger = new CronTrigger(expression);
-        } catch (IllegalArgumentException e) {
-            LOGGER.error("@Scheduled [{}] has invalid cron expression '{}': {}", label, expression, e.getMessage(), e);
+    /** Unschedule + remove the Job rows a class previously registered. */
+    private void unregister(String fqn) {
+        List<String> names = registered.remove(fqn);
+        if (names == null) {
             return;
         }
-        sink.add(taskScheduler.schedule(task, trigger));
-        LOGGER.info("Scheduled Java task [{}] with cron '{}'.", label, expression);
-    }
-
-    private void cancelExisting(String fqn) {
-        List<ScheduledFuture<?>> old = futures.remove(fqn);
-        if (old != null) {
-            old.forEach(f -> f.cancel(false));
+        for (String name : names) {
+            try {
+                jobsManager.unscheduleJob(name, JOB_GROUP);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to unschedule client-Java job [{}]: {}", name, e.getMessage());
+            }
+            try {
+                Job job = jobService.findByName(name);
+                if (job != null) {
+                    jobService.delete(job);
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Failed to remove client-Java job row [{}]: {}", name, e.getMessage());
+            }
         }
     }
 
@@ -179,16 +209,5 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
 
     private static boolean isEligibleMethod(Method method) {
         return Modifier.isPublic(method.getModifiers()) && method.getParameterCount() == 0 && !method.isSynthetic();
-    }
-
-    private static void invoke(Method method, Object instance, String label) {
-        try {
-            method.invoke(instance);
-        } catch (ReflectiveOperationException e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            LOGGER.error("@Scheduled [{}] threw: {}", label, cause.getMessage(), cause);
-        } catch (RuntimeException e) {
-            LOGGER.error("@Scheduled [{}] threw: {}", label, e.getMessage(), e);
-        }
     }
 }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/scheduled/ScheduledClassConsumer.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.eclipse.dirigible.components.base.tenant.TenantContext;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.handler.JavaJobExecutor;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
@@ -66,15 +67,18 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
     private final ComponentContainer componentContainer;
     private final JobsManager jobsManager;
     private final JobService jobService;
+    private final TenantContext tenantContext;
 
-    /** fqn -> the job names it registered (a class may declare several @Scheduled methods). */
+    /** fqn -> the base job names it registered (a class may declare several @Scheduled methods). */
     private final ConcurrentMap<String, List<String>> registered = new ConcurrentHashMap<>();
 
     @Autowired
-    public ScheduledClassConsumer(ComponentContainer componentContainer, JobsManager jobsManager, JobService jobService) {
+    public ScheduledClassConsumer(ComponentContainer componentContainer, JobsManager jobsManager, JobService jobService,
+            TenantContext tenantContext) {
         this.componentContainer = componentContainer;
         this.jobsManager = jobsManager;
         this.jobService = jobService;
+        this.tenantContext = tenantContext;
     }
 
     @Override
@@ -148,25 +152,37 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
      */
     private void register(List<String> sink, String fqn, String handler, String expression) {
         String name = handler.replace('#', '.');
+        // Register the job PER TENANT (like the JS .job/scheduled.ts synchronizer does): each tenant
+        // gets its own scheduled row + tenant-prefixed Quartz job. The job body runs in that tenant's
+        // context at fire time (the jobs engine restores it from the job data), so a global client
+        // bean's repository access is correctly tenant-scoped. Class loading happens off any tenant
+        // thread, hence the explicit executeForEachTenant.
         try {
-            Job job = jobService.findByName(name);
-            if (job == null) {
-                job = new Job();
-            }
-            job.setName(name);
-            job.setGroup(JOB_GROUP);
-            job.setClazz("");
-            job.setHandler(handler);
-            job.setEngine(JavaJobExecutor.ENGINE_JAVA);
-            job.setExpression(expression);
-            job.setSingleton(false);
-            job.setEnabled(true);
-            job.setDescription("Client-Java scheduled job [" + handler + "]");
-            job.setType(Job.ARTEFACT_TYPE);
-            job.setLocation(JavaJobExecutor.RUNTIME_LOCATION_PREFIX + handler);
-            job.updateKey();
-            jobService.save(job);
-            jobsManager.scheduleJob(job);
+            tenantContext.executeForEachTenant(() -> {
+                // findByName THROWS when absent (it does not return null) - treat that as "new", and
+                // otherwise mutate the existing managed row so save() updates it rather than duplicating.
+                Job job;
+                try {
+                    job = jobService.findByName(name);
+                } catch (Exception notFound) {
+                    job = new Job();
+                }
+                job.setName(name);
+                job.setGroup(JOB_GROUP);
+                job.setClazz("");
+                job.setHandler(handler);
+                job.setEngine(JavaJobExecutor.ENGINE_JAVA);
+                job.setExpression(expression);
+                job.setSingleton(false);
+                job.setEnabled(true);
+                job.setDescription("Client-Java scheduled job [" + handler + "]");
+                job.setType(Job.ARTEFACT_TYPE);
+                job.setLocation(JavaJobExecutor.RUNTIME_LOCATION_PREFIX + handler);
+                job.updateKey();
+                jobService.save(job);
+                jobsManager.scheduleJob(job);
+                return null;
+            });
             sink.add(name);
             LOGGER.info("Registered client-Java job [{}] (handler [{}]) with cron '{}' on the shared scheduler.", name, handler,
                     expression);
@@ -175,7 +191,7 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         }
     }
 
-    /** Unschedule + remove the Job rows a class previously registered. */
+    /** Unschedule + remove the Job rows a class previously registered (per tenant). */
     private void unregister(String fqn) {
         List<String> names = registered.remove(fqn);
         if (names == null) {
@@ -183,17 +199,22 @@ public class ScheduledClassConsumer implements JavaClassConsumer, DisposableBean
         }
         for (String name : names) {
             try {
-                jobsManager.unscheduleJob(name, JOB_GROUP);
+                tenantContext.executeForEachTenant(() -> {
+                    try {
+                        jobsManager.unscheduleJob(name, JOB_GROUP);
+                    } catch (Exception e) {
+                        LOGGER.warn("Failed to unschedule client-Java job [{}]: {}", name, e.getMessage());
+                    }
+                    try {
+                        jobService.delete(jobService.findByName(name));
+                    } catch (Exception e) {
+                        // findByName throws when the row is already gone - nothing to remove.
+                        LOGGER.debug("No client-Java job row [{}] to remove: {}", name, e.getMessage());
+                    }
+                    return null;
+                });
             } catch (Exception e) {
-                LOGGER.warn("Failed to unschedule client-Java job [{}]: {}", name, e.getMessage());
-            }
-            try {
-                Job job = jobService.findByName(name);
-                if (job != null) {
-                    jobService.delete(job);
-                }
-            } catch (Exception e) {
-                LOGGER.warn("Failed to remove client-Java job row [{}]: {}", name, e.getMessage());
+                LOGGER.warn("Failed to unregister client-Java job [{}]: {}", name, e.getMessage());
             }
         }
     }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JavaJobExecutor.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JavaJobExecutor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.jobs.handler;
+
+/**
+ * SPI that runs a client-Java scheduled job identified by its handler string, invoked by
+ * {@link JobExecutionService} when a job's engine is {@value #ENGINE_JAVA}. The implementation
+ * lives in the Java engine (which can resolve and invoke the client bean); this interface keeps the
+ * jobs engine free of a compile dependency on it (jobs -> javascript only). When no implementation
+ * is on the classpath a {@value #ENGINE_JAVA} job fails loudly rather than silently no-op'ing.
+ */
+public interface JavaJobExecutor {
+
+    /** The engine discriminator that routes a job to this executor (vs the default JS runner). */
+    String ENGINE_JAVA = "java";
+
+    /**
+     * The synthetic {@code location} prefix under which the Java engine registers a client-Java job's
+     * {@code Job} row. These rows are runtime-registered (from compiled client classes), not backed by
+     * a registry artefact, so the job synchronizer must NOT reap them as orphans - it skips any job
+     * whose location starts with this prefix.
+     */
+    String RUNTIME_LOCATION_PREFIX = "/__runtime_java_job__/";
+
+    /**
+     * Run the client-Java job.
+     *
+     * @param handler the job handler string - the fully-qualified class name of the client
+     *        {@code JobHandler} bean, optionally suffixed {@code #method} for a {@code @Scheduled}
+     *        method.
+     * @throws Exception when the job body throws - surfaced by the caller as a job failure (logged to
+     *         the job log like any other engine).
+     */
+    void execute(String handler) throws Exception;
+}

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionService.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/handler/JobExecutionService.java
@@ -35,11 +35,14 @@ public class JobExecutionService {
     private final JobLogService jobLogService;
     private final JobNameCreator jobNameCreator;
     private final DataSourcesManager dataSourcesManager;
+    private final org.springframework.beans.factory.ObjectProvider<JavaJobExecutor> javaJobExecutor;
 
-    JobExecutionService(JobLogService jobLogService, JobNameCreator jobNameCreator, DataSourcesManager dataSourcesManager) {
+    JobExecutionService(JobLogService jobLogService, JobNameCreator jobNameCreator, DataSourcesManager dataSourcesManager,
+            org.springframework.beans.factory.ObjectProvider<JavaJobExecutor> javaJobExecutor) {
         this.jobLogService = jobLogService;
         this.jobNameCreator = jobNameCreator;
         this.dataSourcesManager = dataSourcesManager;
+        this.javaJobExecutor = javaJobExecutor;
     }
 
     public void executeJob(JobExecutionContext context) throws JobExecutionException {
@@ -55,6 +58,8 @@ public class JobExecutionService {
         JobDataMap params = context.getJobDetail()
                                    .getJobDataMap();
         String handler = params.getString(JOB_PARAMETER_HANDLER);
+        String engine = params.getString(JOB_PARAMETER_ENGINE);
+        boolean java = JavaJobExecutor.ENGINE_JAVA.equals(engine);
         Span.current()
             .setAttribute("handler", handler);
 
@@ -65,10 +70,20 @@ public class JobExecutionService {
 
             if (triggered != null) {
                 context.put("handler", handler);
-                Path handlerPath = Path.of(handler);
-
-                try (DirigibleJavascriptCodeRunner runner = new DirigibleJavascriptCodeRunner()) {
-                    runner.run(handlerPath);
+                if (java) {
+                    // Client-Java scheduled job: dispatch to the Java engine's executor (the client
+                    // bean resolved + invoked there). Same JobLog wrapping as the JS path below, so
+                    // it is equally visible/monitored in the Jobs perspective.
+                    JavaJobExecutor executor = javaJobExecutor.getIfAvailable();
+                    if (executor == null) {
+                        throw new IllegalStateException("No JavaJobExecutor is available to run the Java job [" + handler + "]");
+                    }
+                    executor.execute(handler);
+                } else {
+                    Path handlerPath = Path.of(handler);
+                    try (DirigibleJavascriptCodeRunner runner = new DirigibleJavascriptCodeRunner()) {
+                        runner.run(handlerPath);
+                    }
                 }
             }
 
@@ -76,7 +91,7 @@ public class JobExecutionService {
         } catch (Exception ex) {
             registeredFailed(name, handler, triggered, ex);
 
-            String msg = "Failed to execute JS. Job name [" + name + "], handler [" + handler + "]";
+            String msg = "Failed to execute " + (java ? "Java" : "JS") + " job. Job name [" + name + "], handler [" + handler + "]";
             throw new JobExecutionException(msg, ex);
         }
     }

--- a/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizer.java
+++ b/components/engine/engine-jobs/src/main/java/org/eclipse/dirigible/components/jobs/synchronizer/JobSynchronizer.java
@@ -21,6 +21,7 @@ import org.eclipse.dirigible.components.base.synchronizer.SynchronizerCallback;
 import org.eclipse.dirigible.components.base.synchronizer.SynchronizersOrder;
 import org.eclipse.dirigible.components.jobs.domain.Job;
 import org.eclipse.dirigible.components.jobs.domain.JobParameter;
+import org.eclipse.dirigible.components.jobs.handler.JavaJobExecutor;
 import org.eclipse.dirigible.components.jobs.manager.JobsManager;
 import org.eclipse.dirigible.components.jobs.parser.ScheduledMetadata;
 import org.eclipse.dirigible.components.jobs.parser.ScheduledParser;
@@ -309,6 +310,12 @@ public class JobSynchronizer extends MultitenantBaseSynchronizer<Job, Long> {
      */
     @Override
     public void cleanupImpl(Job job) {
+        // Runtime-registered client-Java jobs are not backed by a registry artefact, so they always
+        // look like orphans to the synchronizer - never reap them here; the Java engine owns their
+        // lifecycle (registers on class load, removes on class unload).
+        if (isRuntimeManaged(job)) {
+            return;
+        }
         try {
             jobsManager.unscheduleJob(job.getName(), job.getGroup());
             jobLogService.deleteAllByJobName(job.getName());
@@ -318,6 +325,16 @@ public class JobSynchronizer extends MultitenantBaseSynchronizer<Job, Long> {
             callback.addError(e.getMessage());
             callback.registerState(this, job, ArtefactLifecycle.DELETED, e);
         }
+    }
+
+    /**
+     * A job whose location is under {@link JavaJobExecutor#RUNTIME_LOCATION_PREFIX} is owned by the
+     * Java engine at runtime (no registry file backs it), so the registry synchronizer must leave it
+     * alone.
+     */
+    private static boolean isRuntimeManaged(Job job) {
+        String location = job.getLocation();
+        return location != null && location.startsWith(JavaJobExecutor.RUNTIME_LOCATION_PREFIX);
     }
 
     /**

--- a/modules/parsers/typescript/src/main/java/org/eclipse/dirigible/parsers/typescript/TypeScriptLexer.java
+++ b/modules/parsers/typescript/src/main/java/org/eclipse/dirigible/parsers/typescript/TypeScriptLexer.java
@@ -1,12 +1,3 @@
-/*
- * Copyright (c) 2010-2026 Eclipse Dirigible contributors
- *
- * All rights reserved. This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v20.html
- *
- * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
- */
 // Generated from org/eclipse/dirigible/parsers/typescript/TypeScriptLexer.g4 by ANTLR 4.13.2
 package org.eclipse.dirigible.parsers.typescript;
 

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaJobDecoratorSampleProjectIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/ui/tests/sample/JavaJobDecoratorSampleProjectIT.java
@@ -9,11 +9,14 @@
  */
 package org.eclipse.dirigible.integration.tests.ui.tests.sample;
 
+import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.dirigible.tests.framework.logging.LogsAsserter;
+import org.eclipse.dirigible.tests.framework.util.SynchronizationUtil;
 import org.junit.jupiter.api.BeforeEach;
 
 import ch.qos.logback.classic.Level;
@@ -43,6 +46,25 @@ public class JavaJobDecoratorSampleProjectIT extends SampleProjectRepositoryIT {
         await().atMost(20, TimeUnit.SECONDS)
                .pollInterval(1, TimeUnit.SECONDS)
                .until(() -> consoleLogAsserter.containsMessage("Maintenance.purgeTempFiles executed", Level.INFO));
+
+        // Client-Java jobs are now real Job definitions on the shared scheduler, so they are VISIBLE
+        // and MONITORED in the Jobs perspective (which reads /services/jobs) with engine "java" -
+        // not hidden on a private in-JVM scheduler as before.
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/jobs")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("findAll { it.engine == 'java' }.size()", greaterThanOrEqualTo(2)));
+
+        // And they SURVIVE a registry synchronization pass - the synchronizer must not reap the
+        // runtime-registered rows (they are not backed by a registry artefact).
+        synchronizationProcessor.forceProcessSynchronizers();
+        SynchronizationUtil.waitForStableSynchronization();
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get("/services/jobs")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("findAll { it.engine == 'java' }.size()", greaterThanOrEqualTo(2)));
     }
 
 }


### PR DESCRIPTION
### Problem

Client-Java scheduled jobs — a `@Component` implementing `JobHandler` (`cron()`/`run()`) or a `@Scheduled`-annotated method — were scheduled by `ScheduledClassConsumer` on a **private in-JVM Spring `ThreadPoolTaskScheduler`**. They executed, but:

- they were **invisible** in the Jobs perspective (`/services/jobs`) — no row, no run log;
- they were **not monitored** — no `JobLog` triggered/finished/failed entries;
- in a cluster they fired **once per node**, not once cluster-wide (a private scheduler per JVM), so e.g. a recurring-invoice or cleanup job would double-run.

This diverged from JS `.job` / `scheduled.ts` jobs, which register through the Quartz jobs engine and get all of the above.

### Fix

Register each client-Java job as a real `Job` definition (engine `java`, handler = the client FQN, optionally `#method`) via `JobService` + `JobsManager` on the **shared clustered Quartz scheduler**, per tenant (mirroring the JS job synchronizer). At fire time the jobs engine dispatches back through a new `JavaJobExecutor` SPI (implemented in `engine-java`) to run the client bean, wrapped in the same `JobLog` as every engine.

Result: client-Java jobs now appear in the Jobs perspective with a run log and fire **once cluster-wide**.

- **engine-jobs**: `JavaJobExecutor` SPI; a `java` branch in `JobExecutionService` (keeps jobs → javascript layering — the impl is looked up via `ObjectProvider`); `JobSynchronizer` skips runtime-registered rows (`RUNTIME_LOCATION_PREFIX`) so they are not reaped as registry orphans.
- **engine-java**: depends on engine-jobs; `JavaJobExecutorImpl` resolves + invokes the client bean (`ComponentContainer.instanceOfClassName`); `ScheduledClassConsumer` registers/unregisters `Job` rows per tenant instead of using a private scheduler.

### Test

`JavaJobDecoratorSampleProjectIT` (self-interface + method-level sample) now additionally asserts the jobs appear in `GET /services/jobs` with engine `java` **and survive a forced synchronization pass**. Green locally: `Tests run: 1, Failures: 0`.

### Notes / follow-ups

- The SDK javadoc previously said "Quartz cron expression / mirrors org.quartz.Job" — that described only the cron string; the jobs were not on Quartz. Now they are.
- Cron parser: `JobsManager` uses Quartz `CronScheduleBuilder` (7-field Quartz), whereas the old private path used Spring `CronTrigger` (6-field). Expressions already used the Quartz `?` form in samples; worth a line in the SDK docs.
