### PR TITLE
chore(logging): silence Hibernate hbm.xml deprecation warning (HHH90000028)

### DIFF
--- a/modules/commons/commons-resources/src/main/resources/logback.xml
+++ b/modules/commons/commons-resources/src/main/resources/logback.xml
@@ -84,6 +84,10 @@
 
     <logger name="net.snowflake.client" level="ERROR"/>
 
+    <!-- Silence Hibernate's legacy hbm.xml deprecation notice (HHH90000028). The hbm mapping comes
+         from a third-party dependency, not from Dirigible, so the WARN is noise we cannot act on. -->
+    <logger name="org.hibernate.orm.deprecation" level="ERROR"/>
+
     <!-- Configuration for the 'open-telemetry' Spring profile -->
     <springProfile name="open-telemetry">
         <appender name="OpenTelemetry"


### PR DESCRIPTION
### Problem
On startup / synchronization Hibernate logs a recurring WARN:

```
[WARN] org.hibernate.orm.deprecation - HHH90000028: Support for `<hibernate-mappings/>`
is deprecated [INPUT_STREAM : null]; migrate to orm.xml or mapping.xml, or enable
`hibernate.transform_hbm_xml.enabled` for on the fly transformation
```

The legacy `hbm.xml` mapping originates from a third-party dependency, not from Dirigible, so there is nothing on our side to migrate — the message is pure noise.

### Change
Set the `org.hibernate.orm.deprecation` logger to `ERROR` in the bundled `logback.xml`, alongside the existing targeted mutes (`net.snowflake.client`, `sharepoint`). One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)