### PR TITLE
feat(document): server-side print rendering (sdk.print.Print + PrintFacade)

### DIFF
--- a/components/api/api-modules-java/pom.xml
+++ b/components/api/api-modules-java/pom.xml
@@ -68,6 +68,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-engine-document</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
             <artifactId>dirigible-components-api-component</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/print/Print.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/print/Print.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.sdk.print;
+
+import java.io.IOException;
+
+import org.eclipse.dirigible.components.engine.document.PrintFacade;
+import org.eclipse.dirigible.sdk.component.Beans;
+
+/**
+ * Client SDK for server-side print rendering: render a document's CMS print template to PDF bytes
+ * from data the caller already holds. The counterpart to the browser's Print button (which POSTs
+ * its own data) - for server-initiated renders such as the generated snapshot delegate that stores
+ * an immutable printed copy of an invoice on issue.
+ *
+ * <p>
+ * Pair with a {@code PrintFeeder} to obtain the {@code {document, items}} payload for a record,
+ * then {@link org.eclipse.dirigible.sdk.cms.Attachments#store} the returned PDF as a snapshot.
+ */
+public final class Print {
+
+    private Print() {}
+
+    /**
+     * Render the entity's print template (for the language) with the given {@code {document, items}}
+     * JSON payload to PDF bytes.
+     *
+     * @param entity the document entity name (the {@code Templates/<entity>/Print/<language>} folder)
+     * @param language the template language code (e.g. {@code en})
+     * @param dataJson the {@code {document, items}} payload as JSON (e.g. a {@code PrintFeeder}'s
+     *        output)
+     * @return the rendered PDF
+     */
+    public static byte[] render(String entity, String language, String dataJson) {
+        try {
+            return Beans.get(PrintFacade.class)
+                        .renderToPdf(entity, language, dataJson);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to render the print for [" + entity + "] / [" + language + "]", e);
+        }
+    }
+}

--- a/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintFacade.java
+++ b/components/engine/engine-document/src/main/java/org/eclipse/dirigible/components/engine/document/PrintFacade.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.engine.document;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Server-side print rendering for callers that already hold the data — chiefly the generated
+ * snapshot delegate, which renders a document to an immutable PDF copy on issue. It is the
+ * server-initiated counterpart to {@code PrintEndpoint}: where the endpoint takes the data the
+ * browser POSTs, this resolves the entity's CMS print template for the language and renders the
+ * supplied data map to PDF.
+ *
+ * <p>
+ * The {@code String}-payload overload parses the same {@code {document, items}} shape a
+ * {@code PrintFeeder} emits, with the SAME plain Gson number policy as the endpoint
+ * ({@link ToNumberPolicy#LONG_OR_DOUBLE} — integers stay integral, decimals arrive as
+ * {@code Double} for the money pattern; never the {@code @Expose} {@code JsonHelper}).
+ */
+@Component
+public class PrintFacade {
+
+    /** Plain Gson (no {@code @Expose} filtering), integers as longs — matches {@code PrintEndpoint}. */
+    private static final Gson GSON = new GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+                                                      .create();
+
+    private final CmsStore cmsStore;
+
+    PrintFacade(CmsStore cmsStore) {
+        this.cmsStore = cmsStore;
+    }
+
+    /**
+     * Render the entity's print template for the language with the given data to PDF bytes.
+     *
+     * @param entity the document entity name (the {@code Templates/<entity>/Print/<language>} folder)
+     * @param language the template language code (e.g. {@code en})
+     * @param data the {@code {document, items}} data the template binds
+     * @return the rendered PDF
+     * @throws IOException if no template exists for the entity/language or the CMS read fails
+     */
+    public byte[] renderToPdf(String entity, String language, Map<String, Object> data) throws IOException {
+        String template = cmsStore.findTemplate(entity, language)
+                                  .orElseThrow(() -> new IOException(
+                                          "No print template for entity [" + entity + "] and language [" + language + "]"));
+        return PrintRenderer.renderPdf(template, data);
+    }
+
+    /**
+     * Render from the {@code {document, items}} JSON payload (e.g. a {@code PrintFeeder}'s output).
+     *
+     * @param entity the document entity name
+     * @param language the template language code
+     * @param dataJson the {@code {document, items}} payload as JSON
+     * @return the rendered PDF
+     * @throws IOException if no template exists for the entity/language or the CMS read fails
+     */
+    public byte[] renderToPdf(String entity, String language, String dataJson) throws IOException {
+        Map<String, Object> data = GSON.fromJson(dataJson, new TypeToken<Map<String, Object>>() {}.getType());
+        return renderToPdf(entity, language, data);
+    }
+}

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PrintRenderIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/PrintRenderIT.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.integration.tests.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.dirigible.components.initializers.synchronizer.SynchronizationProcessor;
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.eclipse.dirigible.repository.api.IRepositoryStructure;
+import org.eclipse.dirigible.tests.base.IntegrationTest;
+import org.eclipse.dirigible.tests.framework.restassured.RestAssuredExecutor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * End-to-end test for server-side print rendering ({@code sdk.print.Print} -> {@code PrintFacade}).
+ * Seeds a {@code .print} template under a project's {@code doc/} folder (the CmsSeedSynchronizer
+ * mirrors it into the tenant CMS) and drops a client-Java {@code @Controller} that calls
+ * {@code Print.render} with a {@code {document, items}} payload, then asserts over HTTP (in the
+ * caller's tenant scope) that the response is a valid PDF. Exercises the CMS template lookup + the
+ * SDK bean bridge + the render pipeline in the same tenant scope the generated snapshot delegate
+ * will use.
+ */
+class PrintRenderIT extends IntegrationTest {
+
+    private static final String PROJECT = "print-render-it";
+
+    /** Registry-relative locations: the seeded template and the client-Java controller source. */
+    private static final String TEMPLATE_LOCATION = "/" + PROJECT + "/doc/Templates/TestDoc/Print/en/standard.print";
+    private static final String CONTROLLER_LOCATION = "/" + PROJECT + "/api/PrintTestController.java";
+    private static final String TEMPLATE_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + TEMPLATE_LOCATION;
+    private static final String CONTROLLER_PATH = IRepositoryStructure.PATH_REGISTRY_PUBLIC + CONTROLLER_LOCATION;
+
+    private static final String ENDPOINT = "/services/java/" + PROJECT + "/api/PrintTestController/render";
+
+    private static final long ASSERTION_TIMEOUT_SECONDS = 30;
+
+    @Autowired
+    private IRepository repository;
+
+    @Autowired
+    private SynchronizationProcessor synchronizationProcessor;
+
+    @Autowired
+    private RestAssuredExecutor restAssuredExecutor;
+
+    @Test
+    void rendersSeededTemplateToPdf() {
+        repository.createResource(TEMPLATE_PATH, TEMPLATE.getBytes(StandardCharsets.UTF_8), false, "text/plain", true);
+        repository.createResource(CONTROLLER_PATH, controllerSource().getBytes(StandardCharsets.UTF_8), false, "text/x-java", true);
+        synchronizationProcessor.forceProcessSynchronizers();
+
+        // The controller renders the seeded template server-side and reports the PDF's size + magic
+        // (a client-Java @Controller returns text/plain, so assert on the raw body, not a JSON path).
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .get(ENDPOINT)
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body(containsString("\"head\": \"%PDF"))
+                                                 .body(containsString("\"size\":")),
+                ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @AfterEach
+    void cleanup() {
+        boolean any = false;
+        if (repository.hasResource(TEMPLATE_PATH)) {
+            repository.removeResource(TEMPLATE_PATH);
+            any = true;
+        }
+        if (repository.hasResource(CONTROLLER_PATH)) {
+            repository.removeResource(CONTROLLER_PATH);
+            any = true;
+        }
+        if (any) {
+            synchronizationProcessor.forceProcessSynchronizers();
+        }
+    }
+
+    private static final String TEMPLATE = """
+            <document id="test-doc">
+                <page>
+                    <section>
+                        <field label="Number">{{document.number}}</field>
+                        <field label="Customer">{{document.customer}}</field>
+                    </section>
+                    <table source="items">
+                        <column width="2*">{{name}}</column>
+                        <column width="*" align="right">{{amount}}</column>
+                    </table>
+                    <total align="right">{{document.total}}</total>
+                </page>
+            </document>
+            """;
+
+    private static String controllerSource() {
+        return """
+                package api;
+
+                import java.nio.charset.StandardCharsets;
+
+                import org.eclipse.dirigible.sdk.http.Controller;
+                import org.eclipse.dirigible.sdk.http.Get;
+                import org.eclipse.dirigible.sdk.print.Print;
+
+                @Controller
+                public class PrintTestController {
+
+                    @Get("/render")
+                    public String render() {
+                        String data = "{\\"document\\":{\\"number\\":\\"INV-001\\",\\"customer\\":\\"ACME Ltd.\\",\\"total\\":\\"123.45\\"},\\"items\\":[{\\"name\\":\\"Widget\\",\\"amount\\":\\"100.00\\"}]}";
+                        byte[] pdf = Print.render("TestDoc", "en", data);
+                        int n = Math.min(5, pdf.length);
+                        String head = new String(pdf, 0, n, StandardCharsets.ISO_8859_1);
+                        return "{\\"size\\": " + pdf.length + ", \\"head\\": \\"" + head + "\\"}";
+                    }
+                }
+                """;
+    }
+
+}


### PR DESCRIPTION
## What

A **server-initiated** counterpart to the client-data-driven `PrintEndpoint`: render a document's CMS print template to PDF from data the caller already holds. Enables server-side print flows — chiefly a generated snapshot delegate storing an immutable printed copy of a document on issue.

## Changes
- **engine-document `PrintFacade`** (`@Component`) — `renderToPdf(entity, language, data | dataJson) → byte[]`: resolves the entity's `Templates/<entity>/Print/<language>` template via `CmsStore` and runs the existing `PrintRenderer` pipeline (parse → bind → XSL-FO → FOP). The `String` overload parses the same `{document, items}` payload a `PrintFeeder` emits, with the **same plain Gson number policy** as the endpoint (`LONG_OR_DOUBLE` — never the `@Expose` `JsonHelper`).
- **SDK `sdk.print.Print.render(entity, language, dataJson) → byte[]`** — bridges client-Java to the facade via `Beans.get`; pair with a `PrintFeeder` for the payload and `Attachments.store` for the result.
- `api-modules-java` depends on `engine-document` (acyclic — engine-document doesn't depend on the SDK).

## Verified
`PrintRenderIT` seeds a `.print` template under `doc/`, drops a client-Java `@Controller` calling `Print.render`, and asserts a valid PDF (`%PDF`, ~25 KB) over HTTP in the caller's tenant scope. Green.

## Context
Part **C** of the Sales-Invoice snapshot flow (kf-catalog UPSTREAM_PLAN #11) — but **independent** of the attachment/snapshot type work (#6371/#6374), so mergeable on its own. Follow-up **D** wires it into a `generateSnapshot` BPM serviceTask (render on issue → store as a `function: Snapshot` copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)