### PR TITLE
feat(intent+harmonia): process task-form UX - full-height layout, status step indicator, dialog close icon

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.eclipse.dirigible.components.base.helpers.JsonHelper;
 import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
@@ -28,6 +29,7 @@ import org.eclipse.dirigible.components.intent.model.FormIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.model.ProcessIntent;
 import org.eclipse.dirigible.components.intent.model.RelationIntent;
+import org.eclipse.dirigible.components.intent.model.SeedIntent;
 import org.eclipse.dirigible.components.intent.model.StepIntent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,6 +103,13 @@ public class FormIntentGenerator implements IntentTargetGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FormIntentGenerator.class);
 
+    /**
+     * Terminal / negative status names excluded from the step indicator - a cancel/reject/void is an
+     * off-path outcome (it stays the status pill), not a forward step. Same heuristic the badge
+     * colouring uses so the two stay consistent.
+     */
+    private static final Pattern TERMINAL_STATUS = Pattern.compile("(cancel|reject|declin|void|fail|overdue|insufficient|exhaust)");
+
     @Override
     public String name() {
         return "form";
@@ -137,7 +146,7 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                 continue;
             }
             EntityIntent boundEntity = form.getForEntity() == null ? null : entitiesByName.get(form.getForEntity());
-            Map<String, Object> document = buildForm(form, boundEntity, entitiesByName, taskFormNames.contains(form.getName()));
+            Map<String, Object> document = buildForm(form, boundEntity, entitiesByName, taskFormNames.contains(form.getName()), model);
             context.writeModelFile(fileName, JsonHelper.toJson(document));
         }
     }
@@ -169,10 +178,29 @@ public class FormIntentGenerator implements IntentTargetGenerator {
         return index;
     }
 
+    /**
+     * Test seam: build the form documents ({@code form name -> document}) for a parsed model without
+     * writing any files - so emission (e.g. the status-flow step-indicator metadata) can be asserted.
+     */
+    static Map<String, Map<String, Object>> buildFormsForTest(IntentModel model) {
+        Map<String, EntityIntent> entitiesByName = indexEntities(model);
+        Set<String> taskFormNames = taskFormNames(model);
+        Map<String, Map<String, Object>> documents = new LinkedHashMap<>();
+        for (FormIntent form : model.getForms()) {
+            if (form.getName() == null || form.getName()
+                                              .isBlank()) {
+                continue;
+            }
+            EntityIntent boundEntity = form.getForEntity() == null ? null : entitiesByName.get(form.getForEntity());
+            documents.put(form.getName(), buildForm(form, boundEntity, entitiesByName, taskFormNames.contains(form.getName()), model));
+        }
+        return documents;
+    }
+
     private static Map<String, Object> buildForm(FormIntent form, EntityIntent entity, Map<String, EntityIntent> entitiesByName,
-            boolean isTaskForm) {
+            boolean isTaskForm, IntentModel model) {
         Map<String, Object> document = new LinkedHashMap<>();
-        document.put("metadata", buildMetadata(form, isTaskForm));
+        document.put("metadata", buildMetadata(form, isTaskForm, entity, model));
         document.put("feeds", new ArrayList<>());
         document.put("scripts", new ArrayList<>());
         document.put("code", buildCode(form, isTaskForm));
@@ -186,7 +214,7 @@ public class FormIntentGenerator implements IntentTargetGenerator {
      * bound entity's logical name and the editable-field set. Only logical model names are emitted -
      * never a template-engine output path, which the intent layer must stay agnostic about.
      */
-    private static Map<String, Object> buildMetadata(FormIntent form, boolean isTaskForm) {
+    private static Map<String, Object> buildMetadata(FormIntent form, boolean isTaskForm, EntityIntent entity, IntentModel model) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         if (isTaskForm) {
             metadata.put("taskForm", true);
@@ -194,8 +222,62 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                 metadata.put("entity", form.getForEntity());
             }
             metadata.put("editable", new ArrayList<>(form.getEditable()));
+            putStatusSteps(metadata, entity, model);
         }
         return metadata;
+    }
+
+    /**
+     * The document status flow for the read-only step indicator. When the bound entity has a
+     * {@code function: EntityStatus} relation to a LOCAL status entity, emit that entity's non-terminal
+     * status names (its base seed rows, in seed order, dropping cancel/reject/void-style terminal
+     * statuses via {@link #TERMINAL_STATUS}) as {@code steps}, plus {@code statusVar} - the model
+     * variable holding the current status name (the relation name). The runtime renders these as a
+     * horizontal step indicator with the current status active. Skipped when the status entity is
+     * cross-model (its seeds are not on this model) or the flow has fewer than two steps.
+     */
+    private static void putStatusSteps(Map<String, Object> metadata, EntityIntent entity, IntentModel model) {
+        if (entity == null || entity.getRelations() == null || model == null) {
+            return;
+        }
+        RelationIntent statusRel = null;
+        for (RelationIntent relation : entity.getRelations()) {
+            if (relation.isEntityStatus()) {
+                statusRel = relation;
+                break;
+            }
+        }
+        if (statusRel == null || statusRel.getTo() == null) {
+            return;
+        }
+        if (statusRel.getModel() != null && !statusRel.getModel()
+                                                      .isBlank()) {
+            return; // cross-model status entity: its seeds live in the owner module, not resolvable here
+        }
+        List<String> steps = new ArrayList<>();
+        for (SeedIntent seed : model.getSeeds()) {
+            if (seed.getLanguage() != null || !statusRel.getTo()
+                                                        .equals(seed.getEntity())
+                    || seed.getRows() == null) {
+                continue; // base rows of the status entity only (skip translation seeds)
+            }
+            for (Map<String, Object> row : seed.getRows()) {
+                Object name = row.get("name");
+                if (name == null) {
+                    continue;
+                }
+                String label = name.toString();
+                if (TERMINAL_STATUS.matcher(label.toLowerCase(Locale.ROOT))
+                                   .find()) {
+                    continue; // terminal / off-path status - stays the pill, not a step
+                }
+                steps.add(label);
+            }
+        }
+        if (steps.size() >= 2) {
+            metadata.put("steps", steps);
+            metadata.put("statusVar", statusRel.getName());
+        }
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/form/FormIntentGenerator.java
@@ -254,7 +254,7 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                                                       .isBlank()) {
             return; // cross-model status entity: its seeds live in the owner module, not resolvable here
         }
-        List<String> steps = new ArrayList<>();
+        List<Map<String, Object>> steps = new ArrayList<>();
         for (SeedIntent seed : model.getSeeds()) {
             if (seed.getLanguage() != null || !statusRel.getTo()
                                                         .equals(seed.getEntity())
@@ -271,7 +271,16 @@ public class FormIntentGenerator implements IntentTargetGenerator {
                                    .find()) {
                     continue; // terminal / off-path status - stays the pill, not a step
                 }
-                steps.add(label);
+                Map<String, Object> step = new LinkedHashMap<>();
+                step.put("label", label);
+                Object description = row.get("description");
+                if (description != null && !description.toString()
+                                                       .isBlank()) {
+                    // Optional per-status help text, authored as a `description` seed column on the
+                    // status entity - shown under the step title. Absent -> title only.
+                    step.put("description", description.toString());
+                }
+                steps.add(step);
             }
         }
         if (steps.size() >= 2) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormStepIndicatorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormStepIndicatorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator.form;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the document-status-flow step-indicator metadata the {@link FormIntentGenerator} emits
+ * on a BPM task form: the ordered non-terminal status names ({@code steps}) taken from the bound
+ * entity's {@code function: EntityStatus} relation seeds, plus the current-status variable
+ * ({@code statusVar}). A terminal (cancel/void/…) status is excluded, translation seeds are
+ * ignored, and a non-task form gets no steps.
+ */
+class FormStepIndicatorTest {
+
+    private static final String YAML = """
+            name: sales
+            entities:
+              - name: OrderStatus
+                function: Setting
+                multilingual: true
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: SalesOrder
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                relations:
+                  - { name: Status, kind: manyToOne, to: OrderStatus, function: EntityStatus, init: 1 }
+            processes:
+              - name: OrderApproval
+                trigger: { onCreate: SalesOrder }
+                steps:
+                  - { name: confirm, kind: userTask, args: { assignee: manager, form: ConfirmOrder } }
+                  - { name: end, kind: end }
+            forms:
+              - { name: ConfirmOrder, forEntity: SalesOrder, fields: [Status], actions: [confirm] }
+              - { name: PlainOrder, forEntity: SalesOrder, fields: [Status] }
+            seeds:
+              - name: order-statuses
+                entity: OrderStatus
+                rows:
+                  - { id: 1, name: DRAFT }
+                  - { id: 2, name: APPROVED }
+                  - { id: 3, name: SHIPPED }
+                  - { id: 4, name: CANCELLED }
+              - name: order-statuses-bg
+                entity: OrderStatus
+                language: bg
+                rows:
+                  - { id: 1, name: "Чернова" }
+            """;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void emitsTheStatusFlowStepsOnTheTaskForm() {
+        IntentModel model = IntentParser.parse(YAML);
+        Map<String, Map<String, Object>> forms = FormIntentGenerator.buildFormsForTest(model);
+
+        Map<String, Object> meta = (Map<String, Object>) forms.get("ConfirmOrder")
+                                                              .get("metadata");
+        assertEquals(Boolean.TRUE, meta.get("taskForm"));
+        // CANCELLED is terminal (excluded); the bg translation seed is ignored; order is seed order.
+        assertEquals(List.of("DRAFT", "APPROVED", "SHIPPED"), meta.get("steps"));
+        // The current-status model variable is the EntityStatus relation name.
+        assertEquals("Status", meta.get("statusVar"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void noStepsOnANonTaskForm() {
+        IntentModel model = IntentParser.parse(YAML);
+        Map<String, Map<String, Object>> forms = FormIntentGenerator.buildFormsForTest(model);
+
+        Map<String, Object> meta = (Map<String, Object>) forms.get("PlainOrder")
+                                                              .get("metadata");
+        assertFalse(meta.containsKey("taskForm"));
+        assertFalse(meta.containsKey("steps"));
+        assertTrue(meta.get("statusVar") == null);
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormStepIndicatorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/form/FormStepIndicatorTest.java
@@ -38,6 +38,7 @@ class FormStepIndicatorTest {
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string }
+                  - { name: description, type: string }
               - name: SalesOrder
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
@@ -56,10 +57,10 @@ class FormStepIndicatorTest {
               - name: order-statuses
                 entity: OrderStatus
                 rows:
-                  - { id: 1, name: DRAFT }
-                  - { id: 2, name: APPROVED }
+                  - { id: 1, name: DRAFT, description: Being prepared }
+                  - { id: 2, name: APPROVED, description: Ready to ship }
                   - { id: 3, name: SHIPPED }
-                  - { id: 4, name: CANCELLED }
+                  - { id: 4, name: CANCELLED, description: Called off }
               - name: order-statuses-bg
                 entity: OrderStatus
                 language: bg
@@ -77,7 +78,9 @@ class FormStepIndicatorTest {
                                                               .get("metadata");
         assertEquals(Boolean.TRUE, meta.get("taskForm"));
         // CANCELLED is terminal (excluded); the bg translation seed is ignored; order is seed order.
-        assertEquals(List.of("DRAFT", "APPROVED", "SHIPPED"), meta.get("steps"));
+        // Each step carries its label plus the optional `description` seed column (absent -> no key).
+        assertEquals(List.of(Map.of("label", "DRAFT", "description", "Being prepared"),
+                Map.of("label", "APPROVED", "description", "Ready to ship"), Map.of("label", "SHIPPED")), meta.get("steps"));
         // The current-status model variable is the EntityStatus relation name.
         assertEquals("Status", meta.get("statusVar"));
     }

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_documents.html
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/shell/views/_documents.html
@@ -155,7 +155,7 @@
   <!-- New folder dialog -->
   <div x-h-dialog-overlay :data-open="newFolderOpen">
     <div x-h-dialog>
-      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.newFolder', 'New folder')"></h2><button x-h-dialog-close @click="newFolderOpen = false" aria-label="Close"></button></div>
+      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.newFolder', 'New folder')"></h2><button x-h-dialog-close @click="newFolderOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button></div>
       <div x-h-dialog-content>
         <div x-h-field>
           <label x-h-label for="nf" x-text="T('application-core:shell.documents.folderName', 'Folder name')"></label>
@@ -173,7 +173,7 @@
   <!-- Rename dialog -->
   <div x-h-dialog-overlay :data-open="renameOpen">
     <div x-h-dialog>
-      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.rename', 'Rename')"></h2><button x-h-dialog-close @click="renameOpen = false" aria-label="Close"></button></div>
+      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.rename', 'Rename')"></h2><button x-h-dialog-close @click="renameOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button></div>
       <div x-h-dialog-content>
         <div x-h-field>
           <label x-h-label for="rn" x-text="T('application-core:shell.documents.newName', 'New name')"></label>
@@ -191,7 +191,7 @@
   <!-- Delete dialog -->
   <div x-h-dialog-overlay :data-open="deleteOpen">
     <div x-h-dialog>
-      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.delete', 'Delete')"></h2><button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button></div>
+      <div x-h-dialog-header><h2 x-h-dialog-title x-text="T('application-core:shell.documents.delete', 'Delete')"></h2><button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button></div>
       <div x-h-dialog-content>
         <p x-show="deleteTargets.length === 1">Delete <strong x-text="deleteTargets[0] && deleteTargets[0].name"></strong>? This cannot be undone.</p>
         <p x-show="deleteTargets.length > 1">Delete <strong x-text="deleteTargets.length"></strong> items? This cannot be undone.</p>

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/index.html
@@ -262,7 +262,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
-          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
@@ -278,7 +278,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
-          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"

--- a/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/index.html
+++ b/components/resources/resources-my/src/main/resources/META-INF/dirigible/my/index.html
@@ -237,7 +237,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
-          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
@@ -253,7 +253,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
-          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"

--- a/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
+++ b/components/resources/resources-partner/src/main/resources/META-INF/dirigible/partner/index.html
@@ -237,7 +237,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
-          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
@@ -253,7 +253,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
-          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -264,7 +264,7 @@
     <div x-h-dialog style="width: 92vw; max-width: 640px;">
       <div x-h-dialog-header>
         <h2 x-h-dialog-title x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></h2>
-        <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <div class="grid grid-cols-2 gap-4">
@@ -307,7 +307,7 @@
     <div x-h-dialog data-size="sm">
       <div x-h-dialog-header>
         <span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span>
-        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content><p x-h-text.muted x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure? This cannot be undone.')"></p></div>
       <div x-h-dialog-footer>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -177,7 +177,7 @@
     <div x-h-dialog data-size="sm">
       <div x-h-dialog-header>
         <span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span>
-        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content><p x-h-text.muted x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure? This cannot be undone.')"></p></div>
       <div x-h-dialog-footer>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -155,7 +155,7 @@
     <div x-h-dialog style="width: 92vw; max-width: 640px;">
       <div x-h-dialog-header>
         <h2 x-h-dialog-title x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></h2>
-        <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="itemDialog = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <div class="grid grid-cols-2 gap-4">
@@ -198,7 +198,7 @@
     <div x-h-dialog data-size="sm">
       <div x-h-dialog-header>
         <span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span>
-        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content><p x-h-text.muted x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure? This cannot be undone.')"></p></div>
       <div x-h-dialog-footer>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
@@ -171,7 +171,7 @@
     <div x-h-dialog data-size="sm">
       <div x-h-dialog-header>
         <span x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + '?'"></span>
-        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content><p x-h-text.muted x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure? This cannot be undone.')"></p></div>
       <div x-h-dialog-footer>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -375,7 +375,7 @@ document.addEventListener('alpine:init', () => {
           parent: '${property.widgetHierarchyProperty}', leafOnly: true
         });
 #else
-        this.options${property.name} = (rows${property.name} || []).map(e => ({ value: e.${property.widgetDropDownKey}, text: e.${property.widgetDropDownValue} }));
+        this.options${property.name} = (rows${property.name} || []).map(e => ({ value: e.${property.widgetDropDownKey}, text: e.${property.widgetDropDownValue}#if($property.widgetType == "DOCUMENT_STATUS"), description: e.description#end }));
 #end
       } catch (e) {
         console.error('[${name}DocumentPage] failed to load options for ${property.name}', e);
@@ -415,7 +415,7 @@ document.addEventListener('alpine:init', () => {
           conditions: [{ propertyName: '${property.widgetDependsOnFilterBy}', operator: 'EQ', value: from }#if($property.widgetOptionsFilterBy),
             { propertyName: '${property.widgetOptionsFilterBy}', operator: 'EQ', value: ${property.widgetOptionsFilterValueJs} }#end]
         }, { baseUrl: '' });
-        this.options${property.name} = (rows || []).map(e => ({ value: e.${property.widgetDropDownKey}, text: e.${property.widgetDropDownValue} }));
+        this.options${property.name} = (rows || []).map(e => ({ value: e.${property.widgetDropDownKey}, text: e.${property.widgetDropDownValue}#if($property.widgetType == "DOCUMENT_STATUS"), description: e.description#end }));
         if (adjust) {
           this.form.${property.name} = this.options${property.name}.length === 1 ? String(this.options${property.name}[0].value) : '';
         }
@@ -755,6 +755,19 @@ document.addEventListener('alpine:init', () => {
       if (/(approv|accept|activ|complet|paid|done|available)/.test(t)) return 'positive';
       if (/(issu|sent|ship|process|submit)/.test(t)) return 'information';
       return 'default';
+    },
+    // Forward status flow for the read-only step indicator: the loaded status options minus the
+    // terminal / off-path ones (cancel/void/... stay the pill). Each option carries {value, text} and,
+    // when the status entity has a `description` seed column, `description` (shown under the title).
+    statusSteps() {
+      return (this.options${docStatusProp} || []).filter(o => this.statusVariant(o.text) !== 'negative');
+    },
+    // 1-based index of the current status among the steps (0 when the status is terminal or unset,
+    // so no step is active).
+    activeStep() {
+      const current = this.statusText();
+      return this.statusSteps()
+                 .findIndex(o => String(o.text) === String(current)) + 1;
     },
 #end
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -384,7 +384,7 @@
           <div x-h-dialog>
             <div x-h-dialog-header>
               <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + ' ' + T(def.tkey, def.label)"></h2>
-              <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+              <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
             </div>
             <div x-h-dialog-content><p>Are you sure? This cannot be undone. The document totals will be recalculated.</p></div>
             <div x-h-dialog-footer>
@@ -478,7 +478,7 @@
     <div x-h-dialog>
       <div x-h-dialog-header>
         <h2 x-h-dialog-title x-text="draftMode === 'edit' ? T('$projectName:${tprefix}.defaults.edit', 'Edit line') : T('$projectName:${tprefix}.defaults.add', 'Add line')"></h2>
-        <button x-h-dialog-close @click="closeRowDialog()" aria-label="Close"></button>
+        <button x-h-dialog-close @click="closeRowDialog()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <div x-show="draftError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="draftError"></div></div>
@@ -553,7 +553,7 @@
       <div x-h-dialog-header>
         <h2 x-h-dialog-title>Delete line</h2>
         <p x-h-dialog-description>Delete this line item? This cannot be undone.</p>
-        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-footer>
         <button x-h-button data-variant="transparent" @click="deleteOpen = false">Cancel</button>
@@ -569,7 +569,7 @@
       <div x-h-dialog-header>
         <h2 x-h-dialog-title>Print</h2>
         <p x-h-dialog-description>Choose the template language.</p>
-        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"></button>
+        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <div class="vbox gap-2">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -446,8 +446,9 @@
 #foreach($property in $properties)
 #if($property.isReadOnlyProperty == "true" || ($property.auditType && $property.auditType != "NONE"))#set($hasReadOnly = true)#end
 #end
-#if($hasReadOnly)
+#if($hasReadOnly || $docStatusProp != "")
     <div class="vbox gap-4 shrink-0" style="width: 18rem;" x-show="isEdit || isPreview">
+#if($hasReadOnly)
       <div x-h-card>
         <div x-h-card-header><h3 x-h-card-title x-text="T('$projectName:${tprefix}.defaults.details', 'Details')"></h3></div>
         <div x-h-card-content>
@@ -468,6 +469,31 @@
           </div>
         </div>
       </div>
+#end
+#if($docStatusProp != "")
+      <!-- Read-only status step indicator: the document's forward status flow (the non-terminal
+           statuses in workflow order), current status active. The title-bar pill is kept. Step
+           descriptions come from the status entity's optional `description` seed column. -->
+      <div x-h-card x-show="statusText()">
+        <div x-h-card-header><h3 x-h-card-title x-text="T('$projectName:${tprefix}.defaults.status', 'Status')"></h3></div>
+        <div x-h-card-content>
+          <nav x-h-step-indicator="activeStep()" data-orientation="vertical">
+            <template x-for="(step, i) in statusSteps()" :key="step.value">
+              <div x-h-step-indicator-item="i + 1">
+                <button x-h-step-indicator-trigger data-non-interactive="true" type="button">
+                  <span x-h-step-indicator-marker x-text="i + 1"></span>
+                  <span x-h-step-indicator-content>
+                    <span x-h-step-indicator-title x-text="step.text"></span>
+                    <span x-h-step-indicator-description x-show="step.description" x-text="step.description"></span>
+                  </span>
+                </button>
+                <span x-h-step-indicator-separator x-show="i < statusSteps().length - 1"></span>
+              </div>
+            </template>
+          </nav>
+        </div>
+      </div>
+#end
     </div>
 #end
 

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -318,7 +318,7 @@
             <div x-h-dialog>
               <div x-h-dialog-header>
                 <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete') + ' ' + T(def.tkey, def.label)"></h2>
-                <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+                <button type="button" x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
               </div>
               <div x-h-dialog-content><p>Are you sure? This cannot be undone.</p></div>
               <div x-h-dialog-footer>
@@ -407,7 +407,7 @@
       <div x-h-dialog-header>
         <h2 x-h-dialog-title>Print</h2>
         <p x-h-dialog-description>Choose the template language.</p>
-        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"></button>
+        <button x-h-dialog-close @click="printLangOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <div class="vbox gap-2">

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/list-view.html.template
@@ -324,7 +324,7 @@
       <div x-h-dialog-header>
         <h2 x-h-dialog-title x-text="T('$projectName:${tprefix}.defaults.deleteTitle', 'Delete ${entityLabel}', { name: T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}') })"></h2>
         <p x-h-dialog-description></p>
-        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content>
         <p x-text="T('$projectName:${tprefix}.messages.deleteConfirm', 'Are you sure you want to delete this record?', { name: T('$projectName:${tprefix}.t.${dataName}', '${entityLabel}') })"></p>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -262,7 +262,7 @@
     <div x-h-dialog>
       <div x-h-dialog-header>
         <h2 x-h-dialog-title>Delete ${name}</h2>
-        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"></button>
+        <button x-h-dialog-close @click="deleteOpen = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
       </div>
       <div x-h-dialog-content><p>Are you sure you want to delete this ${name}? This cannot be undone.</p></div>
       <div x-h-dialog-footer>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/shell/index.html.template
@@ -276,7 +276,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.processTasks.formTitle"></h2>
-          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.processTasks.closeForm()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.processTasks.formOpen" :src="$store.processTasks.formUrl"
@@ -292,7 +292,7 @@
       <div x-h-dialog style="width: 92vw; max-width: 1100px;">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.customActions.dialogTitle"></h2>
-          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.customActions.closeDialog()" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content>
           <iframe x-show="$store.customActions.dialogOpen" :src="$store.customActions.dialogUrl"
@@ -569,7 +569,7 @@
       <div x-h-dialog data-size="lg">
         <div x-h-dialog-header>
           <h2 x-h-dialog-title x-text="$store.related.title"></h2>
-          <button x-h-dialog-close @click="$store.related.open = false" aria-label="Close"></button>
+          <button x-h-dialog-close @click="$store.related.open = false" aria-label="Close"><i role="img" x-h-lucide data-lucide="x"></i></button>
         </div>
         <div x-h-dialog-content class="p-0">
           <iframe x-show="$store.related.open" :src="$store.related.src" title="Add new" style="width:100%; height:70vh; border:0;"></iframe>

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
@@ -153,12 +153,15 @@
         <!-- Document status flow, extracted from the intent (the bound entity's function: EntityStatus
              relation -> the status entity's non-terminal seeds, in order). Read-only (non-interactive);
              active step = the current status name (model.$metadata.statusVar). -->
-        <nav x-h-step-indicator="([#foreach($s in $metadata.steps)'$s'#if($foreach.hasNext), #end#end]).indexOf(model.${metadata.statusVar}) + 1" data-orientation="horizontal" class="col-span-full mb-4">
-          <template x-for="(label, i) in [#foreach($s in $metadata.steps)'$s'#if($foreach.hasNext), #end#end]" :key="label">
+        <nav x-h-step-indicator="([#foreach($s in $metadata.steps){ label: '$s.label' }#if($foreach.hasNext), #end#end]).findIndex(s => s.label === model.${metadata.statusVar}) + 1" data-orientation="horizontal" class="col-span-full mb-4">
+          <template x-for="(step, i) in [#foreach($s in $metadata.steps){ label: '$s.label', description: '$!s.description' }#if($foreach.hasNext), #end#end]" :key="step.label">
             <div x-h-step-indicator-item="i + 1">
               <button x-h-step-indicator-trigger data-non-interactive="true" type="button">
                 <span x-h-step-indicator-marker x-text="i + 1"></span>
-                <span x-h-step-indicator-content><span x-h-step-indicator-title x-text="label"></span></span>
+                <span x-h-step-indicator-content>
+                  <span x-h-step-indicator-title x-text="step.label"></span>
+                  <span x-h-step-indicator-description x-show="step.description" x-text="step.description"></span>
+                </span>
               </button>
               <span x-h-step-indicator-separator x-show="i < ($metadata.steps.size() - 1)"></span>
             </div>

--- a/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
+++ b/components/template/template-form-builder-harmonia/src/main/resources/META-INF/dirigible/template-form-builder-harmonia/ui/index.html.template
@@ -128,26 +128,71 @@
          applied by harmonia.min.js (below), which reads the shared `codbex.harmonia.colorMode` the
          shell set — so this iframe'd form matches the shell (light/dark) automatically. */
       html { background-color: var(--background); color: var(--foreground); }
-      body { min-height: 100vh; }
+      /* Fill the host dialog/viewport: the body is a flex column so the form (and, on a task form,
+         its card) grow to the full height instead of floating at content height in the top-left. */
+      body { min-height: 100vh; display: flex; flex-direction: column; }
       [x-cloak] { display: none !important; }
     </style>
   </head>
   <body class="p-4" x-data="harmoniaForm" x-cloak>
-    <form class="vbox gap-4" style="max-width: 720px;" @submit.prevent="submit()">
+    <form class="vbox gap-4" style="flex: 1 1 auto;" @submit.prevent="submit()">
       <div x-show="message" x-h-alert data-variant="information" role="status">
         <div x-h-alert-description x-text="message"></div>
       </div>
 #if($metadata.taskForm)
-      <!-- Task form: read-only fields render inside a headerless Details card (framed), matching the
-           entity detail / document view. A responsive two-column detail grid (single column below the
-           sm breakpoint); headers, separators, textareas and the action-button row span both columns.
-           Editable opt-in inputs and the actions live in the same card. -->
-      <div x-h-card>
-        <div x-h-card-content>
+      <!-- Task form: read-only fields render inside a headerless Details card (framed) that fills the
+           dialog height. A responsive two-column detail grid (single column below the sm breakpoint);
+           the action buttons are pulled into a bottom-pinned footer. When the bound document has a
+           status flow, a read-only horizontal step indicator (the non-terminal statuses in seed order,
+           active = the current status) is shown at the top, bracketed by separators. -->
+      <div x-h-card style="flex: 1 1 auto; display: flex; flex-direction: column;">
+        <div x-h-card-content style="flex: 1 1 auto; display: flex; flex-direction: column;">
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-x-10 gap-y-3">
+#if($metadata.steps && $metadata.steps.size() > 0)
+        <hr class="col-span-full mb-4" style="border: none; border-top: 1px solid var(--border);" />
+        <!-- Document status flow, extracted from the intent (the bound entity's function: EntityStatus
+             relation -> the status entity's non-terminal seeds, in order). Read-only (non-interactive);
+             active step = the current status name (model.$metadata.statusVar). -->
+        <nav x-h-step-indicator="([#foreach($s in $metadata.steps)'$s'#if($foreach.hasNext), #end#end]).indexOf(model.${metadata.statusVar}) + 1" data-orientation="horizontal" class="col-span-full mb-4">
+          <template x-for="(label, i) in [#foreach($s in $metadata.steps)'$s'#if($foreach.hasNext), #end#end]" :key="label">
+            <div x-h-step-indicator-item="i + 1">
+              <button x-h-step-indicator-trigger data-non-interactive="true" type="button">
+                <span x-h-step-indicator-marker x-text="i + 1"></span>
+                <span x-h-step-indicator-content><span x-h-step-indicator-title x-text="label"></span></span>
+              </button>
+              <span x-h-step-indicator-separator x-show="i < ($metadata.steps.size() - 1)"></span>
+            </div>
+          </template>
+        </nav>
+        <hr class="col-span-full mb-4" style="border: none; border-top: 1px solid var(--border);" />
+#end
+#foreach($element in $form)
+#if($element.controlId == "container-hbox")
+## action row: rendered as the bottom-pinned footer below (outside the detail grid)
+#elseif($element.controlId == "container-vbox")
+        <div class="vbox gap-3 col-span-full">
+#foreach($child in $element.children)
+#leaf($child)
+#end
+        </div>
+#else
+#leaf($element)
+#end
+#end
+          </div>
+#foreach($element in $form)
+#if($element.controlId == "container-hbox")
+        <div class="hbox gap-3 items-end pt-4" style="margin-top: auto; border-top: 1px solid var(--border);">
+#foreach($child in $element.children)
+#leaf($child)
+#end
+        </div>
+#end
+#end
+        </div>
+      </div>
 #else
       <div x-h-field-group>
-#end
 #foreach($element in $form)
 #if($element.controlId == "container-hbox")
         <div class="hbox gap-3 items-end col-span-full mt-2">
@@ -165,11 +210,6 @@
 #leaf($element)
 #end
 #end
-#if($metadata.taskForm)
-          </div>
-        </div>
-      </div>
-#else
       </div>
 #end
     </form>


### PR DESCRIPTION
## What

Step-indicator + polish for the status-driven UX, in three areas.

### 1. Full-height task-form layout
The generated task-form template hard-coded `max-width: 720px`, so in the full-screen task dialog the form floated tiny in the top-left. Removed the cap; the `body` is a flex column and, on a task form, the card fills the dialog height with the action buttons in a **bottom-pinned footer**.

### 2. Document status step indicator (extracted from the intent)
A status flow (`function: EntityStatus` relation) now renders as a read-only **`x-h-step-indicator`**, current status active - so the user sees where in the lifecycle a document is. Two surfaces:
- **BPM task forms** - a horizontal indicator at the top of the form, bracketed by separators.
- **Single-record document page** - a vertical indicator card under the Details box in the right sidebar (the title-bar status pill is kept).

The steps come straight from the intent: the status entity's base seed rows, in seed = workflow order, dropping terminal `cancel/reject/void/…` statuses (the same heuristic the badge colouring uses). The task form embeds them at generation time (`FormIntentGenerator` -> `metadata.steps` + `metadata.statusVar`); the document page reads the status options loaded at runtime (`statusSteps()` / `activeStep()`).

**Step descriptions** - an optional `description` seed column on the status entity is surfaced under each step title (title-only when absent). Emitted as `{label, description}` on task forms; carried on the status option objects for the document page.

Requires **harmonia 2.6.0** (dynamic step number, codbex/harmonia#45), already on master.

### 3. Empty dialog close ("X") button
Every `x-h-dialog-close` button across the shells and generated page views was emitted **empty** - no icon child - so the close control was invisible (only its focus ring showed). Added the standard `<i x-h-lucide data-lucide="x">` to all 26 occurrences.

## Verification
- `FormStepIndicatorTest` (new): ordered non-terminal steps, description flows (and is absent when the seed row has none), translation seeds ignored, `statusVar` correct, none on a non-task form. Green.
- Regenerated a status-bearing module on this build and confirmed the emitted task form (object steps + `findIndex` active-match + description spans) and document page (`optionsStatus` carries `description`, `statusSteps()`/`activeStep()`, vertical stepper card). Layout + rendering validated live.

## Follow-up (same pattern, not in this PR)
The vertical stepper on the `manage/form` view (has a sidebar) and the `my-document` / `my-form` views (no sidebar - placement TBD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)