### PR TITLE
feat(intent): generateSnapshot delegate — render + store a document copy on issue

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -100,11 +100,12 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> transitions = buildTransitions(model, byName, compositionParents, settings);
         List<Map<String, Object>> postings = buildPostings(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> printFeeders = PrintFeederSupport.buildPrintFeeders(model, byName, compositionParents, context);
+        List<Map<String, Object>> snapshots = SnapshotSupport.buildSnapshots(model, byName, compositionParents);
 
         if (triggers.isEmpty() && resolvers.isEmpty() && fieldLoaders.isEmpty() && timerLoaders.isEmpty() && waits.isEmpty()
                 && aborts.isEmpty() && writers.isEmpty() && setters.isEmpty() && notifications.isEmpty() && schedules.isEmpty()
                 && integrations.isEmpty() && inbound.isEmpty() && rollups.isEmpty() && expansions.isEmpty() && settlements.isEmpty()
-                && generates.isEmpty() && transitions.isEmpty() && printFeeders.isEmpty() && postings.isEmpty()) {
+                && generates.isEmpty() && transitions.isEmpty() && printFeeders.isEmpty() && postings.isEmpty() && snapshots.isEmpty()) {
             // No process glue for this intent - any stale .glue is removed by the post-pass scrub.
             return;
         }
@@ -129,6 +130,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         glue.put("transitions", transitions);
         glue.put("postings", postings);
         glue.put("printFeeders", printFeeders);
+        glue.put("snapshots", snapshots);
         context.writeModelFile(IntentNaming.baseName(context) + ".glue", JsonHelper.toJson(glue));
         LOGGER.debug(
                 "Wrote glue with [{}] trigger(s), [{}] resolver(s), [{}] writer(s), [{}] setter(s),"

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/SnapshotSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/SnapshotSupport.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.dirigible.components.intent.generator.print.PrintIntentGenerator;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.model.RelationIntent;
+
+/**
+ * Builds the {@code snapshots} glue collection: one descriptor per {@code function: Snapshot} child
+ * whose master is a document (header-items) master, driving the generated
+ * {@code gen/events/<Master>SnapshotGenerator.java} delegate. Wired into a process as a
+ * {@code delegate:} service task ({@code delegate: gen.events.<Master>SnapshotGenerator}) so an
+ * immutable printed copy of the document is rendered and stored on issue - the number stays across
+ * amendments, only the snapshot {@code Version} increments.
+ *
+ * <p>
+ * The delegate reuses the master's generated {@code PrintFeeder} (same {@code gen.events} package)
+ * to assemble the {@code {document, items}} payload, renders it server-side via
+ * {@code sdk.print.Print}, and stores the PDF via {@code sdk.cms.Attachments} - so only a document
+ * master (which has a feeder) can carry a snapshot child.
+ */
+final class SnapshotSupport {
+
+    private SnapshotSupport() {}
+
+    /**
+     * One snapshot descriptor per {@code function: Snapshot} child of a document master.
+     *
+     * @param model the parsed intent model
+     * @param byName entities indexed by name
+     * @param compositionParents each entity's transitive composition parent (perspective resolution)
+     * @return the {@code snapshots} collection (possibly empty)
+     */
+    static List<Map<String, Object>> buildSnapshots(IntentModel model, Map<String, EntityIntent> byName,
+            Map<String, String> compositionParents) {
+        Set<String> documentMasters = new LinkedHashSet<>();
+        for (EntityIntent master : PrintIntentGenerator.documentMasters(model)
+                                                       .keySet()) {
+            documentMasters.add(master.getName());
+        }
+        List<Map<String, Object>> snapshots = new ArrayList<>();
+        for (EntityIntent entity : model.getEntities()) {
+            if (!entity.isSnapshot()) {
+                continue;
+            }
+            RelationIntent masterRelation = compositionMaster(entity);
+            if (masterRelation == null || !documentMasters.contains(masterRelation.getTo())) {
+                continue; // a snapshot needs a document master (with a PrintFeeder) to render from
+            }
+            EntityIntent master = byName.get(masterRelation.getTo());
+            if (master == null) {
+                continue;
+            }
+            Map<String, Object> snapshot = new LinkedHashMap<>();
+            snapshot.put("master", master.getName());
+            snapshot.put("masterPk", IntentEntities.keyFieldName(master));
+            snapshot.put("language", "en");
+            snapshot.put("snapshotEntity", entity.getName());
+            snapshot.put("snapshotPerspective", IntentEntities.resolvePerspective(entity.getName(), compositionParents));
+            snapshot.put("snapshotMasterFk", IntentNaming.pascalCase(masterRelation.getName()));
+            snapshots.add(snapshot);
+        }
+        return snapshots;
+    }
+
+    /** The snapshot's composition to-one relation back to its master (the owning document). */
+    private static RelationIntent compositionMaster(EntityIntent snapshot) {
+        for (RelationIntent relation : snapshot.getRelations()) {
+            boolean toOne = "manyToOne".equals(relation.getKind()) || "oneToOne".equals(relation.getKind());
+            if (toOne && relation.isComposition() && relation.getTo() != null) {
+                return relation;
+            }
+        }
+        return null;
+    }
+}

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -322,11 +322,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (entity.isMultilingual()) {
                 entityMap.put("multilingual", "true");
             }
-            // A file-attachment child: mark it so the generated controller emits the upload/download/
-            // delete verbs and the Harmonia master/document view renders it as an "Attachments" panel
-            // (a composition detail already, so the master-detail wiring is unchanged).
-            if (entity.isAttachment()) {
+            // A file-child: mark it so the generated controller emits the download (and, when editable,
+            // upload/delete) verbs and the Harmonia master/document view renders it as a Files panel
+            // (a composition detail already, so the master-detail wiring is unchanged). A Snapshot is
+            // read-only - copies are generated server-side, never uploaded or deleted by the user - so
+            // it also carries attachmentReadOnly, which suppresses the upload verb and the panel's
+            // upload/remove controls (download + list only).
+            if (entity.isFileChild()) {
                 entityMap.put("attachmentEntity", "true");
+                if (entity.isSnapshot()) {
+                    entityMap.put("attachmentReadOnly", "true");
+                }
             }
             // Custom Java imports for the generated entity Repository (e.g. a calculated-field action's
             // CalculatedField class). Base64-encoded to match the EDM editor's serialization, which the
@@ -342,12 +348,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             }
 
             List<Map<String, Object>> properties = new ArrayList<>();
-            // A file-attachment child (function: Attachment) is a first-class entity, but the author
+            // A file-child (function: Attachment or Snapshot) is a first-class entity, but the author
             // declares no fields at all (the file-metadata columns are injected below), so synthesize
             // the generated integer primary key it still needs.
-            if (entity.isAttachment() && entity.getFields()
-                                               .stream()
-                                               .noneMatch(FieldIntent::isPrimaryKey)) {
+            if (entity.isFileChild() && entity.getFields()
+                                              .stream()
+                                              .noneMatch(FieldIntent::isPrimaryKey)) {
                 FieldIntent id = new FieldIntent();
                 id.setName("id");
                 id.setType("integer");
@@ -378,13 +384,17 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             if (triggerTargets.contains(name)) {
                 properties.add(processIdProperty(name));
             }
-            // A file-attachment child (function: Attachment) gets the standard file-metadata columns
-            // injected (like audit:) - the author never hand-writes plumbing; the upload sets them
-            // server-side. FileName is the row's display title; StoragePath is the CMS reference. The
-            // attachment is implicitly audited (who uploaded when).
+            // A file-child (function: Attachment or Snapshot) gets the standard file-metadata columns
+            // injected (like audit:) - the author never hand-writes plumbing; the upload (attachment) or
+            // the generator (snapshot) sets them server-side. FileName is the row's display title;
+            // StoragePath is the CMS reference. Implicitly audited (who created it when). A Snapshot also
+            // carries a Version - the copy's sequence within its master (DOCUMENT_VERSION widget).
             boolean audited = entity.isAudited();
-            if (entity.isAttachment()) {
+            if (entity.isFileChild()) {
                 properties.addAll(attachmentProperties(name));
+                if (entity.isSnapshot()) {
+                    properties.add(versionProperty(name));
+                }
                 audited = true;
             }
             // The four standard audit columns, populated by the platform's audit annotations downstream.
@@ -1498,6 +1508,29 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         p.put("widgetSize", "");
         p.put("widgetLength", length > 0 ? Integer.toString(length) : "20");
         p.put("widgetIsMajor", major ? "true" : "false");
+        return p;
+    }
+
+    /**
+     * The {@code Version} column injected into a {@code function: Snapshot} child - the copy's sequence
+     * within its master (1, 2, 3 as a document is re-issued after amendment). Read-only (the generator
+     * sets it), shown on the list/panel (major), and carries the {@code DOCUMENT_VERSION} widget so
+     * forms and print templates can treat it specifically (e.g. a version badge).
+     */
+    private static Map<String, Object> versionProperty(String entityName) {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("name", "Version");
+        p.put("description", "");
+        p.put("tooltip", "");
+        p.put("dataName", IntentNaming.upperSnake(entityName) + "_VERSION");
+        p.put("dataType", "INTEGER");
+        p.put("dataNullable", "true");
+        p.put("auditType", "NONE");
+        p.put("isReadOnlyProperty", "true");
+        p.put("widgetType", "DOCUMENT_VERSION");
+        p.put("widgetSize", "");
+        p.put("widgetLength", "20");
+        p.put("widgetIsMajor", "true");
         return p;
     }
 

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/EntityIntent.java
@@ -300,6 +300,24 @@ public class EntityIntent {
         return functionIs("Attachment");
     }
 
+    /**
+     * Whether this entity is a generated-copy child ({@code function: Snapshot}) - a composition detail
+     * holding one system-generated, immutable, versioned file (e.g. the printed invoice stored on
+     * issue). Like an attachment it carries the standard file-metadata columns and renders in the Files
+     * panel, but read-only (download + list only; created server-side, never uploaded or deleted by the
+     * user) and with an added {@code Version} column.
+     */
+    public boolean isSnapshot() {
+        return functionIs("Snapshot");
+    }
+
+    /**
+     * Whether this entity is any file-child kind (attachment or snapshot) - shares metadata injection.
+     */
+    public boolean isFileChild() {
+        return isAttachment() || isSnapshot();
+    }
+
     public String getDescription() {
         return description;
     }

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -86,7 +86,7 @@ public final class IntentParser {
     private static final Set<String> RELATION_KINDS = Set.of("oneToMany", "manyToOne", "oneToOne", "manyToMany");
     /** Implemented entity {@code function} values (lower-cased), selecting the entity's UI template. */
     private static final Set<String> ENTITY_FUNCTIONS =
-            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment");
+            Set.of("document", "documentitem", "master", "detail", "list", "setting", "calendar", "attachment", "snapshot");
     /**
      * Entity {@code function} values whose template is reserved but not yet shipped (gated with a
      * message).

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -171,6 +171,49 @@ class EdmIntentGeneratorTest {
 
         // A plain (non-attachment) entity carries no marker.
         assertNull(entityByName(entities, "Company").get("attachmentEntity"));
+        // An attachment is editable (not read-only).
+        assertNull(att.get("attachmentReadOnly"));
+    }
+
+    @Test
+    void snapshotChildIsReadOnlyWithVersionAndFileMetadata() {
+        String yaml = """
+                name: docs
+                entities:
+                  - name: SalesInvoice
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: number, type: string }
+                  - name: SalesInvoiceCopy
+                    function: Snapshot
+                    relations:
+                      - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "docs");
+        List<Map<String, Object>> entities = entities(model);
+        Map<String, Object> snap = entityByName(entities, "SalesInvoiceCopy");
+
+        // Marked as a file child AND read-only (copies are generated server-side, never uploaded/deleted).
+        assertEquals("true", snap.get("attachmentEntity"));
+        assertEquals("true", snap.get("attachmentReadOnly"));
+        assertEquals("MANAGE_DETAILS", snap.get("layoutType"));
+
+        // Same injected file metadata as an attachment...
+        assertEquals("VARCHAR", propertyByName(snap, "FileName").get("dataType"));
+        assertEquals("true", propertyByName(snap, "FileName").get("isReadOnlyProperty"));
+        assertNotNull(propertyByName(snap, "StoragePath"));
+        assertNotNull(propertyByName(snap, "Uuid"));
+        // ...plus the synthesized generated Id...
+        assertEquals("true", propertyByName(snap, "Id").get("dataPrimaryKey"));
+        // ...plus a read-only, major Version carrying the DOCUMENT_VERSION widget.
+        Map<String, Object> version = propertyByName(snap, "Version");
+        assertEquals("INTEGER", version.get("dataType"));
+        assertEquals("DOCUMENT_VERSION", version.get("widgetType"));
+        assertEquals("true", version.get("isReadOnlyProperty"));
+        assertEquals("true", version.get("widgetIsMajor"));
+        // Implicitly audited.
+        assertEquals("CREATED_AT", propertyByName(snap, "CreatedAt").get("auditType"));
     }
 
     @Test

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Snapshot.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Snapshot.java.template
@@ -1,0 +1,60 @@
+package gen.events;
+
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
+import org.flowable.engine.delegate.DelegateExecution;
+import org.flowable.engine.delegate.JavaDelegate;
+
+import gen.${javaGenFolderName}.data.${snapshotJavaPerspective}.${snapshotEntity}Entity;
+import gen.${javaGenFolderName}.data.${snapshotJavaPerspective}.${snapshotEntity}Repository;
+
+/**
+ * Snapshot generator for ${master}: on the service task it is wired to (e.g. right after Issue),
+ * renders the document to an immutable PDF copy and stores it as a ${snapshotEntity} row. The number
+ * stays across amendments - each generation only increments the copy's Version.
+ *
+ * Generated from the intent snapshots glue - do not edit; it is re-generated with the application.
+ * Wired as a `delegate:` service task (delegate: gen.events.${master}SnapshotGenerator). Data assembly
+ * reuses the generated ${master}PrintFeeder (same gen.events package); the PDF is rendered server-side
+ * via sdk.print.Print and stored in the tenant CMS via sdk.cms.Attachments; the ${snapshotEntity} row
+ * is written through its generated repository (validations / events / audit).
+ */
+public class ${master}SnapshotGenerator implements JavaDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) {
+        Object key = execution.getVariable("${masterPk}");
+        if (!(key instanceof Number)) {
+            return;
+        }
+        int id = ((Number) key).intValue();
+
+        // Assemble the { document, items } payload the print template binds, then render server-side.
+        String payload = new ${master}PrintFeeder().feed(id);
+        byte[] pdf = org.eclipse.dirigible.sdk.print.Print.render("${master}", "${language}", payload);
+
+        ${snapshotEntity}Repository repository = new ${snapshotEntity}Repository();
+        // Next version = max existing + 1. Snapshots are immutable (never deleted), so this is gap-free;
+        // an amend re-issue mints the next version while the document number is unchanged.
+        int version = 1;
+        for (${snapshotEntity}Entity existing : repository.findAll(Criteria.create()
+                                                                          .eq("${snapshotMasterFk}", id))) {
+            if (existing.Version != null && existing.Version >= version) {
+                version = existing.Version + 1;
+            }
+        }
+
+        String fileName = "${master} " + id + " v" + version + ".pdf";
+        org.eclipse.dirigible.sdk.cms.Attachments.Attachment stored =
+                org.eclipse.dirigible.sdk.cms.Attachments.store("${snapshotEntity}", fileName, "application/pdf", pdf);
+
+        ${snapshotEntity}Entity snapshot = new ${snapshotEntity}Entity();
+        snapshot.FileName = stored.fileName();
+        snapshot.ContentType = stored.contentType();
+        snapshot.FileSize = stored.size();
+        snapshot.StoragePath = stored.path();
+        snapshot.Uuid = stored.uuid();
+        snapshot.Version = version;
+        snapshot.${snapshotMasterFk} = id;
+        repository.save(snapshot);
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/template/template.js
@@ -129,6 +129,13 @@ export function getTemplate(parameters) {
                 collection: "printFeeders"
             },
             {
+                location: "/template-application-events-java/events/Snapshot.java.template",
+                action: "generate",
+                rename: "gen/events/{{master}}SnapshotGenerator.java",
+                engine: "velocity",
+                collection: "snapshots"
+            },
+            {
                 location: "/template-application-events-java/events/SettlementOnPayment.java.template",
                 action: "generate",
                 rename: "gen/events/{{name}}OnPayment.java",

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -133,6 +133,7 @@ public class ${name}Controller {
         return repository.save(entity);
     }
 #if($attachmentEntity)
+#if(!$attachmentReadOnly)
 
     @Post("/upload")
     @Documentation("Upload one or more files as ${name} attachments (multipart/form-data)")
@@ -159,6 +160,7 @@ public class ${name}Controller {
         }
         return uploaded;
     }
+#end
 
     @Get("/{id}/download")
     @Documentation("Download the ${name} attachment file")

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1106,6 +1106,34 @@ export function generateFiles(model, parameters, templateSources) {
                         }
                     }
                     break;
+                case "snapshots":
+                    // Snapshot generators (intent layer): one JavaDelegate per function: Snapshot child of
+                    // a document master, wired as a delegate: service task. It reuses the master's
+                    // PrintFeeder (same gen.events package) to assemble the payload, renders via
+                    // sdk.print.Print and stores via sdk.cms.Attachments. Not entity-shaped, so its own
+                    // loop; the snapshot repo lives in this project (javaGenFolderName), its Java package
+                    // segment is the sanitized perspective.
+                    if (model.snapshots) {
+                        for (let s = 0; s < model.snapshots.length; s++) {
+                            const snapshot = model.snapshots[s];
+                            const snapshotParameters = {
+                                ...parameters,
+                                master: snapshot.master,
+                                masterPk: snapshot.masterPk,
+                                language: snapshot.language,
+                                snapshotEntity: snapshot.snapshotEntity,
+                                snapshotJavaPerspective: sanitizeJavaIdentifier(snapshot.snapshotPerspective),
+                                snapshotMasterFk: snapshot.snapshotMasterFk
+                            };
+                            const cleanSnapshotParameters = cleanData(snapshotParameters);
+                            generatedFiles.push({
+                                location: location,
+                                content: getGenerationEngine(template).generate(location, content, cleanSnapshotParameters),
+                                path: templateEngines.getMustacheEngine().generate(location, template.rename, cleanSnapshotParameters)
+                            });
+                        }
+                    }
+                    break;
                 default:
                     // No collection
                     parameters.models = model.entities;


### PR DESCRIPTION
## What

**Part D** of the Sales-Invoice snapshot flow: generates the `JavaDelegate` a process wires as a `delegate:` service task to mint an **immutable printed copy** of a document on issue. The number stays across amendments — only the snapshot **Version** increments.

> **Top of the snapshot stack.** Branched off #6374; the diff also shows #6374's files (and, when built, needs #6376 at runtime). The D-specific change is 5 files (SnapshotSupport, GlueIntentGenerator, generateUtils, Snapshot.java.template, template.js). Rebase to a clean diff once #6374 lands.

## Changes
- **`SnapshotSupport`** builds the `snapshots` glue collection — one descriptor per `function: Snapshot` child of a **document master** (which has a `PrintFeeder` to render from): master, master PK (the process variable), the snapshot entity / perspective / master-FK, language.
- **`GlueIntentGenerator`** emits `snapshots` into the `.glue`.
- **`generateUtils`** adds the `snapshots` case (sanitizes `perspective → javaPerspective`, its own loop like `printFeeders`/`settlements`).
- **`Snapshot.java.template`** generates `gen/events/<Master>SnapshotGenerator.java`: reads the master id from the process variable, reuses the master's generated `PrintFeeder` (same `gen.events` package) for the `{document, items}` payload, renders server-side via `sdk.print.Print` (#6376), stores the PDF via `sdk.cms.Attachments` (#6370), and writes a `<Snapshot>` row with `Version = max existing + 1` (gap-free — snapshots are immutable). Bound by the BPMN via the **existing** `delegate:` (`flowable:class`) path — no new parser/BPMN wiring, and `ServiceTaskHandlerGenerator` already skips a `delegate:` task.

## Verified
On the `SalesInvoice` document master with a `function: Snapshot` child + a `generateSnapshot` delegate step: the `.glue` carries the snapshots descriptor, `gen/events/SalesInvoiceSnapshotGenerator.java` is emitted, and it **compiles cleanly** into the client bean container (538 beans, no javac errors). All delegate references resolve (`PrintFeeder`, `Print.render`, `Attachments.store`, the snapshot entity/repo).

## Depends on
- **#6374** (`function: Snapshot` type — PR base), **#6376** (`sdk.print.Print`), **#6371/#6370** (`sdk.cms.Attachments`).

Follow-up: KF adoption wires `generateSnapshot` into the SalesInvoice process (after `markIssued`) + the Confirm/Amend loop; a full process-run e2e mints the first snapshot on issue. Pairs with first-class document numbering (kf-catalog UPSTREAM_PLAN #11a) for the number-stays/version-increments guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)