### PR TITLE
feat(harmonia): hide the create-time UUID placeholder in the document title

### DIFF
--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/js/services/format.js
@@ -180,6 +180,18 @@
     },
 
     /**
+     * A document number for display. A not-yet-issued document holds a create-time UUID placeholder in
+     * its number field (the platform's numbering places it there until the real number is stamped at
+     * issue); render that as empty so the title shows just the document label ("Sales Invoice", not the
+     * raw UUID). Once the real number is stamped it passes through unchanged, as does any non-UUID value.
+     */
+    documentNumber(v) {
+      if (v === null || v === undefined) return '';
+      const uuid = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+      return uuid.test(String(v)) ? '' : v;
+    },
+
+    /**
      * Convert a date/datetime value to the FIXED shape an HTML <input> requires — NOT pattern-driven.
      * `widget` is one of DATE, DATETIME-LOCAL, TIME, MONTH, WEEK (case-insensitive). Empty -> ''.
      * MONTH (YYYY-MM) and WEEK (YYYY-Www) are stored as plain strings, so they slice through unchanged.

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -15,7 +15,7 @@
 
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title class="shrink-0"
-          x-text="(mode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit') : T('$projectName:${tprefix}.defaults.new', 'New')) + ' ' + T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}')#if($docNumProp != '') + (form.${docNumProp} ? ' ' + form.${docNumProp} : '')#end + (ownerName ? ' ' + T('$projectName:${tprefix}.defaults.for', 'for') + ' ' + ownerName : '')"></span>
+          x-text="(mode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit') : T('$projectName:${tprefix}.defaults.new', 'New')) + ' ' + T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}')#if($docNumProp != '') + (window.HarmoniaFormat.documentNumber(form.${docNumProp}) ? ' ' + window.HarmoniaFormat.documentNumber(form.${docNumProp}) : '')#end + (ownerName ? ' ' + T('$projectName:${tprefix}.defaults.for', 'for') + ' ' + ownerName : '')"></span>
 #if($statusProp != "")
     <span x-h-badge class="shrink-0" :data-variant="statusVariant(statusText())" x-show="mode === 'edit' && statusText()" x-text="statusText()"></span>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -15,7 +15,7 @@
 
   <div x-h-toolbar data-variant="transparent">
     <span x-h-toolbar-title class="shrink-0"
-          x-text="(mode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit') : T('$projectName:${tprefix}.defaults.new', 'New')) + ' ' + T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}')#if($docNumProp != '') + (form.${docNumProp} ? ' ' + form.${docNumProp} : '')#end + (ownerName ? ' ' + T('$projectName:${tprefix}.defaults.for', 'for') + ' ' + ownerName : '')"></span>
+          x-text="(mode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit') : T('$projectName:${tprefix}.defaults.new', 'New')) + ' ' + T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}')#if($docNumProp != '') + (window.HarmoniaFormat.documentNumber(form.${docNumProp}) ? ' ' + window.HarmoniaFormat.documentNumber(form.${docNumProp}) : '')#end + (ownerName ? ' ' + T('$projectName:${tprefix}.defaults.for', 'for') + ' ' + ownerName : '')"></span>
 #if($statusProp != "")
     <span x-h-badge class="shrink-0" :data-variant="statusVariant(statusText())" x-show="mode === 'edit' && statusText()" x-text="statusText()"></span>
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -24,7 +24,7 @@
          (heavier than the caption so it stands out), e.g. "Sales Invoice SI-0000001". -->
     <div class="hbox items-baseline gap-2 shrink-0">
       <span class="text-2xl font-semibold tracking-tight" x-text="T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}')"></span>
-      <span class="text-2xl font-bold tracking-tight" x-show="(isEdit || isPreview) && form.${docNumberProp}" x-text="form.${docNumberProp}"></span>
+      <span class="text-2xl font-bold tracking-tight" x-show="(isEdit || isPreview) && window.HarmoniaFormat.documentNumber(form.${docNumberProp})" x-text="window.HarmoniaFormat.documentNumber(form.${docNumberProp})"></span>
     </div>
 #else
     <span x-h-toolbar-title class="shrink-0" x-text="isPreview ? T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}') : (isEdit ? T('$projectName:${tprefix}.defaults.formHeadUpdate', 'Edit ${documentLabel}', { name: T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}') }) : T('$projectName:${tprefix}.defaults.formHeadCreate', 'New ${documentLabel}', { name: T('$projectName:${tprefix}.t.${dataName}', '${documentLabel}') }))"></span>


### PR DESCRIPTION
A not-yet-issued document holds a create-time **UUID placeholder** in its number field (until the real number is stamped at issue). The Harmonia document title rendered that raw UUID — e.g. *"SALES INVOICE 3f2a1c9e-…"*. Now a draft shows just the label.

- **`HarmoniaFormat.documentNumber(v)`** (shared `format.js`): returns `''` for a UUID-shaped value, else the value unchanged.
- The document title uses it in the main document view (`x-show` + `x-text`) and the partner / my document views → a draft reads *"Sales Invoice"*, and once issued *"Sales Invoice SI00000042"*.

Independent display fix — it also improves the **current** hand-written-placeholder behavior (the KF's `SalesInvoiceNumberAction` puts a UUID there today), not only first-class numbering. Verified: the shared `format.js` serves the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)