### PR TITLE
feat(intent): generate create-time numbering from number: {} (N3b-i)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -918,6 +918,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         if (field.isReadOnly() || "uuid".equalsIgnoreCase(field.getType())) {
             p.put("isReadOnlyProperty", "true");
         }
+        // A uuid field is platform-generated: the generated repository assigns a random UUID on create
+        // when the value is empty (no hand-written calculatedActionOnCreate needed). The author can
+        // still seed/import an explicit value - it is only filled when blank.
+        if ("uuid".equalsIgnoreCase(field.getType())) {
+            p.put("generatedUuid", "true");
+        }
         if (field.isSensitive()) {
             // Hidden from the personal (my) surface: absent from its pages and stripped from the
             // personal REST controller's responses. The power surface ignores this attribute.

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -34,6 +34,7 @@ import org.eclipse.dirigible.components.intent.model.DependsOnIntent;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.LabelExpression;
 import org.eclipse.dirigible.components.intent.model.FieldIntent;
+import org.eclipse.dirigible.components.intent.model.NumberIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
 import org.eclipse.dirigible.components.intent.model.RollupIntent;
@@ -923,6 +924,32 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
         // still seed/import an explicit value - it is only filled when blank.
         if ("uuid".equalsIgnoreCase(field.getType())) {
             p.put("generatedUuid", "true");
+        }
+        // First-class document numbering (intent `number: {}`): the platform maintains a per-series
+        // counter and stamps the formatted number. stampOn:create stamps the real number on insert
+        // (the generated repository calls sdk.numbering.DocumentNumbers); stampOn:issue holds a UUID
+        // placeholder on create (reusing the uuid auto-fill above) until the generated stamp step runs.
+        if (field.getNumber() != null) {
+            NumberIntent number = field.getNumber();
+            List<String> numberScope = new ArrayList<>();
+            if (number.getScope() != null) {
+                for (String scopeName : number.getScope()) {
+                    // Scope names index the counter AND read the entity's field on create; PascalCase them
+                    // to match the generated entity property (year stays the literal token).
+                    numberScope.add("year".equalsIgnoreCase(scopeName) ? "year" : IntentNaming.pascalCase(scopeName));
+                }
+            }
+            p.put("numberSeries", number.getSeries() == null ? entityName : number.getSeries());
+            p.put("numberFormat", number.getFormat() == null ? "" : number.getFormat());
+            p.put("numberScope", numberScope);
+            p.put("isReadOnlyProperty", "true");
+            if ("issue".equalsIgnoreCase(number.getStampOn())) {
+                p.put("numberStampOn", "issue");
+                p.put("generatedUuid", "true"); // UUID placeholder on create; stamped at the issue step
+            } else {
+                p.put("numberStampOn", "create");
+                p.put("numberStampOnCreate", "true"); // real number allocated + formatted on insert
+            }
         }
         if (field.isSensitive()) {
             // Hidden from the personal (my) surface: absent from its pages and stripped from the

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -78,6 +78,39 @@ class EdmIntentGeneratorTest {
     }
 
     @Test
+    void numberFieldEmitsStampMarkers() {
+        String yaml =
+                """
+                        name: billing
+                        entities:
+                          - name: SalesInvoice
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: number, type: string, number: { series: SalesInvoice, format: "SI-{seq:07}", scope: [year], stampOn: issue } }
+                          - name: Proforma
+                            fields:
+                              - { name: id, type: integer, primaryKey: true, generated: true }
+                              - { name: number, type: string, number: { series: Proforma, format: "PF-{seq:05}", stampOn: create } }
+                        """;
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "billing");
+        List<Map<String, Object>> entities = entities(model);
+
+        // stampOn: issue -> a UUID placeholder on create (reusing the uuid auto-fill) + the series markers.
+        Map<String, Object> siNumber = propertyByName(entityByName(entities, "SalesInvoice"), "Number");
+        assertEquals("issue", siNumber.get("numberStampOn"));
+        assertEquals("SalesInvoice", siNumber.get("numberSeries"));
+        assertEquals("true", siNumber.get("generatedUuid"));
+        assertNull(siNumber.get("numberStampOnCreate"));
+
+        // stampOn: create -> the real number is stamped on insert (numberStampOnCreate), no placeholder.
+        Map<String, Object> pfNumber = propertyByName(entityByName(entities, "Proforma"), "Number");
+        assertEquals("create", pfNumber.get("numberStampOn"));
+        assertEquals("true", pfNumber.get("numberStampOnCreate"));
+        assertEquals("PF-{seq:05}", pfNumber.get("numberFormat"));
+        assertNull(pfNumber.get("generatedUuid"));
+    }
+
+    @Test
     void crossModelProjectionCellIsMarkedProjectionInTheEdmDiagram() {
         IntentModel parsed = IntentParser.parse(readResource("/billing/customers.intent"));
         String edm = EdmIntentGenerator.buildEdmXmlForTest(parsed, "customers");

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -66,8 +66,10 @@ class EdmIntentGeneratorTest {
                                .noneMatch(p -> "Country".equals(p.get("name"))),
                 "projection targets must not create perspectives");
 
-        // uuid carries the unique constraint; the four audit columns are present.
+        // uuid carries the unique constraint and is platform-generated on create (no custom action);
+        // the four audit columns are present.
         assertEquals("true", propertyByName(customer, "Uuid").get("dataUnique"));
+        assertEquals("true", propertyByName(customer, "Uuid").get("generatedUuid"));
         assertEquals("CREATED_AT", propertyByName(customer, "CreatedAt").get("auditType"));
         assertEquals("UPDATED_BY", propertyByName(customer, "UpdatedBy").get("auditType"));
 

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -143,6 +143,14 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #end
 #end
 #end
+## A uuid field (intent type: uuid) is platform-generated: assign a random UUID on create when empty.
+#foreach ($property in $properties)
+#if($property.generatedUuid)
+        if (entity.${property.name} == null || entity.${property.name}.isBlank()) {
+            entity.${property.name} = java.util.UUID.randomUUID().toString();
+        }
+#end
+#end
 #if($documentMaster)
         recalculate(entity);
 #end

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -144,10 +144,30 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
 #end
 #end
 ## A uuid field (intent type: uuid) is platform-generated: assign a random UUID on create when empty.
+## A number: {} field with stampOn:issue also carries generatedUuid, so its create-time placeholder is
+## a UUID (the real number is stamped at the issue step); stampOn:create fields are handled just below.
 #foreach ($property in $properties)
 #if($property.generatedUuid)
         if (entity.${property.name} == null || entity.${property.name}.isBlank()) {
             entity.${property.name} = java.util.UUID.randomUUID().toString();
+        }
+#end
+#end
+## First-class numbering, stampOn:create: allocate + format the real document number on insert (when
+## empty), via the shared per-tenant counter. The scope both partitions the counter and feeds the
+## format's tokens; `year` is the current year, any other name reads the entity's own field.
+#foreach ($property in $properties)
+#if($property.numberStampOnCreate)
+        if (entity.${property.name} == null || entity.${property.name}.isBlank()) {
+            java.util.Map<String, String> ${property.name}Scope = new java.util.LinkedHashMap<>();
+#foreach ($scopeName in $property.numberScope)
+#if($scopeName == "year")
+            ${property.name}Scope.put("year", String.valueOf(java.time.Year.now().getValue()));
+#else
+            ${property.name}Scope.put("${scopeName}", entity.${scopeName} == null ? "" : String.valueOf(entity.${scopeName}));
+#end
+#end
+            entity.${property.name} = org.eclipse.dirigible.sdk.numbering.DocumentNumbers.next("${property.numberSeries}", "${property.numberFormat}", ${property.name}Scope);
         }
 #end
 #end


### PR DESCRIPTION
**N3b-i** — turns a `number: {}` field (N1) into its **create-time** behavior against the counter runtime (N2) via the SDK (N3a). No hand-written placeholder action.

- **`EdmIntentGenerator`** emits per-field markers (`numberSeries` / `numberFormat` / `numberScope` [PascalCased] / `numberStampOn`): `stampOn: create` → `numberStampOnCreate`; `stampOn: issue` → `generatedUuid` (a UUID placeholder on create, reusing #6386's auto-fill) pending the issue stamp (N3b-ii). The field is read-only.
- **`Repository.java.template`** `save()`: for a `numberStampOnCreate` field, builds the scope map (`year` = current year; any other name reads the entity's field) and stamps the real number via `sdk.numbering.DocumentNumbers.next(series, format, scope)` when blank.

## Verified
Live: a Company with `number: { series: CompanyDoc, format: "CO-{seq:05}", stampOn: create }` stamps **CO-00001 / CO-00002 / CO-00003** on successive REST creates (gap-free); the counter shows in the shell's Document Numbering settings; compiles clean. `EdmIntentGeneratorTest#numberFieldEmitsStampMarkers` covers both modes.

Stacked on #6386 (the uuid auto-fill = the issue-mode placeholder). **N3b-ii** next: the generated issue stamp delegate (`gen.events.<Entity>NumberStamp`, idempotent) the process wires via `delegate:`, so `stampOn: issue` documents drop `SalesInvoiceNumberAction` + the `generateNumber` delegate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)