### PR TITLE
feat(intent): auto-generate type: uuid fields on create

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -918,6 +918,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType())) {
             p.put("isReadOnlyProperty", "true");
         }
+        // A uuid field is platform-generated: the generated repository assigns a random UUID on create
+        // when the value is empty (no hand-written calculatedActionOnCreate needed). The author can
+        // still seed/import an explicit value - it is only filled when blank.
+        if ("uuid".equalsIgnoreCase(field.getType())) {
+            p.put("generatedUuid", "true");
+        }
         if (field.isSensitive()) {
             // Hidden from the personal (my) surface: absent from its pages and stripped from the
             // personal REST controller's responses. The power surface ignores this attribute.

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -66,8 +66,10 @@ class EdmIntentGeneratorTest {
                                .noneMatch(p -> "Country".equals(p.get("name"))),
                 "projection targets must not create perspectives");
 
-        // uuid carries the unique constraint; the four audit columns are present.
+        // uuid carries the unique constraint and is platform-generated on create (no custom action);
+        // the four audit columns are present.
         assertEquals("true", propertyByName(customer, "Uuid").get("dataUnique"));
+        assertEquals("true", propertyByName(customer, "Uuid").get("generatedUuid"));
         assertEquals("CREATED_AT", propertyByName(customer, "CreatedAt").get("auditType"));
         assertEquals("UPDATED_BY", propertyByName(customer, "UpdatedBy").get("auditType"));
 

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -143,6 +143,14 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #end
 #end
 #end
+## A uuid field (intent type: uuid) is platform-generated: assign a random UUID on create when empty.
+#foreach ($property in $properties)
+#if($property.generatedUuid)
+        if (entity.${property.name} == null || entity.${property.name}.isBlank()) {
+            entity.${property.name} = java.util.UUID.randomUUID().toString();
+        }
+#end
+#end
 #if($documentMaster)
         recalculate(entity);
 #end


### PR DESCRIPTION
A `type: uuid` field is now **platform-generated**: the generated repository assigns a random UUID on create when the value is empty — so a document's system/business-key `uuid` no longer needs a hand-written `calculatedActionOnCreate`. An explicitly seeded/imported value is respected (filled only when blank).

- **`EdmIntentGenerator`** marks a uuid property `generatedUuid="true"` (beside the existing read-only flag).
- **`Repository.java.template`** `save()` (create path) assigns `java.util.UUID.randomUUID().toString()` to each `generatedUuid` property that is null/blank, next to the calculated-on-create assignments.

## Verified
- `EdmIntentGeneratorTest` asserts `Customer.Uuid` carries `generatedUuid`.
- Live: a generated `CompanyRepository.save()` contains the UUID auto-fill and compiles clean (544 beans, no javac errors).

## Context
This is the reusable UUID primitive the first-class-numbering placeholder (`stampOn: issue`, N3b) will reuse; together they retire the hand-written per-document UUID/number placeholder actions (e.g. `SalesInvoiceNumberAction`). Independent of the numbering PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)