### PR TITLE
feat(intent): honor `major` on to-one relations (off the list, still in the form)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -1108,7 +1108,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 : relation.getSize()
                           .toString());
         p.put("widgetLength", "20");
-        p.put("widgetIsMajor", "true");
+        p.put("widgetIsMajor", relation.isMajor() ? "true" : "false");
         p.put("widgetDropDownKey", keyFieldName(target));
         p.put("widgetDropDownValue", labelFieldName(target));
         putLookupColumns(p, relation);
@@ -1157,7 +1157,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 : relation.getSize()
                           .toString());
         p.put("widgetLength", "20");
-        p.put("widgetIsMajor", "true");
+        p.put("widgetIsMajor", relation.isMajor() ? "true" : "false");
         p.put("widgetDropDownKey", info.keyField());
         p.put("widgetDropDownValue", info.labelField());
         putLookupColumns(p, relation);

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RelationIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/RelationIntent.java
@@ -66,6 +66,13 @@ public class RelationIntent {
      */
     private Integer size;
     /**
+     * Whether this to-one relation shows as a column in the entity's list / document-items table
+     * ({@code widgetIsMajor}). Defaults to {@code true} (relations are list columns). Set
+     * {@code major: false} to keep the dropdown in the create/edit form and detail pane but off the
+     * list table - the relation counterpart of a field's {@code major: false}.
+     */
+    private boolean major = true;
+    /**
      * Optional list of the target entity's field names to surface as extra <b>read-only</b> columns
      * wherever this to-one relation shows as a lookup column (the master-detail / document allocation
      * tables). The FK lookup already fetches the referenced rows to resolve the display label, so these
@@ -229,6 +236,14 @@ public class RelationIntent {
 
     public void setSize(Integer size) {
         this.size = size;
+    }
+
+    public boolean isMajor() {
+        return major;
+    }
+
+    public void setMajor(boolean major) {
+        this.major = major;
     }
 
     public List<String> getShow() {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -343,6 +343,36 @@ class EdmIntentGeneratorTest {
     }
 
     @Test
+    void relationMajorFalseEmitsWidgetIsMajorFalseAndDefaultsTrue() {
+        String yaml = """
+                name: shop
+                uses:
+                  - { model: products }
+                entities:
+                  - name: Category
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                  - name: OrderItem
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: name, type: string }
+                    relations:
+                      - { name: Category, kind: manyToOne, to: Category }                             # default -> list column
+                      - { name: Note, kind: manyToOne, to: Category, major: false }                   # local, off the list
+                      - { name: Product, kind: manyToOne, to: Product, model: products, major: false } # cross-model, off the list
+                """;
+        IntentModel parsed = IntentParser.parse(yaml);
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(parsed, "shop");
+        Map<String, Object> item = entityByName(entities(model), "OrderItem");
+
+        assertEquals("true", propertyByName(item, "Category").get("widgetIsMajor"), "a relation is a list column by default");
+        assertEquals("false", propertyByName(item, "Note").get("widgetIsMajor"), "major:false keeps a local relation off the list table");
+        assertEquals("false", propertyByName(item, "Product").get("widgetIsMajor"),
+                "major:false keeps a cross-model relation off the list table");
+    }
+
+    @Test
     void documentMasterWithACalendarViewStillCarriesThePrintFlag() {
         // A document (header-items) master whose UI is overridden to a range calendar: the layout
         // becomes MANAGE_CALENDAR (the document page is replaced by the calendar + the shared manage


### PR DESCRIPTION
## What

A relation's `major` attribute was silently ignored. `RelationIntent` had no `major` field, and `EdmIntentGenerator` hardcoded `widgetIsMajor="true"` for every relation (both `relationProperty` and `crossModelRelationProperty`). So `major: false` on a `manyToOne`/`oneToOne` parsed without error but never dropped the dropdown from the entity list / document-items table.

## Change

- `RelationIntent`: new `major` field (default `true`) + `isMajor()`/`setMajor()`.
- `EdmIntentGenerator`: both relation emitters now emit `widgetIsMajor` from `relation.isMajor()`.

The Harmonia `detail-register` columns loop already filters on `widgetIsMajor`, so a `major: false` relation now renders in the create/edit **form** and detail pane but **not** as a list/items-table **column** — the exact counterpart of a field's `major: false` (already supported). Default `true` preserves all existing behavior; the attribute is opt-in.

## Motivation

Document line-item tables often want the FK dropdown in the add/edit dialog only, with a Depends-On-copied descriptive field shown as the single column instead (e.g. an invoice item auto-copying the Product's name into an editable `Name`, and hiding the raw `Product` column). That needs `major: false` on the relation, which this enables.

## Test

`EdmIntentGeneratorTest#relationMajorFalseEmitsWidgetIsMajorFalseAndDefaultsTrue` — a local and a cross-model `major: false` relation emit `widgetIsMajor=false`; a default relation stays `true`. Full engine-intent unit suite green (214).

Docs follow-up (separate `dirigible.io` PR): extend the DSL reference note on `major: false` to say it applies to relations too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)