### PR TITLE
fix(numbering): quote the counter column in the increment SET expression (PostgreSQL)

### DIFF
--- a/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberStore.java
+++ b/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberStore.java
@@ -146,10 +146,17 @@ class DocumentNumberStore {
     }
 
     private int increment(Connection connection, String series, String scope) throws SQLException {
+        // The table is created with QUOTED (case-sensitive) identifiers, and the builder encapsulates
+        // the SET-target column and the WHERE-condition identifiers the same way. But the SET VALUE is a
+        // free expression appended verbatim (NOT encapsulated) - so its column reference must be quoted
+        // explicitly, otherwise a case-folding dialect (PostgreSQL lower-cases unquoted identifiers)
+        // fails to resolve it against the quoted-uppercase column (H2 upper-cases unquoted, so it
+        // happened to match). The WHERE columns stay unquoted: the builder quotes those for us (quoting
+        // them here would double-encapsulate into a zero-length delimited identifier).
         String sql = SqlFactory.getNative(connection)
                                .update()
                                .table(TABLE_NAME)
-                               .set(COLUMN_COUNTER, COLUMN_COUNTER + " + 1")
+                               .set(COLUMN_COUNTER, QUOTED_COUNTER + " + 1")
                                .where(COLUMN_SERIES + " = ? AND " + COLUMN_SCOPE + " = ?")
                                .build();
         try (PreparedStatement statement = connection.prepareStatement(sql)) {


### PR DESCRIPTION
### Problem
The `master` build's **integration-tests-postgresql** job fails in `NumberingSdkIT.allocatesAGapFreeFormattedSequence` (h2 job is green):

```
org.postgresql.util.PSQLException: ERROR: column "document_counter" does not exist
  Position: 62
  at ...DocumentNumberStore.increment(DocumentNumberStore.java:158)
```

`DocumentNumberStore` creates `DIRIGIBLE_DOCUMENT_NUMBERS` with **quoted** (case-sensitive, upper-case) identifiers, and the SQL builder encapsulates the SET-target column and the WHERE-condition identifiers the same way. But the increment's **SET value** is a free expression appended verbatim — `SET "DOCUMENT_COUNTER" = DOCUMENT_COUNTER + 1` — whose column reference was left **unquoted**. PostgreSQL lower-cases unquoted identifiers, so it looked for `document_counter` and could not find the quoted-upper-case column. H2 upper-cases unquoted identifiers, so it happened to match there — hence the green/red split.

### Fix
Quote the column reference in the SET **value** expression (`QUOTED_COUNTER`). One line.

The WHERE columns stay unquoted on purpose: the builder encapsulates those for us — quoting them explicitly double-encapsulates into a `zero-length delimited identifier ""` error (confirmed empirically while iterating).

### Verification
Ran `NumberingSdkIT` against a real `postgres:16` using the CI datasource env (`DIRIGIBLE_DATASOURCE_DEFAULT_*`):
- before the fix: `column "document_counter" does not exist`;
- after the fix: `Tests run: 1, Failures: 0, Errors: 0` — BUILD SUCCESS.

`NumberingSdkIT` runs in both the h2 and postgresql CI jobs, so it guards this regression going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)