### PR TITLE
docs: multitenancy behaviour reference, AWS deployment research, target architecture, and setup guide

### DIFF
--- a/AWS_MULTITENANCY_RESEARCH.md
+++ b/AWS_MULTITENANCY_RESEARCH.md
@@ -1,0 +1,581 @@
+# Running Multitenant Eclipse Dirigible on AWS — Architecture Research
+
+**Status:** research / design note. Nothing here is implemented.
+**Date:** 2026-07-27
+**Scope:** a production AWS architecture for a multitenant Dirigible deployment — one application instance today, scaling as tenant count grows.
+**Companion:** [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — the platform-side multitenancy reference this document is built on (how resolution, isolation, pooling and provisioning actually work). Read that first if you want the behaviour rather than the deployment.
+
+---
+
+## 1. Purpose and scope
+
+This document answers one question: *how do you run Eclipse Dirigible as a multitenant SaaS on AWS, in production, starting from a single instance and growing?*
+
+It is grounded in what the platform actually does today, read out of this repository — not in what the documentation or the 2024 blog says. Where the two disagree, the code wins and the discrepancy is called out.
+
+### Decisions taken as given
+
+| Decision | Choice |
+| --- | --- |
+| Data isolation | Schema-per-tenant on a shared Aurora PostgreSQL cluster (the AWS "bridge" model) — this is what Dirigible's provisioner already does |
+| Compute | ECS on Fargate |
+| IDE in production | Production is **runtime-only**; authoring runs on a separate single instance |
+| Tenant addressing | Wildcard subdomain `*.app.example.com` |
+| Approach | **Infrastructure only.** No changes to Dirigible's code. The platform is treated as a fixed black box |
+| Detail level | Architecture, component choices, rationale, scaling stages, risks. Not a runbook, not IaC |
+
+### Explicitly out of scope
+
+- Platform code changes. Several limitations below *could* be fixed upstream; this document works around them instead of proposing patches.
+- IaC. No Terraform/CDK. The topology is described so it can be expressed in either.
+- Exhaustive configuration reference. Config keys appear only where they are architectural decisions.
+
+---
+
+## 2. How Dirigible multitenancy actually works
+
+> **Full reference:** [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) is the extracted, standalone description of the platform's multitenancy behaviour — resolution, the scope API, the isolation mechanism, pooling, provisioning, per-tenant synchronizer replay, security, the config-key table, the clustering status, the executable-spec ITs, and the footguns. This section is the condensed version needed to follow the AWS design; go there for detail.
+
+One sentence: **a shared application instance, a shared platform database, a schema and a dedicated DB user per tenant for application data, and a single shared on-disk repository.**
+
+### 2.1 Request to tenant
+
+`TenantExtractor` matches both the `host` and `x-forwarded-host` headers against `DIRIGIBLE_TENANT_SUBDOMAIN_REGEX` (default `^([^\.]+)\..+$`, group 1 = subdomain), and `TenantContextInitFilter` wraps the request in `TenantContext.execute(tenant, ...)` — a `ThreadLocal`. Multi-tenant mode off, or no regex match (bare `localhost`, an IP), falls back to the default tenant. A match with **no matching tenant row is HTTP 404**. Lookups are cached in a static Caffeine cache, 10-minute TTL, `maximumSize(100)`, which also caches `Optional.empty()` — so a 404 for an unknown subdomain sticks for up to ten minutes.
+
+The filter is inserted ahead of the authentication filters on every security chain, because authentication itself is tenant-scoped: `CustomUserDetailsService` looks the user up *within the current tenant*.
+
+Two properties matter for the AWS design: **`x-forwarded-host` is honoured**, so the app works behind an ALB with no extra configuration; and the **404-on-unknown-subdomain** behaviour is what makes wildcard DNS safe — an unprovisioned subdomain is rejected rather than silently served as the default tenant.
+
+### 2.2 The isolation mechanism is a naming indirection
+
+`TenantDataSourceNameManager` rewrites the datasource *name* per request:
+
+```java
+public String getTenantDataSourceName(String dataSourceName) {
+    if (isSystemDataSource(dataSourceName) || tenantContext.isNotInitialized()) { return dataSourceName; }
+    return createName(tenantContext.getCurrentTenant(), dataSourceName);   // "<tenantId>_" + name
+}
+```
+
+Every `getDefaultDataSource()` inside a tenant scope resolves to `<tenantId>_DefaultDB`. There is no routing DataSource, no per-request `SET SCHEMA`, and no discriminator column on application data. Consequences: `SystemDB` is never prefixed and is shared; the default tenant is never prefixed; and **outside a tenant scope you silently get the default tenant's datasource** — a forgotten `TenantContext.execute` wrapper writes to the wrong tenant without failing.
+
+### 2.3 What is shared and what is isolated
+
+| Concern | Isolation |
+| --- | --- |
+| Application tables/views/data | **Schema per tenant**, one dedicated DB user per tenant |
+| Platform tables (tenants, roles, artefacts, Quartz, ActiveMQ store, Flowable) | **Shared** `SystemDB`, unpartitioned |
+| Users | Discriminator column in the shared DB, unique on `(tenant, username)` |
+| Roles | **Global** definitions; only the *assignments* are tenant-scoped, transitively via the user |
+| Registry `/registry/public` and IDE workspaces | **Shared.** Workspaces are keyed by *user*, not tenant |
+| Documents / CMS | **Tenant-prefixed** (`TenantPathResolver` -> `<tenantId>/...`) |
+| Quartz jobs / JMS destinations | `<tenantId>###<name>` |
+| BPMN | Single Flowable engine using Flowable's native `tenantId` discriminator |
+
+### 2.4 Provisioning
+
+`TenantStatus` has exactly two values — `INITIAL` and `PROVISIONED`. No `PROVISIONING`, no `FAILED`. Two triggers call the same `synchronized provision()`: a hard-coded 30 s delay after `ApplicationReadyEvent`, and a clustered Quartz job on `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` (**default 900 s**).
+
+The single provisioning step (`DefaultDataSourceProvisioning`) does `CREATE USER <uuid>` with a generated password, `CREATE SCHEMA <TENANT_ID uppercased> AUTHORIZATION <that user>`, and clones the `DefaultDB` definition into a `<tenantId>_DefaultDB` row. **So the connecting credential needs `CREATE ROLE` and `CREATE SCHEMA` privileges.** A post-step then blanks the multitenant artefact checksums and forces a synchronization pass, which is how the new schema gets its tables, views and seed data.
+
+Three gaps shape the AWS control plane (§6): **no user or role is created** (a new tenant has no admin user), **retry is not idempotent** (each attempt creates another DB user and schema, so failures leave orphans), and **there is no de-provisioning path** at all.
+
+### 2.5 Per-tenant synchronizer replay
+
+`BaseSynchronizer.completeInternal` replays `completeImpl` once per provisioned tenant plus the default, for the eight synchronizers that opt in (tables, views, schemas, csvim, jobs, bpmn, listeners, cms-seed). The artefact *file* is read once from the shared registry; the *side effects* — DDL, CSV import, Quartz scheduling, BPMN deployment — happen per tenant. Everything else (datasources, access, expose, extensions, roles, web, JS, Java, Camel) is global.
+
+Two AWS-relevant implications: synchronization cost grows with tenant count, so pass duration is a signal to watch (§4.8); and a single `.datasource` artefact is global, so per-tenant custom datasources need per-tenant rows.
+
+### 2.6 What the 2024 blog no longer reflects
+
+The blog ["Multitenant applications with zero effort"](https://www.dirigible.io/blogs/2024/03/26/multitenancy) is still directionally right about subdomain resolution, schema-per-tenant, the `{TENANT_ID}_` datasource prefix, the `###` naming for queues and jobs, and the 30 s / 15 min provisioning cadence. Two things have moved:
+
+- **Onboarding.** The blog shows raw `INSERT`s into `DIRIGIBLE_TENANTS` and `DIRIGIBLE_USERS`. There are now role-guarded REST endpoints (`POST /services/security/tenants`, `POST /services/security/users`), which is what automation should call.
+- **Tenant-scoped configuration** did not exist then. There is now a per-tenant `DIRIGIBLE_CONFIGURATIONS` table *inside each tenant schema*, resolved per request into a thread-local config map, gated by an explicit key allow-list (currently the branding keys only).
+
+One documentation-vs-code note: the root `CLAUDE.md` says multi-tenancy is on by default. `DirigibleConfig` declares `DIRIGIBLE_MULTI_TENANT_MODE` default `false`, but `dirigible-commons.properties` sets it to `true`, and module properties lose to environment variables — so it is effectively on, and an env var can turn it off.
+
+---
+
+## 3. The constraints that dictate the architecture
+
+### 3.1 A Dirigible instance is a single-writer runtime
+
+Four independent, verified reasons why you cannot simply raise the replica count.
+
+**(a) The embedded ActiveMQ broker takes an exclusive database lock.**
+`components/engine/engine-listeners/.../config/MessagingConfig.java` builds a `BrokerService` with `setPersistent(true)` and a `JDBCPersistenceAdapter` on `SystemDB`, on the `vm://localhost` transport, and never disables the database locker. ActiveMQ's default locker takes an exclusive row lock on `ACTIVEMQ_LOCK` and `broker.start()` **blocks until it wins**. The bean is therefore an indefinite block on the second instance — its Spring context never finishes refreshing and it never becomes ready. Classic ActiveMQ master/slave. The connector URL is a hardcoded constant, so there is no configuration path to a shared external broker.
+
+**(b) `SynchronizationJob` is a cluster-singleton whose effects are node-local.**
+Because the Quartz job store is clustered (`org.quartz.jobStore.isClustered=true`), the synchronization trigger fires on exactly *one* instance per interval (`DIRIGIBLE_SYNCHRONIZER_FREQUENCY`, default 10 s). What it does is reconcile that instance's local `/registry/public` into *that JVM's* runtime state: Camel routes, JMS listeners, OData services, Quartz job registrations, compiled client-Java classloaders, native-app processes. Any other instance never reconciles and serves stale runtime until it restarts. This is architectural, not configurable — the synchronizer model assumes the node that owns the disk owns the runtime.
+
+**(c) The repository is a POSIX filesystem, and it is the only implementation.**
+`RepositoryConfig` unconditionally constructs a `LocalRepository`. `IRepository.DIRIGIBLE_REPOSITORY_PROVIDER_DATABASE = "database"` is a dead constant — the `repository-database` module was deleted. Living on that filesystem: the registry, IDE workspaces, git working trees, GraalJS module-proxy caches, compiled client `.java` bytecode, two Lucene indexes, and the internal CMS. Change detection is `java.nio.file.WatchService`, which degrades or silently misses events on NFS/EFS; Lucene's `write.lock` makes a shared index a corruption risk.
+
+**(d) Per-JVM caches with no invalidation channel.**
+`TenantConfigurationCache` is an unbounded `ConcurrentHashMap` with no TTL, invalidated only by a local write — its own Javadoc states that multi-node deployments need an external invalidation signal and that this is out of scope. `TenantExtractor.TENANT_CACHE` gives ten minutes of staleness. `AccessVerifier`'s security-ACL cache refreshes only when the *local* file watcher flags a change, so on an instance that never sees local writes it effectively never refreshes. `DataSourceInitializer.DATASOURCES` and `Configuration.RUNTIME_VARIABLES` are static maps mutated locally.
+
+### 3.2 Even one instance cannot be rolled in place
+
+Several boot-time actions are not safe if a new instance starts while the old one is still running:
+
+- `spring.quartz.jdbc.initialize-schema=always` runs `org/quartz/impl/jdbcjobstore/tables_postgres.sql`, whose first eleven statements are `DROP TABLE IF EXISTS QRTZ_*`. A booting instance recreates the scheduler tables from scratch.
+- `JobsInitializer` does unschedule → delete → schedule for every system job, and throws `IllegalStateException` (failing the boot) on a collision.
+- Flowable runs `DB_SCHEMA_UPDATE_TRUE` by default; its `ACT_GE_PROPERTY` versioning is not first-boot-concurrent-safe.
+- The ActiveMQ JDBC adapter creates its own tables on first start.
+- `DefaultTenantInitializer` and `AdminUserInitializer` are check-then-insert.
+- `SynchronizationProcessor.prepareSynchronizers()` calls `setRunningToAll(false)` across shared artefact rows, clobbering another instance's in-flight pass.
+
+Liquibase (`components/core/core-liquibase`) *is* cluster-safe — it serialises on `DATABASECHANGELOGLOCK`. It is everything layered on top that is not.
+
+**Conclusion: deployments must be stop-then-start** (ECS `minimumHealthyPercent=0`, `maximumPercent=100`). The shipped Helm chart reaching the same conclusion independently — `replicaCount: 1`, `strategyType: Recreate`, a `ReadWriteOnce` PVC — is the upstream statement of intent.
+
+### 3.3 The capacity limit is database connections
+
+`components/data/data-sources/.../manager/DataSourceInitializer.java`:
+
+```java
+Properties hikariProperties = getHikariProperties(name);   // <NAME>_HIKARI_* env overrides
+HikariConfig config = new HikariConfig(hikariProperties);
+...
+config.setSchema(schema);
+config.setMaximumPoolSize(20);
+config.setMinimumIdle(10);
+```
+
+The explicit setters run *after* the properties constructor, so they override any `<NAME>_HIKARI_maximumPoolSize` you set. **Pool sizing is effectively hardcoded.** One pool per `(instance, tenant)`, created lazily on that tenant's first request, each with a dedicated `JdbcTransactionManager` registered as a runtime Spring singleton.
+
+```
+idle connections per instance  ≈  10 × (tenants that have made a request)
+peak connections per instance  ≈  20 × (concurrently busy tenants)
+```
+
+Aurora PostgreSQL's default is `max_connections = LEAST({DBInstanceClassMemory/9531392}, 5000)` — roughly 1,800 on a 16 GiB instance, hitting the 5,000 ceiling around 64 GiB. So ~100 active tenants on one instance is ~1,000 idle connections held open, and a few hundred tenants saturates any class.
+
+This is the number that sizes a cell, and connection count is the leading indicator to alarm on.
+
+### 3.4 Why RDS Proxy does not help here
+
+It looks like the obvious fix for the connection problem. It is not, for two independent reasons:
+
+1. **Pinning.** Schema selection happens via `HikariConfig.setSchema` → JDBC `Connection.setSchema` → pgjdbc emits `SET search_path`. [AWS documents](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-pinning.html) that for PostgreSQL, "using `SET` commands" pins the client connection to a database connection for the life of the session, and unlike MySQL there is no session-pinning filter to opt out. Multiplexing — the entire point of the proxy — would be off for every tenant connection.
+2. **Dynamic credentials.** Each tenant gets a freshly generated DB user at provisioning time. RDS Proxy authenticates against Secrets Manager secrets registered on the proxy, so every tenant onboarding would have to create a secret and modify the proxy.
+
+Size Aurora for the real connection count instead. (A conventional PgBouncer sidecar in transaction mode has the same `SET search_path` problem; session mode adds little over Hikari.)
+
+### 3.5 In-System Programming is a security boundary, not a feature toggle
+
+Dirigible's premise is that authenticated developers modify the running system through the browser. Concretely, a user with the DEVELOPER role can execute arbitrary JavaScript and arbitrary Java **in the application's own JVM**, and — via `.nativeapp` artefacts — spawn arbitrary OS processes in the container.
+
+On AWS that means: **the ECS task role is effectively delegated to anyone who can author code on that instance.** So does the task's network position, its instance metadata, and its database credentials.
+
+This is the single strongest argument for the runtime/authoring split, and it makes the split a security control rather than an operational convenience:
+
+- The **runtime** service grants no DEVELOPER role, carries a minimal task role (S3 documents prefix, KMS key, Logs, nothing else), and has content baked in rather than authored live.
+- The **authoring** service is not internet-facing in the same way, is IP-restricted, and its task role is scoped to the dev environment's resources only.
+
+### 3.6 Surfaces that are on by default and must be closed
+
+Discovered while inventorying ports. All of these are shipped defaults:
+
+| Surface | Default | Why it matters |
+| --- | --- | --- |
+| ttyd terminal, port **9000** | `DIRIGIBLE_TERMINAL_ENABLED=true` | `ttyd -p 9000 --writable sh` — a writable root shell with **no authentication**. Started from a static initializer. Port is not configurable |
+| Graalium inspector, port **8081** | `DIRIGIBLE_GRAALIUM_ENABLE_DEBUG=true` shipped in `dirigible-commons.properties`; `inspect.Secure=false`, `inspect.Suspend=true` | A Chrome DevTools inspector; `Suspend=true` means JS execution blocks waiting for a debugger. Exposed by the Dockerfile |
+| SFTP server, port **8022** | `engine-sftp` is on the classpath; `DIRIGIBLE_SFTP_USERNAME`/`_PASSWORD` default to `admin`/`admin` | Live SSH/SFTP into the CMS tree. Host key is regenerated per container, so clients see key mismatches |
+| Actuator | `management.endpoints.web.exposure.include=*` | Exposes `heapdump`, `threaddump`, `env`, `loggers`. Non-health endpoints are OPERATOR-gated, but the gate is the only thing standing between the internet and a heap dump |
+| Basic auth | `DIRIGIBLE_BASIC_USERNAME`/`_PASSWORD` = base64(`admin`)/base64(`admin`) | Default credentials |
+| Spring Boot Admin | `admin`/`admin` when the profile is enabled | Default credentials |
+| Logback | three non-rotating `FileAppender`s under `/logs` | Grows without bound; will fill the volume |
+| CSRF / frame options | both disabled in `BasicSecurityConfig` | Accepted platform design; compensate at the edge |
+
+The Docker image also runs as **root**, sets **no JVM heap flags** (so the JVM takes the default 25 % of task memory), declares `VOLUME /tmp`, and has no `WORKDIR` — meaning the working directory is `/`, and the repository lands at `/target/`, logs at `/logs/`, plus `./ttyd.sh` and `./host.ser` written into `/`.
+
+---
+
+## 4. Target architecture — one cell
+
+```
+                              Route 53
+                     *.app.example.com  ── A/ALIAS ──┐
+                                                     │
+                             ┌───────────────────────▼───────────────────────┐
+                             │  AWS WAF  →  ALB (HTTPS, ACM *.app.example.com)│
+                             │  stickiness on · idle timeout ≥ longest async  │
+                             │  health check → /services/core/healthcheck     │
+                             └───────┬──────────────────────────┬─────────────┘
+                                     │ host: *.app.example.com  │ host: ide.example.com
+                                     │                          │ (+ WAF IP allow-list)
+  ══════════════ private subnets ════╪══════════════════════════╪═════════════════════
+                                     ▼                          ▼
+                        ┌──────────────────────┐   ┌──────────────────────────┐
+                        │ ECS service RUNTIME  │   │ ECS service AUTHORING    │
+                        │ Fargate ARM64, N = 1 │   │ Fargate, N = 1           │
+                        │ stop-then-start      │   │ IDE · ttyd · LSP · git   │
+                        │ IDE off, publish off │   │ EFS/EBS repository       │
+                        │ content baked in     │   │ minimal dev task role    │
+                        │ + ADOT sidecar       │   │                          │
+                        └───┬────────┬─────────┘   └────────┬─────────────────┘
+                            │        │                      │
+  ══════ isolated subnets ══╪════════╪══════════════════════╪══════════════════════
+                            ▼        │                      ▼
+        ┌────────────────────────┐   │        ┌──────────────────────────┐
+        │ Aurora PostgreSQL      │   │        │ Aurora (dev)             │
+        │ Serverless v2, Multi-AZ│   │        └──────────────────────────┘
+        │ SystemDB   (platform)  │   │
+        │ DefaultDB  (default    │   │        VPC endpoints (no NAT):
+        │   tenant + one schema  │   │          S3 (gateway) · ECR api/dkr
+        │   and DB user per      │   │          Logs · Secrets Manager · KMS
+        │   tenant)              │   │
+        └────────────────────────┘   │
+                                     ▼
+                      ┌──────────────────────────────┐        ┌──────────────────┐
+                      │ S3 — documents / CMS         │        │ Amazon Cognito   │
+                      │ cms-provider-s3              │        │ ONE user pool    │
+                      │ key prefix = <tenantId>/…    │        │ custom:tenant    │
+                      │ SSE-KMS · versioned          │        │ cognito:groups   │
+                      └──────────────────────────────┘        │ 1 app client per │
+                                                              │ tenant subdomain │
+                                                              └──────────────────┘
+```
+
+### 4.1 Network
+
+Three AZs. Public subnets carry only the ALB. Fargate tasks sit in private subnets; Aurora in isolated subnets with no route out. Use VPC endpoints — S3 gateway, ECR api + dkr, CloudWatch Logs, Secrets Manager, KMS — rather than a NAT gateway; the task's only genuine internet need is outbound HTTPS to Cognito's JWKS endpoint and whatever user code calls, so scope a single NAT (or an egress proxy) deliberately rather than by default. Egress restriction matters more here than in a normal app, because user code runs in-process (§3.5).
+
+### 4.2 Edge, DNS and TLS
+
+One wildcard ACM certificate for `*.app.example.com` plus the apex, one Route 53 wildcard alias record to the ALB. **Onboarding a tenant requires no DNS change** — this is the main reason to prefer subdomain addressing.
+
+AWS WAF on the ALB: the managed common rule set, a rate-based rule per IP, and a rule blocking `/actuator/**` and `/spring-admin/**` from anything but the admin CIDRs (defence in depth behind the OPERATOR role gate).
+
+ALB details that matter for this application:
+- **Stickiness on.** Two independent reasons: HTTP sessions are in Tomcat's heap with no `spring-session` on the classpath (8 h timeout), and the four platform WebSocket handlers (`terminal`, `java-lsp`, `java-debug`, `data/transfer`) bind to instance-local OS processes.
+- **Idle timeout** must exceed the longest legitimate request; the app ships `spring.mvc.async.request-timeout=3600000` (1 h) and allows 1 GB multipart uploads.
+- **Health check target must be `/services/core/healthcheck`, not `/actuator/health/readiness`.** Spring's readiness probe flips UP as soon as the context refreshes, but `ApplicationReadyEvent` then kicks off classpath expansion and a full synchronization pass that can take minutes — during which `HealthCheckFilter` 302-redirects every request to `/index-busy.html`. Pointing the ALB at the actuator probe means routing live traffic to an instance that redirects everything.
+
+**CloudFront is deliberately deferred.** It would be valuable later for caching the UI's static assets (`/webjars/**`, `/services/web/**`), but tenant resolution reads the `Host` header, and CloudFront rewrites `Host` to the origin domain by default and does not send `X-Forwarded-Host`. Adding it requires an origin request policy that forwards the viewer `Host` (or a CloudFront Function copying it into `X-Forwarded-Host`) — a known-good pattern, but one more thing to get right, and worth adding only when static-asset egress actually costs something.
+
+### 4.3 Compute
+
+Two ECS services in one cluster, both Fargate on ARM64 (the CI pipeline already publishes multi-arch images, so Graviton is free money).
+
+**`dirigible-runtime`** — desired count **1**. Deployment configuration `minimumHealthyPercent=0`, `maximumPercent=100`, i.e. stop-then-start, for the reasons in §3.2. This accepts a short outage per deploy; §8 discusses that trade-off.
+
+**`dirigible-authoring`** — desired count **1**, its own hostname, WAF IP allow-list, its own Aurora and repository volume. This is where the IDE, ttyd, JDT.LS and git live.
+
+Task configuration worth calling out:
+
+- **JVM memory.** The image sets no heap flags, so the JVM caps itself at 25 % of task memory — on an 8 GiB task that is ~2 GiB of heap. Raise it via `JAVA_TOOL_OPTIONS` (`-XX:MaxRAMPercentage`, `-XX:+ExitOnOutOfMemoryError`, `-XX:+HeapDumpOnOutOfMemoryError`). But do not push it to 80 %: this container has substantial *out-of-JVM* residents — a `tsc --watch` node process, one JDT.LS child at `-Xmx2g` **per user/workspace**, and any `.nativeapp` processes. On a runtime task those should all be off (`DIRIGIBLE_JAVA_LSP_ENABLED=false`, `DIRIGIBLE_TERMINAL_ENABLED=false`), which is what makes the runtime task far leaner than the authoring task.
+- **CPU.** GraalJS and GraalPython run as Truffle interpreters on stock Corretto 21 — the image is *not* GraalVM, and does not need to be, but JS/TS execution is interpreted and therefore CPU-hungry. Size on CPU, not just memory, and measure with real tenant workloads.
+- **Ephemeral storage.** Raise it above the 20 GiB Fargate default. `engine-java`'s `ClassPathIndex` extracts `BOOT-INF/lib/*.jar` to a temp directory at startup, multipart uploads land in `java.io.tmpdir` at up to 1 GiB each, and the ActiveMQ temp store and Graal caches are on disk.
+- **Startup grace.** A generous ECS health-check `startPeriod` and ALB `deregistration_delay`; boot includes classpath expansion plus a synchronization pass over the whole registry.
+- **Shutdown.** `server.shutdown=graceful` is not set anywhere, and Quartz is configured with `waitForJobsToCompleteOnShutdown(false)`. A SIGTERM drops in-flight requests and abandons running jobs (Quartz recovers them via `requestRecovery`). Set the Spring properties as task environment overrides and give the container a stop timeout that exceeds the ALB deregistration delay.
+- **Logging.** Redirect the three non-rotating file appenders; log to stdout and let awslogs/FireLens carry it to CloudWatch. The console appender is already wired.
+- Non-root user and a read-only root filesystem are *not* achievable without relocating a set of hardcoded relative paths (`./target/dirigible/kahadb`, `./ttyd.sh`, `./host.ser`, the SFTP root). Treat "runs as root with a writable root filesystem" as a known property and compensate with a minimal task role and network isolation.
+
+### 4.4 Data
+
+One Aurora PostgreSQL cluster per cell — Serverless v2 is the right default (the load is bursty and tenant-count-driven), Multi-AZ with a reader.
+
+Two logical databases in the cluster, matching Dirigible's two datasources:
+
+- **`SystemDB`** — the platform's own schema: tenants, users, roles, artefact registry, Quartz, the ActiveMQ message store, Flowable. Its own credentials. Managed by Liquibase (`core-liquibase`, changelog `db/changelog/dirigible-system.json`), which is cluster-safe. Set `DIRIGIBLE_DATABASE_SYSTEM_DDL_AUTO=validate` so Hibernate never emits DDL behind Liquibase's back, and the Postgres Quartz delegate (`DIRIGIBLE_SCHEDULER_DATABASE_DELEGATE=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate`).
+- **`DefaultDB`** — application data. The default tenant lives in the connecting user's default schema; every other tenant gets its own schema and its own DB user, created by the provisioner. **The credential Dirigible connects with therefore needs `CREATE ROLE` and `CREATE SCHEMA` privileges** — on RDS/Aurora the master user (an `rds_superuser` member) has these; a least-privilege application role does not, and provisioning will fail silently into the `INITIAL` retry loop if you get this wrong.
+
+Keeping them as separate databases with separate credentials means a tenant's DB user cannot see the platform's tables. Note that tenant DB passwords are generated by Dirigible and stored in `DIRIGIBLE_DATA_SOURCES` in `SystemDB` — encryption at rest covers the storage, but anything with read access to that table holds every tenant's credentials.
+
+Capacity: size from §3.3, alarm on `DatabaseConnections` against the class's `max_connections`, and treat that ratio as the trigger for a new cell. Skip RDS Proxy (§3.4).
+
+Backup: Aurora automated backups plus PITR covers the cluster. **Per-tenant restore is the operational cost of the bridge model** — restoring one tenant means cloning the cluster to a point in time, `pg_dump -n <TENANT_SCHEMA>` out of the clone, and restoring into the live database. Write and rehearse that runbook before you need it; it is the thing customers ask about.
+
+### 4.5 Storage
+
+**Documents go to S3.** Set `DIRIGIBLE_CMS_PROVIDER=cms-provider-s3` with `DIRIGIBLE_S3_BUCKET`; `TenantPathResolver` already prefixes every key with the tenant id, so isolation comes for free. Authenticate with the task role, not `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` — `S3Facade` falls back to the default credentials chain when those are unset. Bucket policy scoped per environment, SSE-KMS, versioning on, lifecycle rules for old versions.
+
+**The repository is where the runtime/authoring split earns its keep.**
+
+- *Authoring instance*: a persistent volume (EFS with an access point, or EBS if you accept single-AZ). It holds IDE workspaces, git working trees and the Lucene indexes, none of which survive task replacement otherwise. Point `DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER` at an explicit absolute path rather than relying on the relative default resolving against `/`.
+- *Runtime instances*: **no persistent volume.** Content arrives immutably at boot, by one of two mechanisms that already exist:
+  - `ClasspathExpander` walks every `META-INF/dirigible/**` on the classpath at `ApplicationReadyEvent` and writes it into `/registry/public`. Bake the published projects into a jar layer and the runtime task is content-immutable by construction. A jar containing `META-INF/dirigible/.skip` is skipped.
+  - `DIRIGIBLE_REGISTRY_EXTERNAL_FOLDER` replicates an external folder into the registry and keeps watching it — useful if you prefer to sync content from S3 into an ephemeral local directory at task start.
+  Then set `DIRIGIBLE_PUBLISH_DISABLED=true` so nothing can write to the registry at runtime.
+
+Two traps worth knowing: `DIRIGIBLE_MASTER_REPOSITORY_PROVIDER`/`_ZIP_LOCATION`/`_JAR_PATH` look like exactly the right mechanism for immutable seeding but are **dead code** — nothing in `components/` ever creates an `IMasterRepository`. And EFS is a poor fit for the registry even where it works: `WatchService` change detection degrades on NFS, Lucene explicitly should not live on it, and the registry is thousands of small files.
+
+### 4.6 Identity
+
+Dirigible already implements the wildcard-subdomain SaaS pattern against Cognito. No code change is needed.
+
+Activate the profile (`spring_profiles_active=cognito`, which also sets `basic.enabled=false`) with `DIRIGIBLE_MULTI_TENANT_MODE=true` and `DIRIGIBLE_MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL=true`.
+
+**One Cognito user pool for all tenants.** Two claims carry the tenancy:
+
+- `custom:tenant` — a comma-separated list of tenant **subdomains** the user belongs to. `CognitoTenantFilter` resolves the tenant from the request host and returns 403 unless the list contains that subdomain. A user with no value gets 403.
+- `cognito:groups` — mapped straight to Dirigible role authorities by `CognitoSecurityConfiguration.userAuthoritiesMapper()`. **Cognito group names must equal Dirigible role names** (`ADMINISTRATOR`, `OPERATOR`, and the application's own `.roles`). Note that on a *runtime* cell you simply do not create a `DEVELOPER` group (§3.5).
+
+**One OAuth client registration per tenant, whose registration id is the tenant's subdomain.** This is the piece that makes per-tenant callbacks work despite `DIRIGIBLE_HOST` being a single value. `CognitoLoginController` exposes `GET /login/{registrationId}`, validates the id against the set of `PROVISIONED` tenant subdomains, and redirects to `/oauth2/authorization/{registrationId}`:
+
+```java
+if (!provisionedClients.contains(registrationId)) {
+    throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Invalid OAuth2 client");
+}
+return "redirect:/oauth2/authorization/" + registrationId;
+```
+
+Registrations are held by `DynamicClientRegistrationRepository` — DB-persisted, resolvable at runtime, and each carries its own `redirectUri`. They can be created two ways: through `ClientRegistrationEndpoint` (REST, the automation path), or seeded from the environment via `DIRIGIBLE_OAUTH_CUSTOM_CLIENTS=<name1>,<name2>` plus `<NAME>_CLIENT_ID`, `<NAME>_REDIRECT_URI`, `<NAME>_TOKEN_URI`, … per name.
+
+So a tenant's login entry point is `https://acme.app.example.com/login/acme`, with `redirectUri` `https://acme.app.example.com/login/oauth2/code/acme`. Onboarding adds one Cognito app client (or reuses one) and one client registration — no DNS, no infrastructure change.
+
+Machine-to-machine access works through the same pool: client-credentials tokens are validated as resource-server JWTs against the pool's JWKS, and `ScopeRoleJwtAuthoritiesConverter` derives roles from the `scope` claim.
+
+### 4.7 Messaging
+
+The embedded ActiveMQ broker opens **no network port** — it is `vm://` in-JVM only. Within a cell that is fine: a single instance produces and consumes its own queues, persistence is in `SystemDB` so messages survive a restart, and destinations are tenant-prefixed. There is nothing to provision on AWS.
+
+What you are accepting: `.listener` artefacts are an in-process async mechanism, not a cross-instance bus. Cross-cell messaging does not exist and cannot be configured into existence. If a workload genuinely needs a shared broker, that workload should talk to SQS/SNS/Amazon MQ directly from user code (the `api-*` modules make that straightforward) rather than through `.listener`.
+
+### 4.8 Observability
+
+`engine-open-telemetry` is already in the tree and Camel OTel is wired in `DirigibleApplication`. Run an **ADOT collector sidecar** in the task and point `otel.exporter.otlp.endpoint` at it; fan out to CloudWatch/AMP and X-Ray.
+
+The one genuinely nice property: **per-tenant log correlation is free.** `components/core/core-base/.../logging/TenantConverter.java` already injects the current tenant id into every log line (and the literal `background` for system threads). Structure the log output as JSON and every CloudWatch Logs Insights query, metric filter and per-tenant dashboard becomes a one-liner — this is usually the hardest part of SaaS observability and it is already done.
+
+Metrics: scrape `/actuator/prometheus` into AMP. Watch, per cell: `DatabaseConnections` against the class limit, active tenant count, JVM heap and GC, synchronization pass duration, tenant-provisioning lag (`INITIAL` rows older than one job interval), and ALB 5xx/target response time.
+
+---
+
+## 5. Scaling out: cells
+
+### 5.1 Why cells rather than replicas
+
+§3.1 establishes that the unit of Dirigible that can be replicated safely is *the whole instance with its own database and its own filesystem*. That is precisely AWS's definition of a **cell** in cell-based architecture. The platform's constraint and the AWS pattern land on the same boundary, which is why this is the recommended shape rather than a workaround.
+
+A cell is:
+
+```
+cell-01 ─┬─ ALB listener rule / dedicated ALB
+         ├─ ECS service "runtime", desired count 1
+         ├─ Aurora PostgreSQL cluster (SystemDB + DefaultDB with K tenant schemas)
+         ├─ S3 prefix (or bucket)
+         └─ its own CloudWatch dashboard + alarms
+```
+
+Global, shared by all cells: the Cognito user pool, the ECR image, the IaC pipeline, the observability account/workspace, and the tenant→cell registry.
+
+### 5.2 Routing tenants to cells
+
+Three options, in order of preference:
+
+1. **Route 53 per-tenant CNAME to the cell's ALB.** `acme.app.example.com` → `cell-03-alb...elb.amazonaws.com`. No rule limits, no shared listener to grow, per-tenant moves are a DNS change (with a TTL-bounded cutover). The cost is that onboarding now *does* touch DNS — one API call, easily automated. **This is the recommendation.**
+2. **One shared ALB with host-header listener rules** per cell. Simplest mental model and keeps wildcard DNS, but ALB listener rules are limited (on the order of 100 per listener, with a handful of host conditions each), so this caps total tenants unless you group cells behind wildcard-ish patterns.
+3. **CloudFront with a Function selecting the origin** from the `Host` header. Most flexible and adds edge caching, but it puts the tenant→cell map in a Function (and its own deployment cycle) and reintroduces the `Host`-forwarding concern from §4.2.
+
+### 5.3 Sizing a cell
+
+Three ceilings, take the lowest:
+
+- **Connections** — from §3.3, `10 × activeTenants` idle. This is usually the binding constraint.
+- **Memory/CPU** — measured, not derived. Per-tenant cost depends entirely on the applications those tenants run.
+- **Blast radius** — a business decision. A cell failure takes down every tenant in it, and a deploy stops the instance briefly. Smaller cells cost more per tenant and fail less broadly.
+
+Open a new cell when any of these crosses its threshold. Keep the number a published, monitored figure rather than an emergent one; "how many tenants fit in a cell" should be a known constant, revisited when the workload mix changes.
+
+### 5.4 Operating multiple cells
+
+- **Deploy in waves.** A canary cell (internal tenants only) takes every release first, then a small wave, then the rest. Because each cell stops briefly during a deploy, schedule waves against each cell's own quiet hours where tenant geography allows.
+- **Blast radius is the point.** Cell-level alarms, cell-level dashboards, and an explicit decision about whether a cell failure degrades or hard-fails its tenants.
+- **Cell rebalancing** is a tenant migration: `pg_dump -n <SCHEMA>` from the source cell, restore into the target, copy the S3 prefix, re-point DNS, delete the source schema. Automate it before you need it, because tenants grow unevenly and the first cell will fill with the wrong mix.
+- **Cell provisioning should be one IaC module instantiated N times**, with a cell index as the only meaningful parameter. If standing up cell #4 is bespoke work, the model has failed.
+
+---
+
+## 6. Tenant lifecycle
+
+### 6.1 Onboarding
+
+```
+signup
+  │
+  ├─ 1. control plane: allocate a cell, reserve the subdomain,
+  │       write tenant → cell into the registry (DynamoDB)
+  │
+  ├─ 2. Cognito: create/attach the user, set custom:tenant = <subdomain>,
+  │       add role groups, ensure an app client with callback
+  │       https://<subdomain>.app.example.com/login/oauth2/code/<subdomain>
+  │
+  ├─ 3. Route 53: CNAME <subdomain>.app.example.com → cell ALB
+  │
+  ├─ 4. cell: POST /services/security/tenants   { name, subdomain }  → row INITIAL
+  │
+  ├─ 5. cell: POST /services/security/client-registrations
+  │            { name/id = <subdomain>, clientId, clientSecret,
+  │              redirectUri = https://<subdomain>…/login/oauth2/code/<subdomain>, … }
+  │
+  ├─ 6. cell: POST /services/security/users     { username, tenant } → tenant admin
+  │
+  ├─ 7. wait for the provisioning tick:
+  │       CREATE USER + CREATE SCHEMA + datasource row + status PROVISIONED
+  │       + forced synchronization pass creates tables/views/seed data
+  │
+  └─ 8. poll until PROVISIONED, then mark the tenant live
+```
+
+Steps 4–6 are role-guarded REST calls under `services/security/` (`ADMINISTRATOR`/`OPERATOR`). Note step 7's latency: the provisioning job defaults to **900 s**. Lower `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` to ~60 s for a responsive signup flow, and remember the job is a *clustered Quartz* job so a single cell instance runs it exactly once per tick.
+
+Implement the control plane as a small service or a Step Functions state machine with Lambda tasks, backed by a DynamoDB table that is the authority on tenant → cell, subdomain reservation, and onboarding state. Dirigible's `DIRIGIBLE_TENANTS` table remains the authority *within* a cell; the two must be reconciled by the control plane, not assumed consistent.
+
+### 6.2 Failure handling
+
+Provisioning has no failure state — a failed attempt leaves the row at `INITIAL` and the next tick retries from scratch, creating another DB user and schema. So the control plane must:
+
+- Alarm on `INITIAL` rows older than a small multiple of the job interval, rather than waiting for the tenant to complain.
+- Treat repeated retries as an incident, and include orphaned-user/orphaned-schema cleanup in the remediation.
+
+### 6.3 Offboarding
+
+**The platform has no de-provisioning path.** The tenant API refuses to delete a `PROVISIONED` tenant, and nothing drops the schema, the DB user, the datasource row or the live connection pool. Offboarding is therefore a scripted runbook the control plane owns:
+
+1. Suspend access — remove the tenant's subdomain from every user's `custom:tenant`, delete the Cognito app client.
+2. Export — `pg_dump -n <TENANT_SCHEMA>` and copy the S3 prefix to the retention location; hold for the contractual period.
+3. Remove Route 53 record.
+4. In the cell's `SystemDB`: delete the tenant's users and role assignments, delete the `<tenantId>_DefaultDB` row from `DIRIGIBLE_DATA_SOURCES`, delete the client registration, delete the tenant row.
+5. In `DefaultDB`: `DROP SCHEMA <TENANT_SCHEMA> CASCADE`, `DROP USER <tenant user>`.
+6. Delete the S3 prefix.
+7. Restart the cell's runtime task so the stale connection pool and the cached tenant lookup are discarded — the pool is a static map with no removal path from outside, and `TENANT_CACHE` holds the subdomain for up to ten minutes regardless.
+
+Rehearse it. Step 4 before step 5 matters (the datasource row is what keeps the pool alive), and step 7 is easy to forget.
+
+---
+
+## 7. Scaling stages
+
+| Stage | Tenants | Shape | What changes |
+| --- | --- | --- | --- |
+| **1** | 0 – ~50 | One cell. Runtime + authoring split from day one. Aurora Serverless v2 with a low floor | Get the hardening (§3.6), the health-check target, the JVM flags and the stop-then-start deploy right. Establish the connection-count dashboard |
+| **2** | ~50 – 150 | Same one cell, vertically scaled | Move documents to S3. Make runtime content immutable (`ClasspathExpander` + `DIRIGIBLE_PUBLISH_DISABLED`). Tune the provisioning interval. Measure the real per-tenant connection and memory cost and *publish the cell capacity number* |
+| **3** | 150+ | Multiple cells, Route 53 per-tenant CNAME, DynamoDB tenant→cell registry | Cell IaC module. Onboarding automation gains cell allocation. Deploy waves with a canary cell. Tenant-migration tooling |
+| **4** | many cells | Real control plane | Cell health/capacity as a first-class service, automatic cell provisioning, rebalancing on a schedule, per-cell cost attribution |
+
+Leading indicators, per cell:
+
+- `DatabaseConnections` ÷ `max_connections` — **the primary signal**; open a new cell well before saturation.
+- Active tenants in the cell vs. the published capacity number.
+- JVM heap after GC, and GC pause time (user code shares the heap).
+- Synchronization pass duration — it grows with registry size and tenant count, since side effects replay per tenant.
+- Tenants stuck in `INITIAL`.
+- ALB target response time p99 and 5xx rate.
+
+---
+
+## 8. Risks and accepted limitations
+
+These are consequences of the "no code changes" constraint. They are deliberate, and each should be an explicit conversation with whoever owns the SLA.
+
+| Limitation | Consequence | Mitigation available today |
+| --- | --- | --- |
+| **One runtime task per cell** | No intra-cell HA. A task failure or an AZ event takes the cell down until ECS replaces the task (~1–3 min) | Fast task replacement, cell-level alarms, tenants spread across cells so no single failure is total. Communicate the SLA honestly |
+| **Stop-then-start deploys** | A short planned outage per cell per release | Deploy waves in each cell's quiet window; keep releases small and frequent so the window is short and routine |
+| **Cross-tenant admin visibility** | `TenantEndpoint` and `UsersEndpoint` do not tenant-scope reads. An `ADMINISTRATOR` in *any* tenant can list and modify *every* tenant's users | Do not grant `ADMINISTRATOR` to tenant users. Keep it to the platform operator; give tenant admins an application-level role instead. This is the most important item in this table |
+| **Tenant DB credentials in the platform DB** | `DIRIGIBLE_DATA_SOURCES` holds every tenant's generated DB password | Encryption at rest; tightly restrict who can read `SystemDB`; treat a `SystemDB` compromise as a full-cell compromise |
+| **Tenant cache: 10 min TTL, `maximumSize(100)`** | Tenant create/disable takes up to 10 min to take effect; above 100 tenants per cell the cache thrashes and every miss hits the DB | Keep cells at or below ~100 tenants (which the connection budget suggests anyway); accept the onboarding delay or restart after onboarding |
+| **No de-provisioning** | Offboarding is manual (§6.3) | Scripted, rehearsed runbook owned by the control plane |
+| **Per-tenant restore is a clone + `pg_dump`** | Restoring one tenant is slow and operationally involved | Documented, rehearsed runbook; set customer expectations accordingly |
+| **Lucene indexes are instance-local** | Search results are whatever that instance indexed; the authoring and runtime instances diverge | Acceptable with one instance per cell. Do not put the index on EFS |
+| **GraalJS/Python run interpreted** | JS/TS-heavy tenants are CPU-expensive | Size on CPU; watch per-tenant CPU; consider it in cell capacity |
+| **Runs as root, writable root filesystem** | Weaker container hardening than a normal Java service | Minimal task role, private subnets, tight egress, no DEVELOPER role in production |
+| **In-System Programming = code execution** | Anyone who can author code on an instance effectively holds its task role | Runtime/authoring split as a security boundary (§3.5). Non-negotiable |
+
+---
+
+## 9. Cost model
+
+Order-of-magnitude only, one region, on-demand, before any discounting. Verify against the current price list.
+
+**One cell, steady state:**
+
+| Component | Assumption | Rough monthly |
+| --- | --- | --- |
+| Fargate runtime task | 2 vCPU / 8 GiB, ARM64, 24×7 | $60 – 80 |
+| Fargate authoring task | 2 vCPU / 8 GiB, business hours only | $25 – 80 |
+| ALB | 1 ALB + modest LCU | $20 – 35 |
+| Aurora Serverless v2 | floor 1 ACU, average 2–4 ACU, + reader | $90 – 300 |
+| S3 + KMS | documents, modest volume | $5 – 25 |
+| EFS (authoring only) | small, elastic throughput | $10 – 30 |
+| CloudWatch Logs + metrics | with sane retention | $20 – 60 |
+| Cognito | scales with monthly active users | verify current pricing |
+| **Total** | | **~$250 – 600** |
+
+**Marginal cell:** roughly the runtime task + ALB (or listener rule) + Aurora + S3 — call it $200–450, since the authoring instance, the Cognito pool and the pipeline are shared.
+
+Main levers, in order of impact:
+
+1. **Aurora floor.** The Serverless v2 minimum ACU dominates a lightly loaded cell. Tune it per cell rather than globally.
+2. **Graviton** for both tasks — the image is already multi-arch.
+3. **Avoid NAT.** VPC endpoints instead; a NAT gateway per AZ is $32+/month each before data processing.
+4. **Log retention and volume.** With per-tenant tenant ids in every line, log volume grows with tenants; set retention deliberately and consider a cheaper tier for older data.
+5. **Authoring task schedule.** Scale it to zero outside working hours.
+6. Compute Savings Plans once the baseline is stable.
+
+---
+
+## 10. Verification checklist
+
+Confirm each of these in your own account and against your own build before committing to the design.
+
+**AWS-side**
+- [ ] Aurora PostgreSQL `max_connections` for the instance class you pick — the documented default is `LEAST({DBInstanceClassMemory/9531392}, 5000)`; measure the actual value.
+- [ ] Cognito limits and current pricing: app clients per user pool, callback URLs per app client, custom attributes, and the monthly-active-user price for your tier.
+- [ ] ALB listener-rule and target limits, if you choose the shared-ALB routing option.
+- [ ] EFS throughput and latency for the registry's file-count and size profile (thousands of small files) on the authoring instance.
+- [ ] CloudFront `Host`-header forwarding behaviour with the origin request policy you choose, if and when you add CloudFront.
+
+**Dirigible-side**
+- [ ] Whether `spring.quartz.jdbc.initialize-schema=always` really recreates the `QRTZ_*` tables on your engine and version. The referenced script (`org/quartz/impl/jdbcjobstore/tables_postgres.sql` in quartz 2.5.2) opens with `DROP TABLE IF EXISTS` for all eleven tables, but confirm the initializer runs it on every boot in your build.
+- [ ] The `default-tenant` Cognito registration: `application-cognito.properties` sets `redirect-uri=${DIRIGIBLE_HOST}/login/oauth2/code/cognito` while `client-name=default-tenant` becomes the registration id. Confirm the callback path and the registration id line up, or you will get a redirect-URI mismatch on the default tenant specifically.
+- [ ] That the connecting `DefaultDB` credential really can `CREATE ROLE` and `CREATE SCHEMA` on Aurora — provision one throwaway tenant end to end before anything real depends on it.
+- [ ] Actual per-tenant connection and memory cost, measured with a representative application, to fix the cell capacity number.
+- [ ] That `DIRIGIBLE_TERMINAL_ENABLED=false`, `DIRIGIBLE_GRAALIUM_ENABLE_DEBUG=false`, SFTP disabled or credentialled, and restricted actuator exposure are all actually in effect on the running task — verify by probing ports 9000, 8081 and 8022 from inside the VPC, not by reading the task definition.
+- [ ] Behaviour of a tenant whose subdomain is requested before provisioning completes (expect a cached 404 for up to ten minutes) — decide what the signup UX does about it.
+
+---
+
+## 11. References
+
+### In-repo
+
+| Concern | Path |
+| --- | --- |
+| **Multitenancy behaviour reference — start here** | [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) |
+| Tenant SPI (`Tenant`, `TenantContext`, provisioning steps) | `components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/tenant/` |
+| Host → tenant resolution + cache | `components/core/core-tenants/.../tenant/TenantExtractor.java`, `TenantContextInitFilter.java` |
+| Tenant entity, status, CRUD API | `components/core/core-tenants/.../domain/Tenant.java`, `domain/TenantStatus.java`, `endpoint/TenantEndpoint.java`, `endpoint/UsersEndpoint.java` |
+| Provisioning | `components/core/core-tenants/.../provisioning/`, `components/data/data-sources/.../provisioning/DefaultDataSourceProvisioning.java` |
+| **The isolation switch** | `components/data/data-sources/.../manager/TenantDataSourceNameManager.java` |
+| Per-tenant pools (hardcoded sizing, `setSchema`) | `components/data/data-sources/.../manager/DataSourceInitializer.java` |
+| Shared platform datasource + JPA | `components/core/core-database/.../DataSourceSystemConfig.java` |
+| Platform schema (Liquibase) | `components/core/core-liquibase/` |
+| Per-tenant synchronizer replay | `components/core/core-base/.../synchronizer/BaseSynchronizer.java`, `MultitenantBaseSynchronizer.java` |
+| Synchronization loop | `components/core/core-initializers/.../synchronizer/` |
+| Single local repository | `components/core/core-repository/.../RepositoryConfig.java`, `modules/repository/repository-local/` |
+| Immutable content seeding | `components/core/core-initializers/.../classpath/ClasspathExpander.java`, `components/core/core-registry/.../watcher/ExternalRegistryWatcher.java` |
+| Embedded broker (`vm://`, JDBC store) | `components/engine/engine-listeners/.../config/MessagingConfig.java` |
+| Quartz configuration | `modules/commons/commons-resources/src/main/resources/quartz.properties`, `components/engine/engine-jobs/.../config/QuartzConfig.java` |
+| Cognito profile, tenant filter, login controller | `components/security/security-cognito/` |
+| Per-tenant OAuth client registrations | `components/security/security-client-registration/` |
+| CMS tenant path prefixing, S3 provider | `components/engine/engine-cms/.../TenantPathResolver.java`, `components/engine/engine-cms-s3/`, `components/api/api-s3/` |
+| Tenant id in every log line | `components/core/core-base/.../logging/TenantConverter.java` |
+| Tenant-scoped configuration | `components/core/core-configurations/.../tenant/` |
+| Config keys and defaults (authoritative) | `modules/commons/commons-config/.../DirigibleConfig.java`, `Configuration.java` |
+| Shipped properties | `modules/commons/commons-resources/src/main/resources/application-common.properties`, `dirigible-commons.properties` |
+| Container image | `build/application/Dockerfile` |
+
+`build/helm-charts/` is **stale** and should not be used as a deployment reference — it targets a Tomcat-era layout (`/usr/local/tomcat/...`, `tomcat-users.xml`), probes a v4-era health path (`/services/v4/healthcheck`, now `/services/core/healthcheck`), and sets keys that no longer do anything (`DIRIGIBLE_DATABASE_PROVIDER=custom`, `DIRIGIBLE_SCHEDULER_MEMORY_STORE`). Its `replicaCount: 1` + `strategyType: Recreate` + `ReadWriteOnce` PVC remain accurate as a statement of the single-writer model.
+
+### External
+
+- ["Multitenant applications with zero effort"](https://www.dirigible.io/blogs/2024/03/26/multitenancy) — the original feature announcement (March 2024); see §2.6 for what has since changed.
+- [Avoiding pinning an RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy-pinning.html) — the PostgreSQL `SET` pinning behaviour behind §3.4.
+- [Amazon RDS Proxy for Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/rds-proxy.html)
+- [AWS Prescriptive Guidance: multi-tenant SaaS on managed PostgreSQL](https://docs.aws.amazon.com/prescriptive-guidance/latest/saas-multitenant-managed-postgresql/) — the silo / bridge / pool taxonomy this document's "bridge" choice comes from.
+- [Amazon Aurora PostgreSQL parameters](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Reference.ParameterGroups.html)

--- a/AWS_MULTITENANCY_RESEARCH.md
+++ b/AWS_MULTITENANCY_RESEARCH.md
@@ -4,6 +4,7 @@
 **Date:** 2026-07-27
 **Scope:** a production AWS architecture for a multitenant Dirigible deployment — one application instance today, scaling as tenant count grows.
 **Companion:** [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — the platform-side multitenancy reference this document is built on (how resolution, isolation, pooling and provisioning actually work). Read that first if you want the behaviour rather than the deployment.
+**Sequel:** [`AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`](AWS_MULTITENANCY_TARGET_ARCHITECTURE.md) — the *recommended* architecture, written without the "no code changes" constraint below. It adds cross-tenant login (one identity, many tenants, per-tenant roles) by making identity, membership and roles come from the IdP token instead of the platform's own tables. Read this document for what you can deploy today; read that one for where the model should go.
 
 ---
 

--- a/AWS_MULTITENANCY_RESEARCH.md
+++ b/AWS_MULTITENANCY_RESEARCH.md
@@ -5,6 +5,7 @@
 **Scope:** a production AWS architecture for a multitenant Dirigible deployment — one application instance today, scaling as tenant count grows.
 **Companion:** [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — the platform-side multitenancy reference this document is built on (how resolution, isolation, pooling and provisioning actually work). Read that first if you want the behaviour rather than the deployment.
 **Sequel:** [`AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`](AWS_MULTITENANCY_TARGET_ARCHITECTURE.md) — the *recommended* architecture, written without the "no code changes" constraint below. It adds cross-tenant login (one identity, many tenants, per-tenant roles) by making identity, membership and roles come from the IdP token instead of the platform's own tables. Read this document for what you can deploy today; read that one for where the model should go.
+**Setup guide:** [`AWS_MULTITENANCY_SETUP_GUIDE.md`](AWS_MULTITENANCY_SETUP_GUIDE.md) — the concrete step-by-step for the recommended model: how many Cognito app clients and their config, single pool vs pool-per-tenant, the pre-token Lambda and DynamoDB membership store, and the exact Dirigible env vars.
 
 ---
 

--- a/AWS_MULTITENANCY_SETUP_GUIDE.md
+++ b/AWS_MULTITENANCY_SETUP_GUIDE.md
@@ -1,0 +1,477 @@
+# Multitenant Dirigible on AWS with Amazon Cognito — Setup Guide
+
+**Status:** implementation & configuration guide. Nothing here is deployed for you; the steps are ready to run.
+**Date:** 2026-07-28
+
+**Companion documents**
+- [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md) — what deploys on the current release, unchanged.
+- [`AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`](AWS_MULTITENANCY_TARGET_ARCHITECTURE.md) — the recommended claims-driven identity model and the platform changes behind it.
+- [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — how multitenancy works in the code today.
+
+This guide is the **how-to**. It answers, concretely: *how many OAuth applications and with what config; one user pool or one per tenant; how a user's tenants and roles live in Cognito and reach Dirigible; and which Cognito settings to use.* A user must be able to sign into several tenants but gain access only where authorized — that requirement drives every choice below.
+
+---
+
+## Decisions at a glance
+
+| Question | Answer |
+| --- | --- |
+| **One user pool, or one per tenant?** | **One user pool for all tenants.** Cross-tenant login means one identity per person; pool-per-tenant means one account per person per tenant, which breaks the requirement |
+| **How many OAuth app clients?** | **One confidential app client per tenant**, plus one for the default/platform tenant, plus (optionally) one machine-to-machine client per tenant that needs API access |
+| **Where do tenant membership and roles live?** | **In a control-plane store (DynamoDB), not in Cognito.** A pre-token-generation Lambda turns them into token claims at sign-in |
+| **How do roles reach Dirigible?** | The Lambda writes the caller's roles *for this tenant* into the standard `cognito:groups` claim; Dirigible's existing mapper turns those into Spring authorities |
+| **Which Cognito feature plan?** | **Essentials** (or Plus) — required for the pre-token trigger versions used here |
+
+The rest of the document is the build order for exactly that.
+
+### Two modes
+
+**Mode A — configuration only.** Everything here works against the **current** Dirigible code with no changes: the per-tenant app client makes each token carry only that tenant's roles, and Dirigible's shipped `cognito:groups` → authorities mapper is then correct per tenant by construction. Mode A has real caveats (§13) — most importantly that machine-to-machine tokens skip the tenant membership check and that `@RolesAllowed` may be inert under the cognito profile.
+
+**Mode B — fork hardening.** The small set of platform changes from the target-architecture document (§6 there) that close Mode A's caveats. Called out inline as *[Mode B]* and collected in §13.
+
+---
+
+## 1. Architecture overview
+
+```
+   Anna's browser
+        │  https://acme.app.example.com        https://globex.app.example.com
+        ▼                                        ▼
+   ┌─────────────────────── ALB (wildcard *.app.example.com, ACM) ──────────────────────┐
+   │  Host header → tenant subdomain (Dirigible TenantExtractor)                          │
+   └───────────────────────────────────┬─────────────────────────────────────────────────┘
+                                        ▼
+                              ┌──────────────────────┐
+                              │  Dirigible (Fargate) │  spring_profiles_active=cognito
+                              │  cognito:groups →     │  MULTI_TENANT_MODE=true
+                              │  ROLE_* authorities   │  ..._COGNITO_SINGLE_USER_POOL=true
+                              └───────┬──────────────┘
+                                      │ OIDC (per-tenant app client)
+                                      ▼
+   ┌──────────────────────────── ONE Cognito user pool ──────────────────────────────────┐
+   │  identities: one per person (sub = global id)                                        │
+   │  app clients:  acme   globex   …   default   [+ acme-m2m, globex-m2m]                 │
+   │  managed-login session cookie shared across ALL app clients (1h)                     │
+   │                                                                                       │
+   │  Pre-token-generation Lambda  (trigger event V2_0 / V3_0)                             │
+   │    clientId → tenant                                                                   │
+   │    (sub, tenant) → roles          ── reads ──▶  DynamoDB membership store             │
+   │    not a member → throw (deny)                    USER#<sub> / TENANT#<tenant> → roles│
+   │    member → cognito:groups = roles-here                                               │
+   │             dirigible:tenant, dirigible:tenants                                       │
+   └───────────────────────────────────────────────────────────────────────────────────────┘
+                                      ▲
+                                      │ writes (grant/revoke/roles)
+                              ┌───────┴──────────┐
+                              │  Control plane   │  onboarding, membership admin
+                              └──────────────────┘
+```
+
+Three parties, three jobs: **Cognito** authenticates and mints tokens; the **control plane + DynamoDB** own the tenant↔user↔roles graph; **Dirigible** consumes the resulting claims and enforces them. No identity or authorization data is stored in Dirigible's own database.
+
+---
+
+## 2. Step 1 — the user pool
+
+Create **one** user pool for the whole platform.
+
+Settings that matter:
+
+| Setting | Value | Why |
+| --- | --- | --- |
+| Feature plan | **Essentials** | Pre-token trigger event versions V2_0/V3_0 (used to override groups and add claims) require Essentials or Plus. Lite only reaches V1_0/V2_0 |
+| Sign-in identifier | **Email**, case-insensitive | `user-name-attribute=email` is what Dirigible's cognito config already expects |
+| Self-registration | **Off** | Users are invited by the control plane during onboarding; open sign-up would let anyone create an identity with no tenant |
+| MFA | Per your policy (recommend required TOTP) | One pool = one place to enforce it for every tenant |
+| Deletion protection | **On** | The pool is now the identity system of record |
+| Attributes | `email` (required). Add `custom:tenant` (mutable, app-writable) **only for Mode A** | Mode A's `CognitoTenantFilter` reads `custom:tenant`; Mode B replaces that check and doesn't need the attribute |
+
+```bash
+aws cognito-idp create-user-pool \
+  --pool-name dirigible-platform \
+  --user-pool-tier ESSENTIALS \
+  --username-attributes email \
+  --username-configuration CaseSensitive=false \
+  --admin-create-user-config AllowAdminCreateUserOnly=true \
+  --mfa-configuration OPTIONAL \
+  --deletion-protection ACTIVE
+# Mode A only — add the tenant-membership attribute:
+#   --schema Name=tenant,AttributeDataType=String,Mutable=true
+```
+
+Note the pool id (`us-east-1_XXXXXXXXX`) and its region — Dirigible builds the issuer and JWKS URLs from them.
+
+---
+
+## 3. Step 2 — domain and managed login
+
+Give the pool a custom auth domain so tokens have a stable issuer and the hosted UI can be branded once for all tenants.
+
+```bash
+aws cognito-idp create-user-pool-domain \
+  --user-pool-id us-east-1_XXXXXXXXX \
+  --domain auth.app.example.com \
+  --custom-domain-config CertificateArn=arn:aws:acm:us-east-1:<acct>:certificate/<id>
+```
+
+The ACM certificate for a Cognito custom domain **must be in `us-east-1`** regardless of your pool's region. Point a Route 53 alias at the CloudFront distribution Cognito returns.
+
+The managed-login session cookie is set on this domain and is valid for **1 hour, not configurable**. It is the mechanism that lets one sign-in flow into multiple tenants without re-entering credentials — see §12.
+
+---
+
+## 4. Step 3 — the membership store (DynamoDB)
+
+Cognito holds *who a person is*. The control plane holds *which tenants they belong to and with what roles*. A single-table DynamoDB design is enough.
+
+| Item kind | PK | SK | Attributes |
+| --- | --- | --- | --- |
+| Membership | `USER#<sub>` | `TENANT#<tenantSubdomain>` | `roles: ["ADMINISTRATOR", ...]` |
+| Client → tenant map | `CLIENT#<appClientId>` | `TENANT` | `tenant: "<tenantSubdomain>"` |
+
+Example items for Anna, who administers `acme` and manages employees in `globex`:
+
+```json
+{ "PK": "USER#a1b2-c3d4", "SK": "TENANT#acme",   "roles": ["ADMINISTRATOR"] }
+{ "PK": "USER#a1b2-c3d4", "SK": "TENANT#globex", "roles": ["employee-manager"] }
+{ "PK": "CLIENT#3ab...acme",   "SK": "TENANT", "tenant": "acme"   }
+{ "PK": "CLIENT#7cd...globex", "SK": "TENANT", "tenant": "globex" }
+```
+
+Rules:
+- `sub` is Cognito's immutable per-user id — the Lambda cannot alter it, so it is the safe join key.
+- **Role names must equal Dirigible role names exactly** — the three built-ins (`ADMINISTRATOR`, `DEVELOPER`, `OPERATOR`) and any application role defined by a `.roles` artefact. They become `ROLE_<name>` authorities verbatim.
+- Only the control plane writes this table. Nothing in Dirigible reads or writes it directly.
+
+Why not Cognito groups or a custom attribute? A user in many tenants with several roles each would blow past the non-adjustable **100 groups per user** limit, and a custom attribute is user-global (2 KB cap, 50 per pool) so it could not carry per-tenant role sets cleanly. Keeping the graph in DynamoDB and projecting it per-token via the Lambda has neither limit.
+
+---
+
+## 5. Step 4 — the pre-token-generation Lambda
+
+This is where a user's DynamoDB memberships become tenant-scoped token claims, and where a non-member is denied a token at all.
+
+```javascript
+// Node.js 20. Trigger: Pre token generation, event version V2_0 (V3_0 if you
+// also customize M2M tokens — see §6).
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, GetCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.MEMBERSHIP_TABLE;
+
+export const handler = async (event) => {
+  const sub = event.request.userAttributes.sub;
+  const clientId = event.callerContext.clientId;
+
+  // 1. Which tenant is this app client for?
+  const clientMap = await ddb.send(new GetCommand({
+    TableName: TABLE, Key: { PK: `CLIENT#${clientId}`, SK: "TENANT" },
+  }));
+  const tenant = clientMap.Item?.tenant;
+  if (!tenant) {
+    throw new Error(`No tenant mapped for app client ${clientId}`); // deny — misconfig
+  }
+
+  // 2. Is this identity a member of that tenant? With which roles?
+  const membership = await ddb.send(new GetCommand({
+    TableName: TABLE, Key: { PK: `USER#${sub}`, SK: `TENANT#${tenant}` },
+  }));
+  const roles = membership.Item?.roles;
+  if (!roles || roles.length === 0) {
+    // Deny token issuance. Cognito surfaces this as a failed sign-in.
+    throw new Error(`User ${sub} is not a member of tenant ${tenant}`);
+  }
+
+  // 3. Full membership list (for the UI tenant switcher — never an authz input).
+  const all = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    KeyConditionExpression: "PK = :u AND begins_with(SK, :t)",
+    ExpressionAttributeValues: { ":u": `USER#${sub}`, ":t": "TENANT#" },
+  }));
+  const tenants = (all.Items ?? []).map(i => i.SK.replace("TENANT#", ""));
+
+  // 4. Emit tenant-scoped claims. groupsToOverride REPLACES cognito:groups
+  //    in BOTH the ID and access tokens.
+  event.response = {
+    claimsAndScopeOverrideDetails: {
+      groupOverrideDetails: { groupsToOverride: roles },
+      idTokenGeneration: {
+        claimsToAddOrOverride: {
+          "dirigible:tenant": tenant,
+          "dirigible:tenants": tenants.join(","),
+        },
+      },
+      accessTokenGeneration: {
+        claimsToAddOrOverride: { "dirigible:tenant": tenant },
+      },
+    },
+  };
+  return event;
+};
+```
+
+Wire it as the pool's **Pre token generation** trigger with event version **V2_0** ("Basic features + access token customization for user identities"), or **V3_0** if you also want the same treatment for machine-to-machine tokens (§6). Grant the function `dynamodb:GetItem` + `dynamodb:Query` on the table.
+
+Two behaviours to state as contract, not accident:
+
+- **Role propagation is refresh-bound.** The trigger also fires on `TokenGeneration_RefreshTokens`, so a membership or role change in DynamoDB takes effect on the next token refresh — worst case ≈ the access-token lifetime (1 h) plus the Dirigible session. For an immediate revoke, use the "eject user" operation in §15.
+- **The claim-changes quota.** Existing + added claims and scopes in one transaction must total ≤ 5,000 (adjustable). Not a real constraint here, but it exists.
+
+---
+
+## 6. Step 5 — per-tenant app clients
+
+One **confidential** app client per tenant. The client is the thing that tells the Lambda which tenant a token is for, and its registration id in Dirigible must equal the tenant subdomain.
+
+```bash
+aws cognito-idp create-user-pool-client \
+  --user-pool-id us-east-1_XXXXXXXXX \
+  --client-name acme \
+  --generate-secret \
+  --allowed-o-auth-flows code \
+  --allowed-o-auth-flows-user-pool-client \
+  --allowed-o-auth-scopes openid email profile \
+  --callback-urls https://acme.app.example.com/login/oauth2/code/acme \
+  --logout-urls  https://acme.app.example.com/ \
+  --supported-identity-providers COGNITO \
+  --prevent-user-existence-errors ENABLED \
+  --enable-token-revocation \
+  --access-token-validity 60 --id-token-validity 60 --refresh-token-validity 30 \
+  --token-validity-units AccessToken=minutes,IdToken=minutes,RefreshToken=days
+```
+
+Then record the client→tenant mapping the Lambda relies on:
+
+```bash
+aws dynamodb put-item --table-name dirigible-membership \
+  --item '{"PK":{"S":"CLIENT#<thisClientId>"},"SK":{"S":"TENANT"},"tenant":{"S":"acme"}}'
+```
+
+The contract with Dirigible: `CognitoLoginController` exposes `GET /login/{registrationId}`, validates `{registrationId}` against the set of **provisioned tenant subdomains**, and redirects to `/oauth2/authorization/{registrationId}`. So the Dirigible client registration for this tenant must be named **`acme`**, and its callback path must be `/login/oauth2/code/acme`. The per-client callback URL is exactly why one client per tenant beats one shared client — Cognito caps callback URLs at **100 per client** and does not allow wildcards.
+
+Also create **one app client for the default/platform tenant** the same way (name it e.g. `default` or `cognito`), because Dirigible's cognito profile has required Spring placeholders that must resolve at boot (§7).
+
+Quota headroom: **1,000 app clients per pool** by default, raisable to **10,000** — that is your tenants-per-pool ceiling.
+
+---
+
+## 7. Step 6 — machine-to-machine access (optional)
+
+For tenants whose automation calls Dirigible APIs with a token instead of a browser session:
+
+1. Create a resource server on the pool, id `dirigible`, with **custom scopes named after roles** — e.g. `dirigible/ADMINISTRATOR`, `dirigible/data-reader`.
+2. Create a `client_credentials` app client per such tenant, granted the scopes that tenant's automation should hold.
+3. Set the pre-token trigger to **V3_0** — the only version that fires for `TokenGeneration_ClientCredentials`, so the only one that can tenant-scope M2M tokens.
+
+Dirigible maps these with the shipped `ScopeRoleJwtAuthoritiesConverter`: it takes the substring **after the last `/`** of each scope (`dirigible/ADMINISTRATOR` → `ADMINISTRATOR`), optionally expands it through `.scopes` artefacts, and turns the result into `ROLE_*`. A scope with no `/` (like `openid`) is ignored, so standard scopes never become roles.
+
+> **[Mode B]** On today's code, a Bearer/JWT request is a `JwtAuthenticationToken`, which the `CognitoTenantFilter` membership check does **not** inspect — so M2M callers bypass the tenant membership gate entirely. Until the Mode B membership filter lands (§13), scope M2M clients narrowly and treat them as trusted per tenant.
+
+---
+
+## 8. Step 7 — Dirigible configuration
+
+Set these on the Dirigible ECS task (or container env). All keys are verified against `components/security/security-cognito/src/main/resources/application-cognito.properties` and `DirigibleConfig`.
+
+**Profile + multitenancy**
+
+| Env var | Value |
+| --- | --- |
+| `spring_profiles_active` | `cognito` |
+| `DIRIGIBLE_MULTI_TENANT_MODE` | `true` |
+| `DIRIGIBLE_MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL` | `true` |
+| `DIRIGIBLE_HOST` | `https://app.example.com` (used to build the default client's redirect URI) |
+
+**Default-tenant client (satisfies the required Spring placeholders)**
+
+| Env var | Value |
+| --- | --- |
+| `DIRIGIBLE_COGNITO_CLIENT_ID` | the default app client id |
+| `DIRIGIBLE_COGNITO_CLIENT_SECRET` | its secret |
+| `DIRIGIBLE_COGNITO_DOMAIN` | `https://auth.app.example.com` |
+| `DIRIGIBLE_COGNITO_REGION_ID` | `us-east-1` |
+| `DIRIGIBLE_COGNITO_USER_POOL_ID` | `us-east-1_XXXXXXXXX` |
+| `DIRIGIBLE_COGNITO_SCOPE` | `openid` (default) |
+| `DIRIGIBLE_COGNITO_GRANT_TYPE` | `authorization_code` (default) |
+
+`spring.security.oauth2.resourceserver.jwt.jwk-set-uri` and `DIRIGIBLE_HOST` have **no defaults** — if they are unset the context fails to start. That is the main reason the default client exists.
+
+**Per-tenant client registrations.** Two ways; pick one.
+
+- *Runtime (recommended, dynamic):* for each tenant, `POST /services/security/client-registrations` with a JSON body whose **`name` is the tenant subdomain**:
+
+  ```json
+  {
+    "name": "acme",
+    "clientId": "<acme app client id>",
+    "clientSecret": "<acme secret>",
+    "redirectUri": "https://acme.app.example.com/login/oauth2/code/acme",
+    "authorizationGrantType": "authorization_code",
+    "scope": "openid,email,profile",
+    "tokenUri": "https://auth.app.example.com/oauth2/token",
+    "authorizationUri": "https://auth.app.example.com/oauth2/authorize",
+    "userInfoUri": "https://auth.app.example.com/oauth2/userInfo",
+    "issuerUri": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX",
+    "jwkSetUri": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX/.well-known/jwks.json",
+    "userNameAttributeName": "email"
+  }
+  ```
+
+- *Boot-time (static env):* `DIRIGIBLE_OAUTH_CUSTOM_CLIENTS=acme,globex`, then for each name eleven keys prefixed with the **raw name** (no `DIRIGIBLE_`): `acme_CLIENT_ID`, `acme_CLIENT_SECRET`, `acme_REDIRECT_URI`, `acme_GRANT_TYPE`, `acme_SCOPE`, `acme_TOKEN_URI`, `acme_AUTHORIZATION_URI`, `acme_USER_INFO_URI`, `acme_ISSUER_URI`, `acme_JWK_SET_URI`, `acme_USER_NAME_ATTRIBUTE`. Any missing key throws at boot.
+
+**Tenant row.** Each tenant also needs a Dirigible tenant record (subdomain must match): `POST /services/security/tenants` with `{ "name": "Acme", "subdomain": "acme" }`. The provisioning job then creates its schema and datasource (see the companion docs).
+
+**Login entry point:** `https://acme.app.example.com/login/acme`.
+
+---
+
+## 9. End-to-end worked example
+
+Anna (`sub = a1b2-c3d4`) administers `acme` and manages employees in `globex`. DynamoDB holds the four items from §4.
+
+**She signs into `acme`.** App client `acme` → Lambda maps client → tenant `acme` → membership `["ADMINISTRATOR"]`. Token:
+
+```json
+{ "sub": "a1b2-c3d4", "email": "anna@example.com",
+  "cognito:groups": ["ADMINISTRATOR"],
+  "dirigible:tenant": "acme", "dirigible:tenants": "acme,globex" }
+```
+
+Dirigible's `userAuthoritiesMapper` reads `cognito:groups` → authority `ROLE_ADMINISTRATOR`. Anna can reach the admin surfaces in `acme`.
+
+**She opens `https://globex.app.example.com`.** App client `globex` → tenant `globex` → membership `["employee-manager"]`. Token:
+
+```json
+{ "sub": "a1b2-c3d4", "cognito:groups": ["employee-manager"],
+  "dirigible:tenant": "globex", "dirigible:tenants": "acme,globex" }
+```
+
+→ authority `ROLE_employee-manager` **only**. Same person, different roles, and her `acme` admin rights do not follow her into `globex`.
+
+**A non-member is denied.** If Anna somehow reaches the `initech` app client, the Lambda finds no `USER#a1b2-c3d4 / TENANT#initech` item and **throws** — Cognito never issues a token, so Dirigible never sees an unauthorized session.
+
+---
+
+## 10. Login flows
+
+**First login to a tenant**
+
+```
+https://acme.app.example.com/  →  unauthenticated
+  → /login/acme  →  /oauth2/authorization/acme
+  → Cognito managed login (client acme): credentials + MFA
+  → Lambda: member? yes → groups = roles(acme)
+  → callback /login/oauth2/code/acme  →  JSESSIONID for acme.app.example.com
+```
+
+**Cross-tenant hop — the requirement**
+
+```
+same browser → https://globex.app.example.com/  →  no session for this host
+  → /login/globex  →  /oauth2/authorization/globex
+  → Cognito: managed-login cookie still valid (pool-wide, ≤1h)  ⇒  NO credential prompt
+  → Lambda: member? yes → groups = roles(globex)   ← different roles
+  → separate JSESSIONID for globex.app.example.com
+```
+
+One sign-in, two tenants, different roles, no re-authentication — using Cognito's documented shared-cookie behaviour rather than fighting it. Because `JSESSIONID` is host-scoped, each subdomain's Spring session holds its own tenant's authorities, so the "authorities are snapshotted at login" behaviour is correct per tenant.
+
+**Logout.** `https://<sub>.app.example.com/logout` clears the Dirigible session and redirects to Cognito's logout endpoint.
+
+> **[Mode A caveat]** `CognitoLogoutSuccessHandler` uses the single `DIRIGIBLE_COGNITO_CLIENT_ID` and `DIRIGIBLE_HOST`, so logout hits the *default* client and host rather than the current tenant's. It signs the user out, but the redirect can be wrong. Fixed in Mode B (§13).
+
+---
+
+## 11. Mode A caveats → Mode B fixes
+
+| Mode A behaviour (works, but imperfect) | Mode B change (target-architecture §6) |
+| --- | --- |
+| M2M/Bearer tokens bypass the tenant membership check (the filter only inspects `OAuth2AuthenticationToken`) | One provider-agnostic `TenantMembershipFilter` that also inspects `JwtAuthenticationToken` and asserts `dirigible:tenant == host tenant` |
+| `@RolesAllowed` may be inert under the cognito profile — `@EnableMethodSecurity(jsr250Enabled=true)` sits only on the basic-auth config (**hypothesis**, confirm first) | Enable JSR-250 method security in the active security config |
+| `CognitoTenantFilter` isn't added inside the security chain (unlike basic/keycloak/snowflake) — runs only via servlet auto-registration | Add the membership filter explicitly in `CognitoSecurityConfiguration` |
+| Logout uses the single default client/host | Per-tenant logout from the current registration |
+| Client registrations are a CRUD surface with a process-global static map and plaintext-secret reads | Derive registrations from the tenant registry; stop returning secrets |
+| `DIRIGIBLE_TRIAL_ENABLED` grants every role to everyone, tenant-blind | Remove or restrict to the default tenant in a non-prod profile |
+
+None of these blocks Mode A for a trusted set of tenants; all of them matter before untrusted tenants share the pool.
+
+---
+
+## 12. Tenant onboarding runbook
+
+Automate this in the control plane; the order matters (the Lambda must be able to map the client before anyone signs in):
+
+```
+1. Cognito: create app client "<sub>"  (§6)  → note clientId, secret
+2. DynamoDB: put CLIENT#<clientId> → tenant "<sub>"
+3. Route 53: <sub>.app.example.com → ALB
+4. Dirigible: POST /services/security/tenants { name, subdomain: "<sub>" }
+5. Dirigible: POST /services/security/client-registrations  (name = "<sub>")   [or env at next deploy]
+6. DynamoDB: put USER#<adminSub> / TENANT#<sub> → ["ADMINISTRATOR"]   (first member)
+7. wait for provisioning: schema + datasource created, tenant status PROVISIONED
+```
+
+No user row is created in Dirigible's database at any step — membership is the DynamoDB item written in step 6.
+
+---
+
+## 13. User & role operations
+
+| Operation | Action |
+| --- | --- |
+| Invite a person | Create/confirm them in the Cognito pool once (global identity), then add a membership item |
+| Add to a tenant | `put USER#<sub> / TENANT#<sub-domain> → [roles]` |
+| Change roles | Overwrite the `roles` list on that item |
+| Remove from a tenant | Delete that membership item |
+| **Eject immediately** | Delete the membership item **and** call `AdminUserGlobalSignOut` for the user **and** invalidate their Dirigible session — otherwise the change only takes effect at next token refresh |
+
+State the SLA plainly to tenant admins: unless you eject, a role or membership change lands within about one token lifetime (default 1 h).
+
+---
+
+## 14. Enterprise SSO (later, no redesign)
+
+When a tenant wants its own IdP (Entra ID, Okta, Google Workspace):
+
+1. Add the IdP to the **pool** (SAML or OIDC).
+2. On that **tenant's app client**, set `supported-identity-providers` to include it (and drop `COGNITO` if you want to force SSO).
+3. Map the IdP's subject/email so the same `sub` join key resolves; the Lambda and DynamoDB membership are unchanged.
+
+Because the topology is one-client-per-tenant, this is a per-client setting — no new pool, no structural change.
+
+> **Caveat to test:** AWS's shared-cookie / cross-app-client SSO statement is worded for *local* pool users. A user who signs in through an external IdP has their session at that IdP, so the seamless cross-tenant hop of §10 may prompt again for federated tenants. Verify before promising it.
+
+---
+
+## 15. Validation checklist
+
+- [ ] Pool is on **Essentials**; the pre-token trigger shows event version **V2_0** (V3_0 if M2M).
+- [ ] `create-user-pool-client` for a tenant, `put-item` its `CLIENT#…→tenant` map, then sign in — decode the ID token and confirm `cognito:groups` holds *only that tenant's roles* and `dirigible:tenant` matches the host.
+- [ ] Sign in as a non-member against a tenant's client — confirm Cognito denies (Lambda throw), no Dirigible session.
+- [ ] Cross-tenant hop: after signing into tenant A, open tenant B in the same browser — confirm no credential prompt and a *different* authority set.
+- [ ] Dirigible boots under the cognito profile (the required `jwk-set-uri` / `DIRIGIBLE_HOST` placeholders resolve).
+- [ ] `GET /login/<sub>` redirects to `/oauth2/authorization/<sub>`; an unknown subdomain 404s.
+- [ ] **Isolation test worth adding to the suite:** an integration test asserting that `anna` in tenant A and a different `anna` in tenant B get distinct data and workspaces. None of the existing multitenancy ITs covers same-identity-across-tenants.
+- [ ] **Confirm the `@RolesAllowed` hypothesis** (§11) before relying on method-level role checks under the cognito profile: boot with `spring_profiles_active=cognito` and call a `@RolesAllowed`-only endpoint with a token holding no matching group.
+
+---
+
+## 16. References
+
+**Companion documents**
+- [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md), [`AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`](AWS_MULTITENANCY_TARGET_ARCHITECTURE.md), [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md)
+
+**In-repo**
+- `components/security/security-cognito/` — the cognito profile: `CognitoSecurityConfiguration` (the `cognito:groups` → authorities mapper), `CognitoTenantFilter` (`custom:tenant` membership check), `CognitoLoginController` (`/login/{registrationId}` = subdomain), `CognitoLogoutSuccessHandler`, `application-cognito.properties`.
+- `components/security/security-client-registration/` — `ClientRegistrationEndpoint` (`POST /services/security/client-registrations`), `DynamicClientRegistrationRepository` (registrationId = entity `name`; the static-map and `DIRIGIBLE_OAUTH_CUSTOM_CLIENTS` seeding).
+- `components/engine/engine-security/.../oauth/ScopeRoleJwtAuthoritiesConverter.java` — scope → role for M2M.
+- `components/core/core-tenants/.../endpoint/TenantEndpoint.java` — `POST /services/security/tenants`.
+- `components/core/core-base/.../util/AuthoritiesUtil.java` — the `ROLE_<name>` authority format.
+
+**AWS documentation**
+- [Multi-tenant application best practices](https://docs.aws.amazon.com/cognito/latest/developerguide/multi-tenant-application-best-practices.html) — shared pool + cross-app-client session cookie.
+- [Pre token generation Lambda trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) — event versions, the modifiable-claims table, `groupsToOverride`.
+- [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) — app clients per pool (1,000/10,000), callback URLs per client (100), groups per user (100), claim-changes (5,000).
+- [User group](https://docs.aws.amazon.com/cognito/latest/developerguide/group-based-multi-tenancy.html) / [custom attribute](https://docs.aws.amazon.com/cognito/latest/developerguide/custom-attribute-based-multi-tenancy.html) / [custom scope](https://docs.aws.amazon.com/cognito/latest/developerguide/scope-based-multi-tenancy.html) multi-tenancy models.

--- a/AWS_MULTITENANCY_TARGET_ARCHITECTURE.md
+++ b/AWS_MULTITENANCY_TARGET_ARCHITECTURE.md
@@ -6,6 +6,7 @@
 
 **Companion documents**
 - [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md) — what you can deploy on AWS *today* with zero code changes. Still valid; this document does not replace it.
+- [`AWS_MULTITENANCY_SETUP_GUIDE.md`](AWS_MULTITENANCY_SETUP_GUIDE.md) — the step-by-step Cognito + Dirigible setup that implements this model (user pool, per-tenant app clients, the pre-token Lambda, DynamoDB membership, exact config).
 - [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — the behaviour reference for how multitenancy works now.
 
 ---

--- a/AWS_MULTITENANCY_TARGET_ARCHITECTURE.md
+++ b/AWS_MULTITENANCY_TARGET_ARCHITECTURE.md
@@ -1,0 +1,443 @@
+# Multitenant Dirigible on AWS — Recommended Target Architecture
+
+**Status:** design proposal. Nothing is implemented.
+**Date:** 2026-07-27
+**Constraint:** changes to Dirigible's multitenant model **are** permitted. This is a product fork; breaking changes are acceptable.
+
+**Companion documents**
+- [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md) — what you can deploy on AWS *today* with zero code changes. Still valid; this document does not replace it.
+- [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) — the behaviour reference for how multitenancy works now.
+
+---
+
+## 1. Purpose
+
+The as-is document was written under a deliberate constraint: treat the platform as a fixed black box. That produced an honest but limited answer — cells, one instance per cell, and a list of things you simply have to live with.
+
+That constraint is now lifted, and one new functional requirement drives most of what follows:
+
+> **A user registered in one tenant must be able to log into another tenant, if they hold the necessary authorizations there.**
+
+Plus a direction that changes the shape of the answer entirely:
+
+> **The implementation need not use the local user and tenant tables. That data can come from the Cognito token.**
+
+Taken together these move the design from *"add a membership table to the platform schema"* to *"make Dirigible a claims-driven authorization consumer and let the identity provider own identity."* That is a better architecture for a SaaS, and — as §6 shows — it is a **smaller** change than the alternative, because two thirds of it already exists by accident.
+
+### Scope
+
+| In scope | Out of scope |
+| --- | --- |
+| Identity, tenant membership, per-tenant authorization | The data layer (schema-per-tenant on Aurora stands unchanged) |
+| The Cognito topology and the claims contract | Compute topology (ECS Fargate, cells — unchanged) |
+| The platform changes those imply | The IDE/authoring tier's user-scoped state (§9.3 records it as a known constraint) |
+| One runtime isolation gap that must be decided regardless (§6.11) | Upstream contribution / migration path — this is a fork |
+
+---
+
+## 2. The requirement, and why the current model cannot express it
+
+Today a "user" is a row scoped to exactly one tenant — `components/core/core-tenants/.../domain/User.java`:
+
+```java
+@Entity
+@Table(name = "DIRIGIBLE_USERS", uniqueConstraints = {@UniqueConstraint(columnNames = {"USER_TENANT_ID", "USER_USERNAME"})})
+public class User extends Artefact {
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "USER_TENANT_ID") private Tenant tenant;
+    @Column(name = "USER_USERNAME", nullable = false) private String username;
+```
+
+`tenant` is `@ManyToOne` — strictly single-valued. There is **no `@ManyToMany` anywhere in the codebase** and no membership table; a repo-wide search finds only OData mapping-table machinery. So "the same person in two tenants" is two unrelated rows, two password hashes, two independent role-assignment sets, and no way for the platform to know they are the same person.
+
+Login enforces it — `CustomUserDetailsService.loadUserByUsername`:
+
+```java
+Tenant tenant = tenantContext.getCurrentTenant();
+User user = userService.findUserByUsernameAndTenantId(username, tenant.getId())
+                       .orElseThrow(() -> new UsernameNotFoundException(
+                               "Username [" + username + "] was not found in tenant [" + tenant + "]."));
+```
+
+Two things are worth noticing about that method, because they define the whole problem:
+
+1. **The tenant is not chosen by the user.** It comes from `TenantContext.getCurrentTenant()`, i.e. from the `Host` header via `TenantExtractor`. There is no mechanism by which a user says "log me into tenant B."
+2. **The tenant is resolved and then thrown away.** The method returns a plain `org.springframework.security.core.userdetails.User(username, password, authorities)` — no tenant field. From that point on the security context knows *the username*, the thread-local knows *the tenant*, and nothing ties them together. This is the seam any multi-tenant identity model has to close.
+
+Role assignments have no tenant dimension either — `UserRoleAssignment` is `(USER_ID, ROLE_ID)`, unique on that pair, deriving its tenancy transitively from the user row. So "different roles in tenant A and tenant B" is expressible today *only* by virtue of being two different users.
+
+### The irony: the membership model already exists, one layer up
+
+`components/security/security-cognito/.../CognitoTenantFilter.java` already treats one identity as a member of many tenants:
+
+```java
+String tenantAttribute = oauthToken.getPrincipal().getAttribute("custom:tenant");
+...
+Set<String> userTenants = new HashSet<>(Arrays.asList(tenantAttribute.split(","))
+                                              .stream().map(e -> e.trim()).collect(Collectors.toList()));
+if (!userTenants.contains(currentTenant.get().getSubdomain())) {
+    forbidden("User is not member of the [" + ... + "] tenant", response);
+}
+```
+
+`custom:tenant` is a **comma-separated list of tenant subdomains**. The IdP therefore already models one-identity-in-many-tenants. The filter parses that set, answers one yes/no question with it, and **discards it** — nothing downstream can see the membership, and the roles the user gets are `cognito:groups`, a single flat pool-global list that is identical in every tenant.
+
+So the gap is precise: **membership is already cross-tenant; authorization is not.** The design below closes exactly that gap.
+
+One further asymmetry that makes the "token as source of truth" direction natural: under the Cognito and Keycloak profiles the platform's own user tables are **already bypassed**. `CognitoSecurityConfiguration.userAuthoritiesMapper()` derives authorities solely from the `cognito:groups` claim, no `DIRIGIBLE_USERS` row is consulted, and none is created. Half of the recommended model is already the shipped behaviour — it is just tenant-blind.
+
+---
+
+## 3. Design principles
+
+1. **The IdP is the system of record for identity.** The platform stores no passwords, no user directory, no role assignments.
+2. **The platform authorizes from claims, per request.** Roles arrive in the token; Dirigible maps them to authorities and enforces them.
+3. **The tenant is resolved from the host and *proven* by the token.** Host-based resolution stays (it is good, and it already reads `x-forwarded-host`). The token must independently assert which tenant it is for, so a token minted for tenant A cannot be replayed against tenant B.
+4. **A token is scoped to one tenant.** Not "here are all your tenants and all your roles everywhere" — that bloats tokens and makes every authorization decision a filtering exercise.
+5. **The control plane owns the membership graph.** Cognito authenticates and mints tokens; a control-plane store owns tenant ↔ user ↔ roles; the platform consumes the result. Three components, three jobs.
+6. **`.roles` artefacts remain the role vocabulary.** The registry defines what roles exist; the control plane assigns them. That keeps role definitions where developers author them.
+
+---
+
+## 4. Recommended identity architecture
+
+### 4.1 One Cognito user pool, one app client per tenant
+
+```
+                        ┌───────────────────────────────────────────────┐
+                        │  ONE Cognito user pool                        │
+                        │  • one identity per person (sub = global id)  │
+                        │  • managed-login session cookie shared        │
+                        │    across ALL app clients in the pool (1h)    │
+                        │                                               │
+                        │  app client "acme"    app client "globex"  …  │
+                        │    callback:            callback:             │
+                        │    acme.app.ex.com/…    globex.app.ex.com/…   │
+                        └───────┬───────────────────────┬───────────────┘
+                                │                       │
+                     ┌──────────▼───────────────────────▼──────────┐
+                     │  Pre-token-generation Lambda (V2_0 / V3_0)  │
+                     │  clientId → tenant                          │
+                     │  (sub, tenant) → roles, from the control     │
+                     │                  plane store                │
+                     │  emits: groupsToOverride = roles HERE        │
+                     │         dirigible:tenant  = this tenant      │
+                     │         dirigible:tenants = membership list  │
+                     │  denies issuance if not a member             │
+                     └──────────┬──────────────────────────────────┘
+                                │  tenant-scoped token
+                     ┌──────────▼──────────────────────────────────┐
+                     │  Dirigible                                   │
+                     │  host → tenant  (TenantExtractor)            │
+                     │  assert dirigible:tenant == host tenant      │
+                     │  cognito:groups → authorities (per tenant)   │
+                     └──────────────────────────────────────────────┘
+```
+
+**Why a single pool.** The requirement forces it: cross-tenant login means one identity per person, and pool-per-tenant means N accounts per person. AWS's guidance is explicit that a shared pool "supports models where customers have accounts in more than one application," and — decisively — that when you authenticate local users in a pool, "their session cookie authenticates them for all app clients in the same user pool." AWS then names the only two ways to *prevent* that cross-app-client SSO: separate per-tenant pools, or replacing hosted-UI sign-in with the API. **We want the behaviour AWS describes as the thing you'd have to work to avoid.** ([multi-tenant application best practices](https://docs.aws.amazon.com/cognito/latest/developerguide/multi-tenant-application-best-practices.html))
+
+**Why one app client per tenant.** This is the move that makes the platform change small. The pre-token-generation Lambda receives `event.callerContext.clientId`, so it knows which tenant the token is being minted for, and can emit *only that tenant's roles*. Consequences:
+
+- **The token is tenant-scoped at issuance.** Dirigible's existing `cognito:groups` → authorities mapping becomes correct per tenant **with no change to that mapper**.
+- **Roles need not be real Cognito groups.** `groupsToOverride` replaces the `cognito:groups` claim outright, so the Lambda can synthesize it from the control-plane store. That sidesteps the non-adjustable quota **"Groups to which each user can belong: 100"** — a user in 30 tenants with 4 roles each would otherwise blow through it.
+- **Per-tenant callback URLs**, which Dirigible's per-tenant client registrations already support (`redirectUri` is a per-registration column).
+- **Per-tenant federated IdPs later.** An app client selects which identity providers it offers, so "tenant X federates its own Entra ID" is an app-client setting — the enterprise-SSO extension point, with no redesign. (Identity providers per user pool: 300, adjustable to 1,000.)
+- **The tenants-per-pool ceiling is the app-client quota**: 1,000 by default, adjustable to 10,000. Well past the point where you would shard pools by cell anyway.
+
+**Why host-scoped sessions make this work cleanly.** `JSESSIONID` carries no `Domain` attribute, so it is host-only. Each tenant subdomain therefore gets its own Spring session, holding its own tenant-scoped authorities. This neutralises what would otherwise be a serious problem: **authorities are snapshotted at login** and never re-resolved per request in session-based flows. Because the snapshot is per (host, session), and host ⇒ tenant, the snapshot *is* per-tenant. No per-request re-derivation machinery is needed.
+
+### 4.2 The claims contract
+
+| Claim | Source | Meaning | Notes |
+| --- | --- | --- | --- |
+| `sub` | Cognito | The global, immutable identity of the person | The Lambda **cannot** modify `sub` or `cognito:username`; use `sub` as the identity key |
+| `cognito:groups` | Lambda `groupsToOverride` | The caller's roles **in this token's tenant** | Must match `.roles` artefact names (and the three platform roles) exactly |
+| `dirigible:tenant` | Lambda `claimsToAddOrOverride` | The tenant this token was minted for | Dirigible asserts it equals the host-resolved tenant. Defence in depth |
+| `dirigible:tenants` | Lambda `claimsToAddOrOverride` | The caller's full membership list | For the UI tenant switcher only — never an authorization input |
+| `email` | Cognito | Display identity | Already the configured `user-name-attribute` |
+| `scope` | Cognito / Lambda | M2M authorization | Maps to roles via `ScopeRoleJwtAuthoritiesConverter` and `.scopes` artefacts |
+
+Trigger version **V2_0** is required for access-token customization and complex (array/JSON) claim values; it needs the **Essentials or Plus** feature plan. Use **V3_0** if M2M client-credentials tokens need the same treatment — that is the only version that fires for `TokenGeneration_ClientCredentials`. ([pre token generation Lambda trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html))
+
+### 4.3 Flows
+
+**First login to a tenant.**
+
+```
+user → https://acme.app.example.com/
+  → Dirigible: host → tenant "acme"; unauthenticated
+  → redirect /login/acme → /oauth2/authorization/acme   (registration id = subdomain, already implemented)
+  → Cognito managed login (app client "acme"): credentials + MFA
+  → Pre-token Lambda: clientId "acme" → tenant "acme"
+        member? no  → deny, no token issued
+        member? yes → groups = roles(sub, acme), dirigible:tenant = acme,
+                      dirigible:tenants = [acme, globex]
+  → callback https://acme.app.example.com/login/oauth2/code/acme
+  → Dirigible: assert dirigible:tenant == "acme"; authorities = cognito:groups
+  → JSESSIONID for acme.app.example.com
+```
+
+**Cross-tenant navigation — the requirement.**
+
+```
+same browser → https://globex.app.example.com/
+  → no JSESSIONID for this host → unauthenticated
+  → /login/globex → /oauth2/authorization/globex
+  → Cognito: managed-login session cookie is still valid (pool-wide, ≤1h)
+              ⇒ NO credential prompt
+  → Pre-token Lambda: clientId "globex" → tenant "globex"
+              ⇒ groups = roles(sub, globex)      ← DIFFERENT roles
+  → separate JSESSIONID for globex.app.example.com
+```
+
+One sign-in, two tenants, different roles in each, and a user who is not a member of `globex` never gets a token for it. That is the requirement satisfied, using Cognito's documented default behaviour rather than fighting it.
+
+**Role change propagation — state this as an SLA, do not hand-wave it.** The trigger also fires on `TokenGeneration_RefreshTokens`, so a membership or role change takes effect on the next token refresh, not instantly. With a 1-hour access token the worst case is ~1 hour, plus the life of the Dirigible session. If a revocation must be immediate, the control plane has to call Cognito's global sign-out for that user *and* the platform has to invalidate the session — design that as an explicit "eject user" operation rather than assuming propagation is instant.
+
+---
+
+## 5. Why not the alternatives
+
+| Alternative | Why not |
+| --- | --- |
+| **One user pool per tenant** | Directly contradicts the requirement — a person needs one account per tenant, with separate passwords and MFA enrolments, and there is no cross-tenant sign-in. It is the right answer only when you want to *prevent* cross-tenant access |
+| **One shared app client for all tenants** | Cognito callback URLs do not support wildcards and cap at 100 per app client, so per-tenant subdomain callbacks stop working past 100 tenants. The Lambda also loses its tenant signal (`clientId` is the only reliable one — `clientMetadata` is not passed on `InitiateAuth`/hosted-UI flows), so the token must carry *every* tenant's roles and the app must filter per request. Bigger tokens, more platform code, no per-tenant federation |
+| **Per-tenant roles as real Cognito groups** (`acme:ADMINISTRATOR`) | Hits the non-adjustable **100 groups per user** quota for anyone in many tenants, and makes Cognito the authority for a graph that belongs to the control plane. Synthesizing the claim in the Lambda has none of these problems |
+| **A local membership table in the platform DB** | Duplicates the control plane, requires a migration, and keeps the cross-tenant admin CRUD surface (§9.1) that the claims model deletes outright. It also keeps the platform in the business of storing credentials |
+| **Custom attribute holding a role map** (`custom:tenant_roles` as JSON) | Custom attributes cap at 2,048 bytes and 50 per pool, and are user-global — so the token would again carry every tenant's roles. The Lambda + `groupsToOverride` path has no size problem because the claim is per-token |
+
+---
+
+## 6. Platform changes
+
+Ordered so that each step is verifiable before the next depends on it.
+
+### 6.1 Phase 0 — verify method security is actually on (prerequisite)
+
+`@EnableMethodSecurity(securedEnabled = false, jsr250Enabled = true, prePostEnabled = false)` appears on exactly one class — `core-tenants/.../security/BasicSecurityConfig.java:36` — which is `@ConditionalOnProperty(name = "basic.enabled", havingValue = "true")`. The only other occurrence is `KeycloakSecurityConfiguration.java:50`, a bare `@EnableMethodSecurity` whose default is `jsr250Enabled = false`. Every OIDC profile properties file sets `basic.enabled=false`.
+
+Read literally, **all 52 `@RolesAllowed` annotations in `components/` are inert under the cognito, keycloak, snowflake and github profiles**, leaving only the URL-pattern layer and the `.access` filter. If that is true it is a live authorization bug independent of this design, and it changes which layer must be made tenant-aware. **Confirm by experiment before designing anything on top of it** (§10).
+
+### 6.2 Introduce a `TenantIdentityResolver` SPI
+
+The one new abstraction. It answers three questions from whatever the request carries:
+
+- *Who is this?* → a stable identity key (`sub`), plus a display name.
+- *May they act in this tenant?* → yes/no, for the host-resolved tenant.
+- *What are their roles here?* → a role-name set.
+
+Implementations: **cognito-claims** (production), **keycloak-claims**, **local-tables** (dev / single-tenant). Everything else consumes its output, so provider differences stop leaking into the platform. Two unused SPI seams already exist and are the natural mounting points — `core-base/.../http/access/CustomSecurityConfigurator.java` (consumed by `HttpSecurityURIConfigurator`, zero implementations) and `core-base/.../http/access/UserAccessVerifier.java` (loaded by `UserRequestVerifier` via `ServiceLoader`, zero implementations).
+
+### 6.3 Demote the local user tables
+
+`DIRIGIBLE_USERS`, `DIRIGIBLE_USER_ROLE_ASSIGNMENTS`, `UsersEndpoint`, `AdminUserInitializer` and the `view-security` users UI stop being the authorization source. They survive only behind the dev SPI implementation.
+
+This is worth doing for the security posture alone. It **closes the cross-tenant admin gap by construction** (§9.1) and retires four defects found while mapping the code, all in `core-tenants`:
+
+- `UserService.updateUser` stores the password **un-encoded** (`user.setPassword(password)` at line 115) while `createNewUser` BCrypts it — so a `PUT` on a user destroys the hash.
+- `UserParameter` is annotated `@Valid` at both call sites but carries **no constraint annotations at all**, so username/password/tenant may all be null.
+- `UsersEndpoint.get` and the username search call `.get()` on an `Optional` → `NoSuchElementException` → HTTP 500 instead of 404.
+- `User.updateKey()` accepts a null tenant and silently produces the key `user|-|admin|null`.
+
+### 6.4 Unify and universalise the tenant membership check
+
+Replace the two byte-identical `CognitoTenantFilter` / `KeycloakTenantFilter` clones with one provider-agnostic `TenantMembershipFilter` that reads the normalized SPI output, and add it **inside** the security chain. It must assert `dirigible:tenant == host-resolved tenant` and reject on mismatch. Three concrete holes close:
+
+- **Cognito's chain never adds `TenantContextInitFilter` at all.** `BasicSecurityConfig`, `KeycloakSecurityConfiguration` and `SnowflakeSecurityConfig` all `addFilterBefore(...)` it; `CognitoSecurityConfiguration` does not. It still runs, but only because Spring Boot auto-registers plain `OncePerRequestFilter` `@Component`s as servlet filters at lowest precedence — so its ordering relative to authentication is an accident, not a design.
+- **M2M requests bypass the membership check entirely.** Both filters guard on `principal instanceof OAuth2AuthenticationToken`; a Bearer-token request produces a `JwtAuthenticationToken`, which is not one, so the whole body is skipped.
+- **Nothing rejects a session minted on `t1.example.com` replayed against `t2.example.com`** in the basic and snowflake profiles. Authorities are snapshotted; the tenant is re-derived per request from the host; no filter checks that the two agree. Under the recommended design the host-scoped-cookie + `dirigible:tenant` assertion makes this structurally impossible, but the assertion has to be written.
+
+Also note both filters are gated on flags read **once in the constructor**, so they are not runtime-flippable, and when either flag is off **the entire membership check is skipped**.
+
+### 6.5 Carry the tenant in the principal
+
+Close the seam at `CustomUserDetailsService:76`. A principal holding `(sub, username, tenant, roles)` means the tenant is available wherever the identity is, instead of living in a parallel thread-local. Then:
+
+- Add `UserFacade.getTenant()`. `UserFacade` today has no reference to `TenantContext` at all, and all its methods are `static`, so this needs a small restructure.
+- Add a tenant accessor and `getRoles()` to the TypeScript facade (`api-modules-javascript/.../modules/src/security/user.ts`) — it currently has neither, while the Java SDK has `getRoles()`. TS user code cannot presently discover which tenant it is running in.
+- Guard `UserFacade.getUserRoles()`, which reads `SecurityContextHolder.getContext().getAuthentication().getAuthorities()` unguarded and NPEs on job/anonymous threads.
+
+### 6.6 Decide super-role semantics explicitly
+
+The DEVELOPER/ADMINISTRATOR "bypass everything" short-circuit is implemented **three times**: `api-security/.../UserFacade.isInRole`, `engine-java/.../controller/ControllerInvoker.checkRoles`, and `core-extensions/.../ExtensionService.validateRoles`. Meanwhile `engine-native-apps/.../proxy/ExposedPathFilter` deliberately rejects it and documents why. Today these super-roles are neither per-tenant nor platform-global — they are "whatever tenant you logged into, applied everywhere." A tenant-aware model has to state a position and collapse the three copies onto it.
+
+### 6.7 Rework or delete `security-client-registration`
+
+Derive OAuth client registrations from the tenant registry rather than maintaining a parallel CRUD surface. As it stands:
+
+- **No tenant column.** The tenant linkage is convention only (`registrationId` should equal `Tenant.subdomain`).
+- **`registrationId` is the entity `name`, while the REST path uses `id`** — `withRegistrationId(registration.getName())`. The seeded Cognito default is constructed as `new ClientRegistration(clientName, "cognito", ...)` then `setId("default-tenant")`, so its name is `"cognito"`. But `CognitoLoginController` accepts only provisioned tenant **subdomains**, and the default tenant's subdomain is `default`. So `/login/cognito` 404s and `/login/default` finds no registration — the default registration is reachable only via the `permitAll` `/oauth2/authorization/cognito`. (This confirms, as a real inconsistency, what the as-is document listed as a verification item.)
+- **`REGISTRATIONS` is a `private static` non-thread-safe `HashMap`**, process-global, never invalidated, and populated *only* as a side effect of `iterator()` — so `findByRegistrationId` (what Spring actually calls) returns `null` until something iterates.
+- **`GET` returns `clientSecret` in plaintext** to any tenant's ADMINISTRATOR / DEVELOPER / OPERATOR, with no tenant predicate on any operation.
+- The module's beans are unconditional, so its `ClientRegistrationRepository` replaces Spring Boot's in **every** profile, including basic and snowflake.
+
+### 6.8 Remove the unused authorization-server starter
+
+`components/security/security-client-registration/pom.xml:55` pulls in `spring-boot-starter-oauth2-authorization-server`. Nothing configures it — there are no `spring.security.oauth2.authorizationserver.client` properties anywhere in the repo, so no `RegisteredClientRepository`, no token endpoint, no issuer. Its only observable effect is that Boot's auto-configuration publishes a `JwtDecoder` backed by a generated in-memory RSA key, which is why all three resource-server configs must defensively pin their own decoder on the configurer. Removing the starter lets those workarounds go. (The regression test `CognitoResourceServerJwtDecodeTest` guards the current behaviour and documents the failure mode: "no matching key(s) found".)
+
+### 6.9 Kill or scope `DIRIGIBLE_TRIAL_ENABLED`
+
+It grants **every platform role to every authenticated principal**, tenant-blind, in three places (both OIDC authority mappers and `ScopeRoleJwtAuthoritiesConverter`). In a multi-tenant deployment that is a full cross-tenant privilege escalation switch. Either delete it or restrict it to the default tenant in a non-production profile.
+
+### 6.10 Keep the tenant registry, as a projection
+
+`DIRIGIBLE_TENANTS` must stay: provisioning needs it, and `TenantContext.executeForEachTenant` — which drives the per-tenant replay of the eight multitenant synchronizers — needs to enumerate all tenants, which a per-user token can never do. But it becomes a **projection of the control plane**, reconciled by the onboarding automation rather than hand-maintained. Provisioning should be triggered by the control plane on demand instead of discovered by a 900-second poll.
+
+### 6.11 Decide the client-Java isolation gap (runtime, not authoring)
+
+`engine-java/.../runtime/JavaCompiledOutputDirectory.java:42` resolves to a single global directory for **all** tenants:
+
+```java
+this.directory = Paths.get(repoRoot, "dirigible", "java-compiled", "bin")
+```
+
+loaded by one `ClientClassLoader`. Unlike the workspace/git/LSP collisions in §9.3, this is a **runtime** concern: client Java code is not tenant-isolated at all. Two tenants publishing a same-FQN class share one compiled artefact and one classloader. The same applies to `PublisherService`, which publishes into the **shared** `/registry/public` — so two same-named users in two tenants can overwrite each other's running application code.
+
+Neither is caused by the identity change, and both need a decision regardless. The honest options are: accept it (a single shared registry is the platform's model, and per-tenant code is not currently a feature), or partition the compiled output and classloader per tenant, which is a substantial change to `engine-java`.
+
+---
+
+## 7. The authorization model after the change
+
+**Where authorities come from.** The `TenantIdentityResolver` implementation for the active profile. In production: `cognito:groups` from a tenant-scoped token, mapped by `AuthoritiesUtil.toAuthorities` (unchanged — a flat `ROLE_<NAME>` string). No composite `ROLE_<TENANT>__<ROLE>` encoding is needed, because the token is already tenant-scoped; that matters, since `AuthoritiesUtil.toRoleNames` strips the prefix with a regex `replaceAll` and would mangle composite names.
+
+**What stays global.** The role *vocabulary* and the ACL definitions: `.roles`, `.access` and `.scopes` artefacts, and their entities (`Role`, `Access`, `Scope` — none has a tenant column). This is correct and should be stated as a decision, not an omission: the registry is shared, so the definitions are shared. Note `Role.name` is **de-facto globally unique** because `BaseArtefactService.findByName` and `RoleService.roleExistsByName` are single-result queries that throw `IncorrectResultSizeDataAccessException` on duplicates — so per-tenant role *names* are not an option without reworking those.
+
+**What becomes per-tenant.** Assignments only, and they live in the token.
+
+**Where enforcement happens** — unchanged mechanisms, now fed correct per-tenant authorities:
+
+| Layer | File | Note |
+| --- | --- | --- |
+| URL patterns | `core-base/.../http/access/HttpSecurityURIConfigurator.java` | `PUBLIC` / `DEVELOPER` / `OPERATOR` / `AUTHENTICATED` groups, then `anyRequest().denyAll()` |
+| Platform endpoints | 52 × class-level `@RolesAllowed` | Only three distinct sets, all built-in roles. **See §6.1 first** |
+| `.access` constraints | `engine-security/.../filter/SecurityFilter.java` + `verifier/AccessVerifier.java` | Longest-path-wins; magic role `Public`. The ACL cache is a per-JVM `volatile Map`, not tenant-keyed — fine while the definitions are global |
+| Client Java | `engine-java/.../controller/ControllerInvoker.checkRoles` | Duplicates the super-role logic (§6.6) |
+| UI visibility | `core-extensions/.../ExtensionService.validateRoles` | Third copy; returns `true` when there is no request context |
+| CMIS | `api-cms/.../CmisFacade` | `.access` with `scope = "CMIS"`, walked per path prefix |
+| Native apps | `engine-native-apps/.../proxy/ExposedPathFilter` | Deliberately strict; no super-role bypass |
+| M2M | `engine-security/.../oauth/ScopeRoleJwtAuthoritiesConverter` | `scope` → role via `.scopes`; **must gain the membership check** (§6.4) |
+
+---
+
+## 8. What this changes in the AWS architecture
+
+Everything in the as-is document's data, compute, storage and cell design **stands unchanged**: schema-per-tenant on Aurora, ECS Fargate, one instance per cell, wildcard subdomains, S3-backed CMS, connection count as the cell-sizing signal. The deltas are all in identity and the control plane.
+
+**The control plane grows into the authority for the membership graph.** It owns tenant ↔ user ↔ roles (DynamoDB is the natural fit), and it is what the pre-token Lambda reads. It also owns the mirror of `.roles` artefacts, so it can validate that a role being assigned actually exists in the target tenant's application.
+
+**Onboarding a tenant additionally provisions a Cognito app client.**
+
+```
+1. control plane: allocate cell, reserve subdomain, write tenant → cell
+2. Cognito:       create app client "<subdomain>" with callback
+                  https://<subdomain>.app.example.com/login/oauth2/code/<subdomain>
+                  (+ attach federated IdPs later, per tenant)
+3. Route 53:      CNAME <subdomain>.app.example.com → cell ALB
+4. cell:          POST /services/security/tenants  { name, subdomain }   → INITIAL
+5. cell:          register the OAuth client (or derive it — §6.7)
+6. control plane: write the first membership row (tenant admin) — no local user is created
+7. wait for provisioning: CREATE USER + CREATE SCHEMA + synchronizer pass → PROVISIONED
+```
+
+Step 6 replaces the old `POST /services/security/users`. **Nothing writes a user row into the platform database.**
+
+**Adding a person to a second tenant** is one control-plane write plus, at most, a token refresh. No DNS, no infrastructure, no platform call. That is the payoff.
+
+**Offboarding gets simpler and safer.** Revoking membership is a control-plane delete, and it takes effect on the next token refresh (or immediately via a global sign-out). The tenant-deletion runbook still has to drop the schema, the DB user, the datasource row and restart the cell — but it no longer has to hunt down user rows and role assignments across the platform DB.
+
+**The tenant switcher becomes possible.** `dirigible:tenants` gives the UI the membership list, so the shell can offer "switch to Globex" as a link to the other subdomain. The Harmonia application shell (`components/resources/resources-application`) is the natural place for it.
+
+---
+
+## 9. Multi-tenancy security review
+
+### 9.1 Closed by construction
+
+- **The cross-tenant admin gap.** `TenantEndpoint` and `UsersEndpoint` do not tenant-scope reads: `getAll()` returns every user of every tenant, and `createUser` / `updateUser` accept an arbitrary `tenant` id, so an `ADMINISTRATOR` in *any* tenant can enumerate and modify *every* tenant's users. Removing the local user directory removes the surface. (`RepositoryEndpoint`'s unrestricted `/{*path}` CRUD is the same class of problem and is **not** closed by this change — it needs its own fix.)
+- **Tenant DB passwords in the platform DB.** Still stored in `DIRIGIBLE_DATA_SOURCES`, but the platform no longer *also* holds every user's password hash.
+- **Duplicate user administration.** One membership graph instead of N per-tenant directories.
+
+### 9.2 Must be closed deliberately
+
+| Item | Where |
+| --- | --- |
+| M2M tokens bypass the tenant membership check | §6.4 |
+| `@RolesAllowed` possibly inert outside the basic profile | §6.1 |
+| `DIRIGIBLE_TRIAL_ENABLED` grants all roles, tenant-blind | §6.9 |
+| Client-registration secrets readable cross-tenant | §6.7 |
+| `RepositoryEndpoint` `/{*path}` CRUD, no tenant scoping, no ownership check | not addressed here |
+| ttyd (9000), Graalium inspector (8081), SFTP (8022) with `admin`/`admin`, actuator `include=*` | as-is document §3.6 — unchanged |
+
+### 9.3 Explicitly left open (out of scope per the runtime-only decision)
+
+Production is runtime-only and authoring runs on a single instance per environment, so these cannot occur in production — but they are real, they exist today, and they must be recorded:
+
+- **`/users/<user>/<workspace>` is keyed by bare username, hardcoded five times independently**: `ide-workspace/.../WorkspaceService.generateWorkspacePath`, `ide-workspace/.../PublisherService.generateWorkspacePath`, `ide-git/.../GitFileUtils` (with a **duplicate** of the git-root logic in `commons-helpers/.../FileSystemUtils`), `ide-java-lsp/.../JdtLsManager.workspaceRoot()`, and `ide-java-debug/.../JavaDebugManager`. The two `IRepositoryStructure.PATTERN_USERS_WORKSPACE_DEFAULT` / `_NAMED` constants that ought to be the single definition are **dead code** — the only references to them are in the interface that declares them. (`GitFileUtils.PATTERN_USERS_WORKSPACE` is a separate, similarly-named constant that *is* used — by `GitFileUtils` and `CloneCommand` — which is precisely the duplication.) So there is no single place to change.
+- **`GitFileUtils.USER_WORKSPACE_SEGMENTS_COUNT = 3` / `USER_WORKSPACE_PROJECT_SEGMENTS_COUNT = 4`** (lines 53, 56). Inserting a tenant path segment makes these off by one, and the failure mode is **silent file mangling in `ShareCommand`**, not an exception. This is the easiest thing on the list to miss.
+- **The ttyd terminal proxies every user of every tenant to one shared shell** (`ws://localhost:9000/ws`), with no per-user or per-tenant working directory.
+- **`Problem.createdBy` has no tenant column**, and `ProblemEndpoint`'s `deleteAll` / `deleteAllByStatus` / `deleteAllByIds` are global un-scoped mass deletes in the shared `SystemDB`.
+- **`AuditorAwareHandler.getCurrentAuditor()` returns the literal `"SYSTEM"`** with a `// TODO`. So `Artefact.createdBy` is not a username today — but "fixing" it with `UserFacade.getName()` would instantly create the ambiguity across ~35 tables.
+- **`HanaConnectionEnhancer`** sets `APPLICATIONUSER` / `XS_APPLICATIONUSER` to a bare username, so two same-named users in different tenants are indistinguishable to HANA-side row-level security and auditing.
+- **`TaskServiceImpl.getTasks()` is tenant-filtered but not user-filtered**, while `sdk/bpm/Tasks.list()`'s Javadoc claims "the platform pre-filters by candidate user / group." The Javadoc is wrong; the method returns every task in the tenant. An intra-tenant leak, not a cross-tenant one.
+
+BPM is worth a note on the positive side: `TaskServiceImpl.prepareQuery` applies `taskTenantId(getTenantId())` **and** `taskAssignee(UserFacade.getName())` — the one place in the codebase that combines tenant and user correctly. Under the new model its semantics become "my tasks in the tenant I am currently in," which is almost certainly the desired reading, but it should be confirmed rather than inherited by accident. Note also that a `.bpmn` with a design-time `assignee="admin"` deploys into every tenant via `BpmnSynchronizer` and resolves to a different person in each.
+
+---
+
+## 10. Verification and first steps
+
+The cheapest possible first move costs nothing and settles the most important ambiguity:
+
+1. **Write a failing integration test** asserting that `admin` in tenant A and `admin` in tenant B get distinct workspaces and cannot see each other's data. None of the existing multitenancy ITs (`EnabledMultitenantModeIT`, `TenantDeterminationIT`, `MultitenancyIT`, `MultitenancyHarmoniaIT`, `BpmnMultitenancyIT`) exercises a same-username-in-two-tenants scenario, which is why the §9.3 collisions have gone unnoticed.
+2. **Pin down whether `@RolesAllowed` is enforced under the cognito profile** (§6.1). Boot with `spring_profiles_active=cognito` and call a `@RolesAllowed`-only endpoint with a token holding no matching group. This gates the rest of the design.
+3. **Probe the cross-subdomain session replay** — authenticate on `t1.localhost`, replay `JSESSIONID` against `t2.localhost` under the basic profile, and see whether t1's authorities are honoured in t2's tenant context.
+
+Four findings in this document are **hypotheses, not confirmed facts**, and are not asserted anywhere else:
+
+- That all 52 `@RolesAllowed` are inert outside the basic profile (§6.1) — the wiring reads that way; not executed.
+- Whether HTTP Basic re-invokes `loadUserByUsername` per request in this configuration, or restores a session context. No `SecurityContextRepository` is configured explicitly and `formLogin` is also enabled, so a `JSESSIONID` normally exists.
+- Whether the cross-subdomain session replay above is actually exploitable.
+- Whether `Role.name` global uniqueness is enforced anywhere, or merely implied by single-result queries.
+
+AWS-side items to confirm in your own account:
+
+- The **Essentials or Plus** feature plan requirement for pre-token-generation trigger V2_0/V3_0, and its MAU pricing impact.
+- **App clients per user pool** — 1,000 default, 10,000 maximum — as the tenants-per-pool ceiling; and **identity providers per user pool** (300 / 1,000) as the federated-tenant ceiling.
+- **Federated-user session-cookie behaviour.** AWS's cross-app-client SSO statement is worded for *local* users; a user who signs in through an external IdP has their session at that IdP, so cross-tenant navigation may behave differently. Test it before promising seamless switching to federated tenants.
+- Cognito pricing at your expected MAU, including the separate M2M pricing for V3_0.
+- The **"total combined changes in pre token generation Lambda trigger"** quota (5,000 claims + scopes per transaction) — not a practical constraint here, but worth knowing it exists.
+
+---
+
+## 11. References
+
+### In-repo
+
+| Concern | Path |
+| --- | --- |
+| Multitenancy behaviour reference | [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md) |
+| As-is AWS deployment analysis | [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md) |
+| The identity model and its constraint | `components/core/core-tenants/.../domain/User.java`, `domain/UserRoleAssignment.java` |
+| The seam where the tenant is discarded | `components/core/core-tenants/.../security/CustomUserDetailsService.java` |
+| Basic auth chain + the only `jsr250Enabled` | `components/core/core-tenants/.../security/BasicSecurityConfig.java` |
+| Cognito chain, authority mapper, membership filter, login controller | `components/security/security-cognito/` |
+| Keycloak equivalents (byte-identical filter) | `components/security/security-keycloak/` |
+| Per-tenant OAuth client registrations | `components/security/security-client-registration/` |
+| M2M scope → role | `components/engine/engine-security/.../oauth/ScopeRoleJwtAuthoritiesConverter.java` |
+| Authority string format (single choke point) | `components/core/core-base/.../util/AuthoritiesUtil.java` |
+| URL-pattern enforcement + unused SPI seam | `components/core/core-base/.../http/access/HttpSecurityURIConfigurator.java`, `CustomSecurityConfigurator.java` |
+| Role check bottom of stack + unused SPI seam | `components/core/core-base/.../http/access/UserRequestVerifier.java`, `UserAccessVerifier.java` |
+| `.access` model, cache and filter | `components/engine/engine-security/.../domain/Access.java`, `verifier/AccessVerifier.java`, `filter/SecurityFilter.java` |
+| Current-user API (no tenant) | `components/api/api-security/.../UserFacade.java`, `api-modules-javascript/.../modules/src/security/user.ts` |
+| The client-Java isolation gap | `components/engine/engine-java/.../runtime/JavaCompiledOutputDirectory.java` |
+| Audit stub | `components/core/core-base/.../artefact/AuditorAwareHandler.java` |
+| The one correct tenant+user pattern | `components/engine/engine-bpm-flowable/.../config/TaskServiceImpl.java` |
+
+### AWS documentation
+
+- [Multi-tenant application best practices](https://docs.aws.amazon.com/cognito/latest/developerguide/multi-tenant-application-best-practices.html) — the shared-pool advantages and the cross-app-client session cookie.
+- [User-pool multi-tenancy](https://docs.aws.amazon.com/cognito/latest/developerguide/bp_user-pool-based-multi-tenancy.html), [app-client](https://docs.aws.amazon.com/cognito/latest/developerguide/application-client-based-multi-tenancy.html), [user group](https://docs.aws.amazon.com/cognito/latest/developerguide/group-based-multi-tenancy.html), [custom attribute](https://docs.aws.amazon.com/cognito/latest/developerguide/custom-attribute-based-multi-tenancy.html), [custom scope](https://docs.aws.amazon.com/cognito/latest/developerguide/scope-based-multi-tenancy.html) — the five models and their trade-offs.
+- [Pre token generation Lambda trigger](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html) — trigger versions, feature-plan requirements, the modifiable-claims table, `groupsToOverride`.
+- [Quotas in Amazon Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/limits.html) — app clients per pool, groups per user, identity providers per pool, token validity.
+- [Multi-tenancy security recommendations](https://docs.aws.amazon.com/cognito/latest/developerguide/multi-tenancy-security-recommendations.html)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,15 @@ User projects can declare a `*.nativeapp` JSON file that turns an external web s
 
 **Detailed guide:** [`components/engine/engine-native-apps/CLAUDE.md`](components/engine/engine-native-apps/CLAUDE.md). Read it before changing anything under that module — it covers the synchronizer model, kinds + start modes, port resolution, the stop / teardown contract (three layered guarantees), the dual-DELETE rehydrate requirement, PID + port logging, the proxy filter chain, placeholder expansion, the credentials field naming, the management endpoint's role policy, integration-test patterns including the no-manual-cleanup rule, and the macOS gotchas (Python 3.14 bind regression, wildcard-vs-loopback `ServerSocket` probe, `PollingWatchService` deadlock).
 
-## Tenant-aware configuration (`commons-config` + `core-configurations`)
+## Multitenancy (`core-tenants` + `core-base/tenant` + `data-sources`)
+
+Shared application instance, shared `SystemDB`, **schema + dedicated DB user per tenant** for application data, shared on-disk repository. Requests map to a tenant by **subdomain** (`DIRIGIBLE_TENANT_SUBDOMAIN_REGEX`); the tenant travels in a `ThreadLocal` (`TenantContext`). The isolation mechanism is a **datasource-name rewrite** (`TenantDataSourceNameManager`: `DefaultDB` → `<tenantId>_DefaultDB`), not a routing DataSource — so outside a tenant scope you silently get the *default* tenant's datasource.
+
+**Detailed guide:** [`components/core/core-tenants/CLAUDE.md`](components/core/core-tenants/CLAUDE.md). Read it before touching tenant resolution, provisioning, the tenant-aware datasource routing, or before adding an artefact type that should be per-tenant. It covers the resolution algorithm and its caching gotchas, the `TenantContext` scope API and the thread-hand-off rule, the naming indirection + one-Hikari-pool-per-tenant model (pool sizing is **hardcoded**, overriding `<DS>_HIKARI_*`), provisioning (two states only, non-idempotent retry, no de-provisioning, the required `CREATE ROLE`/`CREATE SCHEMA` privileges), the per-tenant replay in `BaseSynchronizer` and which eight synchronizers opt in, the Cognito/Keycloak `custom:tenant` filters and the per-tenant OAuth client-registration design, the cross-tenant admin authorization gap, the config-key table, the multi-node/clustering status (why the app is effectively single-writer), the executable-spec ITs, and the footguns.
+
+**Deployment:** [`AWS_MULTITENANCY_RESEARCH.md`](AWS_MULTITENANCY_RESEARCH.md) — a production AWS architecture built on this model (schema-per-tenant on Aurora, ECS Fargate, wildcard subdomains, Cognito single user pool, cell-based scale-out). Research note, nothing implemented.
+
+### Tenant-aware configuration (`commons-config` + `core-configurations`)
 
 Each tenant can override selected configuration values; overrides are resolved **per request**, scoped to the current tenant. Added on PR [#6205](https://github.com/eclipse-dirigible/dirigible/pull/6205).
 

--- a/components/core/core-tenants/CLAUDE.md
+++ b/components/core/core-tenants/CLAUDE.md
@@ -4,7 +4,7 @@ The authoritative in-repo description of **how multitenancy actually works**. Mu
 
 Read this before touching tenant resolution, provisioning, the tenant-aware datasource routing, or before adding a new artefact type that should be per-tenant.
 
-> The user-facing announcement is the March 2024 blog ["Multitenant applications with zero effort"](https://www.dirigible.io/blogs/2024/03/26/multitenancy). It is still directionally correct but has drifted — see [Where the blog is out of date](#where-the-blog-is-out-of-date). For an AWS deployment architecture built on this model, see [`AWS_MULTITENANCY_RESEARCH.md`](../../../AWS_MULTITENANCY_RESEARCH.md) at the repo root.
+> The user-facing announcement is the March 2024 blog ["Multitenant applications with zero effort"](https://www.dirigible.io/blogs/2024/03/26/multitenancy). It is still directionally correct but has drifted — see [Where the blog is out of date](#where-the-blog-is-out-of-date). For an AWS deployment architecture built on this model, see [`AWS_MULTITENANCY_RESEARCH.md`](../../../AWS_MULTITENANCY_RESEARCH.md) at the repo root; for a proposed **replacement** of the identity half of this model (cross-tenant login, identity and roles from the IdP token rather than `DIRIGIBLE_USERS`), see [`AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`](../../../AWS_MULTITENANCY_TARGET_ARCHITECTURE.md). This file describes what the code does **now**.
 
 ## The model in one paragraph
 

--- a/components/core/core-tenants/CLAUDE.md
+++ b/components/core/core-tenants/CLAUDE.md
@@ -1,0 +1,416 @@
+# CLAUDE.md — components/core/core-tenants (multitenancy reference)
+
+The authoritative in-repo description of **how multitenancy actually works**. Multitenancy is not confined to this module — it is a contract between `core-base` (the SPI), `core-tenants` (resolution, entity, provisioning, users), `data-sources` (the isolation mechanism), `core-configurations` (per-tenant config) and a handful of engines that tenant-scope their own runtime names. This file covers all of it, because the pieces are only comprehensible together.
+
+Read this before touching tenant resolution, provisioning, the tenant-aware datasource routing, or before adding a new artefact type that should be per-tenant.
+
+> The user-facing announcement is the March 2024 blog ["Multitenant applications with zero effort"](https://www.dirigible.io/blogs/2024/03/26/multitenancy). It is still directionally correct but has drifted — see [Where the blog is out of date](#where-the-blog-is-out-of-date). For an AWS deployment architecture built on this model, see [`AWS_MULTITENANCY_RESEARCH.md`](../../../AWS_MULTITENANCY_RESEARCH.md) at the repo root.
+
+## The model in one paragraph
+
+A **shared application instance** serves all tenants. The platform's own tables live in a **shared `SystemDB`** with no tenant partitioning (except a discriminator column on users). Application data is isolated by **one schema plus one dedicated DB user per tenant**, all inside the same physical database as `DefaultDB`. The on-disk repository — registry *and* IDE workspaces — is **shared, not tenant-namespaced**. Documents (CMS), Quartz job names, JMS destination names and Flowable process instances are tenant-scoped by naming/discriminator conventions. Requests are mapped to a tenant by **subdomain**, and the tenant is carried through the call in a `ThreadLocal`.
+
+There is no discriminator column on application data, and no database-per-tenant.
+
+## Architecture
+
+```
+HTTP request
+  │  Host: acme.app.example.com
+  ▼
+TenantContextInitFilter                       core-tenants/tenant/
+  │  ├── TenantExtractor.determineTenantSubdomain(request)
+  │  │     ├── multi-tenant mode off ─────────────────► default tenant
+  │  │     ├── regex no match on host/x-forwarded-host ► default tenant
+  │  │     ├── subdomain found in DIRIGIBLE_TENANTS ──► that tenant  (Caffeine cached)
+  │  │     └── subdomain unknown ─────────────────────► Optional.empty() ► HTTP 404
+  │  └── tenantContext.execute(tenant, () -> chain.doFilter(...))
+  ▼
+TenantContextImpl                     ThreadLocal<Tenant> currentTenantHolder
+  │
+  ├─► security: CustomUserDetailsService.loadUserByUsername
+  │        findUserByUsernameAndTenantId(username, currentTenant.getId())
+  │
+  ├─► TenantConfigurationInitFilter  (core-configurations, @Order(LOWEST_PRECEDENCE))
+  │        Configuration.setThreadConfiguration(allow-listed per-tenant values)
+  │
+  └─► data:  DataSourcesManager.getDefaultDataSource()
+                 └── TenantDataSourceNameManager.getTenantDataSourceName("DefaultDB")
+                         └── "<tenantId>_DefaultDB"   (non-default tenants only)
+                                 └── DataSourceInitializer → dedicated Hikari pool,
+                                     HikariConfig.setSchema(<TENANT_ID>)
+```
+
+## 1. Tenant resolution
+
+`tenant/TenantExtractor.java`:
+
+```java
+private static final List<String> HOST_HEADERS = List.of("host", "x-forwarded-host");
+private static final Pattern TENANT_SUBDOMAIN_PATTERN =
+        Pattern.compile(DirigibleConfig.TENANT_SUBDOMAIN_REGEX.getStringValue());
+public static final Cache<String, Optional<Tenant>> TENANT_CACHE = Caffeine.newBuilder()
+        .expireAfterWrite(10, TimeUnit.MINUTES).maximumSize(100).build();
+
+public Optional<Tenant> determineTenantSubdomain(HttpServletRequest request)
+```
+
+- Both `host` **and** `x-forwarded-host` are tried; the first that resolves wins. This is what makes the app work behind a reverse proxy / load balancer without extra configuration.
+- Default regex `^([^\.]+)\..+$` — capture group 1 is the subdomain. Configurable via `DIRIGIBLE_TENANT_SUBDOMAIN_REGEX`.
+- **No regex match falls back to the default tenant.** `Host: localhost` and a bare IP both resolve to default. This is deliberate (local dev, health probes) and is covered by `EnabledMultitenantModeIT` / `TenantDeterminationIT`.
+- **A match with no matching tenant row is HTTP 404**, not a fallback: `"There is no registered tenant for the current host"`.
+- `TenantImpl` hard-codes the default tenant: id and name `default-tenant`, subdomain `default`. `DefaultTenantInitializer` persists a row for it with status `PROVISIONED`, so `default.localhost` also resolves through the DB path.
+
+### Cache gotchas
+
+`TENANT_CACHE` is **static, per-JVM**, and it caches `Optional.empty()` — a 404 for an unknown subdomain therefore sticks for up to ten minutes. `TenantService` mutates it on write (`save` puts, `delete` invalidates), but only in the local JVM. `maximumSize(100)` also means the cache stops being useful past ~100 tenants.
+
+### Filter wiring
+
+`TenantContextInitFilter extends OncePerRequestFilter`, `@Component`, `shouldNotFilter` skips `/webjars/`, `/css/`, `/js/`, `*.ico`.
+
+It is explicitly `addFilterBefore(...)`-ed into every security chain, because **authentication itself needs the tenant scope** — `CustomUserDetailsService` calls `getCurrentTenant()` unguarded and throws outside a scope:
+
+- `core-tenants/security/BasicSecurityConfig` — before `UsernamePasswordAuthenticationFilter`
+- `security-keycloak/KeycloakSecurityConfiguration` — before `OAuth2LoginAuthenticationFilter`
+- `security-snowflake/SnowflakeSecurityConfig`
+
+Because it is also a plain `@Component`, Spring Boot auto-registers it in the raw servlet filter chain as well. `OncePerRequestFilter` makes the second invocation a no-op, so behaviour is correct — but the effective outer-chain ordering is a side effect of that double registration rather than an explicit design. Don't rely on it; if you need ordering guarantees, make them explicit.
+
+## 2. The tenant scope API
+
+`core-base/tenant/TenantContext.java`:
+
+```java
+<Result, Exc extends Throwable> Result execute(Tenant tenant, CallableResultAndException<Result, Exc> callable) throws Exc;
+<Result, Exc extends Throwable> Result execute(String tenantId, CallableResultAndException<Result, Exc> callable)
+        throws TenantNotFoundException, Exc;
+<Result, Exc extends Throwable> List<TenantResult<Result>> executeForEachTenant(
+        CallableResultAndException<Result, Exc> callable) throws Exc;
+boolean isNotInitialized();
+Tenant getCurrentTenant();     // throws IllegalStateException outside a scope
+```
+
+- `execute` saves and restores the previous tenant, so it nests correctly (including restoring `null`).
+- `getCurrentTenant()` **throws** `IllegalStateException("Attempting to get current tenant but it is not initialized yet.")` outside a scope. That is why `isNotInitialized()` guards appear all over the codebase.
+- `executeForEachTenant` iterates `tenantService.findByStatus(PROVISIONED)` **plus** the default tenant, hitting the DB on every call (no caching).
+- The tenant is a **plain `ThreadLocal`, not inheritable.** Any thread hand-off must re-establish it explicitly. `JobHandler`, `AsynchronousMessageListener` and `ListenerClassConsumer` do exactly that — follow their pattern for any new async entry point.
+- `Tenant extends Serializable` specifically so it can be stuffed into a Quartz `JobDataMap` (`JobHandler.TENANT_PARAMETER = "tenant-id"`).
+- Logging: `core-base/logging/TenantConverter.java` renders the current tenant id into every log line, or the literal `background` when no scope is active. This makes per-tenant log filtering free — don't reinvent it.
+
+## 3. The isolation mechanism — a naming indirection
+
+**This is the single most important thing to understand.** There is no routing DataSource, no `SET SCHEMA` per request, no discriminator column. Isolation is a *name rewrite*.
+
+`components/data/data-sources/.../manager/TenantDataSourceNameManager.java`:
+
+```java
+public String getTenantDataSourceName(String dataSourceName) {
+    if (isSystemDataSource(dataSourceName) || tenantContext.isNotInitialized()) { return dataSourceName; }
+    Tenant tenant = tenantContext.getCurrentTenant();
+    return createName(tenant, dataSourceName);
+}
+public String createName(Tenant tenant, String dataSourceName) {
+    if (isTenantDataSourceName(tenant, dataSourceName)) { return dataSourceName; }
+    return tenant != null && !tenant.isDefault() ? tenant.getId() + "_" + dataSourceName : dataSourceName;
+}
+```
+
+`DataSourcesManager.getDataSourceDefinition(name)` runs every lookup through it, so `getDefaultDataSource()` inside a tenant scope transparently returns `<tenantId>_DefaultDB`.
+
+Consequences, all load-bearing:
+
+- **`SystemDB` is never prefixed** → shared by all tenants.
+- **The default tenant is never prefixed** → its data lives in the connecting JDBC user's default schema.
+- **Outside a tenant scope you silently get the default tenant's datasource.** Forgetting a `TenantContext.execute(...)` wrapper on a background thread does not fail — it writes to the default tenant. This is the most common way to introduce a data-leak bug in this codebase.
+- **Custom datasources are asymmetric.** `CustomDataSourcesService` registers `DIRIGIBLE_DATABASE_CUSTOM_DATASOURCES` entries *unprefixed*, but `getDataSourceDefinition` *will* prefix the lookup inside a tenant scope. So a custom datasource `FOO` is looked up as `<tenantId>_FOO` for non-default tenants and is not found unless a tenant-specific row exists. The blog documents the `{TENANT_ID}_MyDB` convention as the intended workaround. Treat this as sharp-edged rather than designed.
+
+### Connection pools: one per (JVM, tenant)
+
+`data-sources/.../manager/DataSourceInitializer.java`:
+
+```java
+Properties hikariProperties = getHikariProperties(name);      // <NAME>_HIKARI_* env overrides
+HikariConfig config = new HikariConfig(hikariProperties);
+...
+config.setSchema(schema);
+config.setPoolName(name);
+config.setMaximumPoolSize(20);
+config.setMinimumIdle(10);
+config.setIdleTimeout(TimeUnit.MINUTES.toMillis(3));
+config.setMaxLifetime(TimeUnit.MINUTES.toMillis(Configuration.getAsInt(name + "_MAX_LIFETIME_MINUTES", 15)));
+config.setConnectionTimeout(TimeUnit.SECONDS.toMillis(15));
+```
+
+**The explicit setters run *after* the `HikariConfig(Properties)` constructor, so `setMaximumPoolSize(20)` / `setMinimumIdle(10)` override any `<NAME>_HIKARI_maximumPoolSize` you set. Pool sizing is effectively hardcoded.** Only `_MAX_LIFETIME_MINUTES` and `_LEAK_DETECTION_THRESHOLD_MINUTES` are tunable per datasource.
+
+Each pool also gets a dedicated `JdbcTransactionManager` **registered as a runtime Spring singleton** (`transactionManager_<name>`), and the datasource itself as a bean named `<name>`. So N tenants ⇒ N pools ⇒ up to `N × 20` connections with `N × 10` held idle, plus `2N` dynamically registered singletons. Pools are created **lazily**, on the tenant's first request. This is the platform's dominant scaling limit — see the AWS research doc for the arithmetic.
+
+Schema pinning is `HikariConfig.setSchema` → JDBC `Connection.setSchema` on each new physical connection (on PostgreSQL, pgjdbc emits `SET search_path`). No per-request `SET` is issued. `DirigibleConnectionImpl.setSchema` exists but is only used ad hoc by CSVIM and data transfer/export.
+
+### Hibernate's multi-tenancy in `data-store` is decorative
+
+`components/data/data-store/.../config/MultiTenantConnectionProviderImpl.java`:
+
+```java
+@Override
+public Connection getConnection(String tenantIdentifier) throws SQLException {
+    return this.datasourcesManager.getDefaultDataSource().getConnection();   // tenantIdentifier IGNORED
+}
+```
+
+The identifier is discarded; isolation already happened inside `getDefaultDataSource()`. `CurrentTenantIdentifierResolverImpl` returns the current tenant id or the string literal `"default-tenant"` (duplicated rather than referencing `TenantImpl`). Don't "fix" this by wiring the identifier through — it would double-apply the isolation.
+
+## 4. What is shared vs isolated
+
+| Concern | Isolation | Where |
+| --- | --- | --- |
+| Application tables / views / data | **Schema + DB user per tenant** | `DefaultDataSourceProvisioning` |
+| Platform tables (tenants, roles, artefacts, `Definition` checksums, Quartz, ActiveMQ store, Flowable) | **Shared, unpartitioned** `SystemDB` | `core-database/DataSourceSystemConfig` |
+| Users | Discriminator column, shared DB. `DIRIGIBLE_USERS` unique on `(USER_TENANT_ID, USER_USERNAME)`; `updateKey()` appends the tenant id | `domain/User.java` |
+| Role *definitions* | **Global.** `DIRIGIBLE_SECURITY_ROLES` has no tenant column; `.roles` artefacts synchronize single-tenant | `engine-security/domain/Role.java` |
+| Role *assignments* | Tenant-scoped transitively through the user; `DIRIGIBLE_USER_ROLE_ASSIGNMENTS` has no tenant column of its own | `domain/UserRoleAssignment.java` |
+| Registry `/registry/public` | **Shared.** One copy | `core-repository/RepositoryConfig` |
+| IDE workspaces `/users/<user>/…` | Keyed by **user**, not tenant — same-named users in different tenants collide on disk | `IRepositoryStructure` |
+| Per-tenant configuration | `DIRIGIBLE_CONFIGURATIONS` table **inside each tenant schema** | `core-configurations/tenant/` |
+| Documents / CMS | Path-prefixed `<tenantId>/…` | `engine-cms/TenantPathResolver`, `engine-cms-internal/CmsProviderInternalFactory` (appends the tenant id to its root folder) |
+| Quartz jobs | `<tenantId>###<jobName>` | `engine-jobs/tenant/JobNameCreator` |
+| JMS queues / topics | `<tenantId>###<destination>` | `engine-listeners/service/DestinationNameManager` |
+| BPMN | Single Flowable engine, Flowable's native `tenantId` discriminator threaded into every query/deployment/start | `engine-bpm-flowable/config/BpmProviderFlowable` |
+
+## 5. Provisioning
+
+### Entity and lifecycle
+
+`domain/Tenant.java` — `@Table(name = "DIRIGIBLE_TENANTS")`, `extends Artefact`, `String id` (caller-assigned UUID), `TENANT_SUBDOMAIN` unique, `TENANT_STATUS` enumerated as a string.
+
+```java
+public enum TenantStatus { INITIAL, PROVISIONED }
+```
+
+**There is no `PROVISIONING` and no `FAILED` state.** A failure logs `"Failed to provision tenant [{}]. Continue with the next one."` and leaves the row at `INITIAL`, so the next tick retries from scratch.
+
+### Triggers
+
+Two, both calling the same `synchronized void provision()`:
+
+| Trigger | File | Timing |
+| --- | --- | --- |
+| Startup | `provisioning/TenantsInitializer.java` | `ApplicationListener<ApplicationReadyEvent>`, `@Order(TENANTS_INITIALIZER)` = 1000, i.e. last (orders live in `core-base/ApplicationListenersOrder.java`). Schedules on a private `ScheduledThreadPoolExecutor(1)` with a hard-coded **30 s** delay |
+| Periodic | `provisioning/TenantProvisioningJob.java` | Clustered Quartz `SystemJob`, `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` (**default 900**), `withMisfireHandlingInstructionNextWithExistingCount()` |
+
+### The flow
+
+`provisioning/TenantsProvisioner.java`:
+
+```java
+synchronized void provision() {
+    Set<Tenant> tenants = tenantService.findByStatus(TenantStatus.INITIAL);
+    tenants.forEach(this::provisionTenant);
+    if (!tenants.isEmpty()) { postProvisioningSteps.forEach(this::callPostProvisioningStep); }
+}
+```
+
+Steps are injected as **unordered** `Set<TenantProvisioningStep>` / `Set<TenantPostProvisioningStep>`. Harmless with one of each today; adding a second introduces non-deterministic ordering. If you add a step that depends on another, add explicit ordering rather than relying on set iteration.
+
+### The only provisioning step
+
+`components/data/data-sources/.../provisioning/DefaultDataSourceProvisioning.java` — skipped entirely for the default tenant:
+
+1. `CREATE USER <random UUID>` with a generated 20-char password.
+2. `CREATE SCHEMA <tenant.getId().toUpperCase()> AUTHORIZATION <that user>`.
+3. MSSQL only: `ALTER USER … WITH DEFAULT_SCHEMA` plus `GRANT CREATE TABLE/VIEW/PROCEDURE/TYPE`.
+4. Clone the `DefaultDB` definition (same driver, same JDBC URL, copied properties), override username/password/schema, persist as `<tenantId>_DefaultDB` with `location = "TENANT_DEFAULT"`, `createdBy = "TENANT_PROVISIONING_JOB"`.
+
+**The connecting `DefaultDB` credential therefore needs `CREATE ROLE` / `CREATE SCHEMA` privileges.** Without them, provisioning fails silently into the `INITIAL` retry loop.
+
+**No users and no roles are created.** A freshly provisioned tenant has *no admin user*; one must be created explicitly via `POST /services/security/users`. `AdminUserInitializer` creates the `DIRIGIBLE_BASIC_USERNAME` admin **only in the default tenant**.
+
+### The only post-provisioning step
+
+`core-initializers/.../synchronizer/tenants/RetriggerSynchronizersTenantPostProvisioningStep.java`:
+
+```java
+definitionService.updateChecksums(StringUtils.EMPTY, multitenantArtifactTypes);  // force MODIFIED
+synchronizationProcessor.forceProcessSynchronizers();
+```
+
+It blanks the stored checksums of every artefact type whose synchronizer reports `multitenantExecution() == true`, then forces a full pass — which is how the new schema gets its tables, views, CSVIM data, jobs and BPMN deployments.
+
+### Known gaps
+
+- **Retry is not idempotent.** Every attempt creates a *new* random DB user and a `CREATE SCHEMA`. A partial failure retried later leaves orphaned users/schemas behind.
+- **Two nodes booting together can double-provision.** `provision()` is only `synchronized` (intra-JVM); `findByStatus(INITIAL)` → provision → `save(PROVISIONED)` is not under a DB lock or a single transaction. The *periodic* path is safe because clustered Quartz fires it on one node; the *startup* path runs on every node.
+- **There is no de-provisioning.** `TenantEndpoint` refuses to delete anything not `INITIAL` (`"Deletion of already provisioned tenants is currently not supported"`). Nothing drops the schema, the DB user, the `DIRIGIBLE_DATA_SOURCES` row or the live pool — and `DataSourceInitializer.DATASOURCES` has no external removal path, so a stale pool survives until restart.
+
+## 6. Per-tenant synchronizer replay
+
+`core-base/synchronizer/MultitenantBaseSynchronizer.java` is three lines:
+
+```java
+@Override public boolean multitenantExecution() { return true; }
+@Override protected boolean isMultitenantArtefact(A artefact) { return true; }
+```
+
+The behaviour is in `BaseSynchronizer.completeInternal` / `cleanupInternal`:
+
+```java
+if (!multitenantExecution() || !isMultitenantArtefact(artefact)) { return completeImpl(wrapper, flow); }
+List<TenantResult<Boolean>> results = tenantContext.executeForEachTenant(() -> {
+    artefact.setLifecycle(lifecycle);      // reset — completeImpl mutates and persists it
+    return completeImpl(wrapper, flow);
+});
+return results.stream().map(TenantResult::getResult).allMatch(Boolean.TRUE::equals);
+```
+
+So: **the artefact file is read once from the shared registry, but `completeImpl` — the side-effecting part (DDL, CSV import, Quartz scheduling, BPMN deployment) — is replayed once per provisioned tenant plus the default.** The single `Artefact` row in `SystemDB` is re-saved on every iteration; note the explicit `setLifecycle(lifecycle)` reset. The row is effectively "last tenant wins" and records **no per-tenant state**.
+
+Exactly eight synchronizers are multitenant:
+
+| Synchronizer | Module |
+| --- | --- |
+| `TablesSynchronizer`, `ViewsSynchronizer`, `SchemasSynchronizer` | `data-structures` |
+| `CsvimSynchronizer` | `data-csvim` |
+| `JobSynchronizer` | `engine-jobs` |
+| `BpmnSynchronizer` | `engine-bpm-flowable` |
+| `ListenerSynchronizer` | `engine-listeners` |
+| `CmsSeedSynchronizer` | `engine-document` |
+
+Everything else is **global**: datasources, access, expose, extension points/extensions, roles, markdown, proxy, web/JS, Java, Camel, OData, websockets. In particular `DataSourcesSynchronizer extends BaseSynchronizer` — a user-authored `.datasource` is registered once, globally.
+
+The one conditional override, in `CsvimSynchronizer`:
+
+```java
+@Override protected boolean isMultitenantArtefact(Csvim csvim) {
+    return !Objects.equals(systemDataSourceName, csvim.getDatasource());
+}
+```
+
+**When adding a new artefact type**, decide deliberately whether it is per-tenant, and extend `MultitenantBaseSynchronizer` if so. If its side effects register a runtime name (a scheduler key, a destination, an endpoint), that name must be tenant-qualified too — follow `JobNameCreator` / `DestinationNameManager`.
+
+## 7. Security and users
+
+- `security/CustomUserDetailsService.java` — login is tenant-scoped:
+
+  ```java
+  Tenant tenant = tenantContext.getCurrentTenant();
+  User user = userService.findUserByUsernameAndTenantId(username, tenant.getId())
+      .orElseThrow(() -> new UsernameNotFoundException("Username [" + username + "] was not found in tenant [" + tenant + "]."));
+  ```
+
+  `getCurrentTenant()` is unguarded, which is why the tenant filter must run before the auth filters.
+- `init/DefaultTenantInitializer.java` — `@Order(DEFAULT_TENANT_INITIALIZER)` = 20, idempotently persists the default tenant as `PROVISIONED`, `location = "-"`.
+- `init/AdminUserInitializer.java` — `@ConditionalOnProperty("basic.enabled")`, `@Order(ADMIN_USER_INITIALIZER)` = 30. Default tenant only; assigns **every** `Roles` enum value; credentials from `DIRIGIBLE_BASIC_USERNAME` / `_PASSWORD` (base64, default `admin`/`admin`).
+- **Cross-tenant admin surface — a real authorization gap.** `TenantEndpoint` and `UsersEndpoint` are ordinary `@RolesAllowed({"ADMINISTRATOR","OPERATOR"})` endpoints with **no tenant scoping on read**. `GET /services/security/tenants` lists every tenant; `GET /services/security/users` lists every user of every tenant; `createUser` accepts an arbitrary `tenant` id. So an `ADMINISTRATOR` in *any* tenant can enumerate and manipulate every other tenant's users. Nothing upstream restricts this. If you are running real multi-tenant workloads, do not grant `ADMINISTRATOR` to tenant users — reserve it for the platform operator.
+- **Tenant DB passwords are stored in `DIRIGIBLE_DATA_SOURCES`** in `SystemDB`. Read access to that table is read access to every tenant's database credentials.
+
+### IdP flavours
+
+`security-cognito/CognitoTenantFilter` and `security-keycloak/KeycloakTenantFilter` are the same logic, gated on `MULTI_TENANT_MODE_ENABLED && <single user pool | single realm>`:
+
+1. Resolve the tenant from the host (404 if unknown).
+2. Read the `custom:tenant` claim — a **comma-separated list of tenant subdomains**.
+3. 403 unless the list contains the resolved tenant's subdomain.
+
+Without the single-pool/single-realm flag these filters are pass-through, and isolation is expected to come from separate pools/realms.
+
+`CognitoSecurityConfiguration` maps `cognito:groups` straight to Dirigible role authorities (so **Cognito group names must equal Dirigible role names**), and derives roles from the `scope` claim for client-credentials tokens via `ScopeRoleJwtAuthoritiesConverter`. `SessionCreationPolicy.ALWAYS`.
+
+`CognitoLoginController` reveals the intended per-tenant OAuth wiring — **one client registration per tenant, whose registration id is the tenant's subdomain**:
+
+```java
+@GetMapping("/{registrationId}")
+public String login(@PathVariable String registrationId, HttpServletRequest request) {
+    Set<String> provisionedClients = tenantService.findByStatus(TenantStatus.PROVISIONED)
+                                                  .stream().map(Tenant::getSubdomain).collect(toSet());
+    if (!provisionedClients.contains(registrationId)) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Invalid OAuth2 client");
+    }
+    return "redirect:/oauth2/authorization/" + registrationId;
+}
+```
+
+Registrations live in `security-client-registration` (`DynamicClientRegistrationRepository`, DB-persisted, CRUD via `POST /services/security/client-registrations`, or seeded from `DIRIGIBLE_OAUTH_CUSTOM_CLIENTS=<name>,…` plus `<NAME>_CLIENT_ID`/`_REDIRECT_URI`/…). Each carries its own `redirectUri`, which is what lets per-tenant subdomains work despite `DIRIGIBLE_HOST` being a single value.
+
+## 8. Per-tenant configuration (`core-configurations`)
+
+Layering is load-bearing and documented in the root `CLAUDE.md`: `commons-config` carries only the neutral `ThreadLocal<Map<String,String>>` mechanism and the `get()` precedence branch; everything tenant/DB/policy-related lives in `core-configurations`. **Never add a tenant or DB dependency to `commons-config`.**
+
+- `TenantConfigurationStore` — raw `SqlFactory` CRUD against `DataSourcesManager.getDefaultDataSource()`, which inside a tenant scope is already that tenant's schema. So a distinct `DIRIGIBLE_CONFIGURATIONS` table (`CONFIGURATION_KEY` / `CONFIGURATION_VALUE`) exists **per tenant schema**, created create-if-absent.
+- `TenantConfigurationCache` — per-tenant map, invalidated on local write. Its Javadoc states plainly that a multi-node deployment needs an external invalidation signal and that this is out of scope.
+- `TenantConfigurationKeyPolicy` — an **explicit allow-list of full keys, exact match, no wildcards**, default-deny. Currently the eight `DIRIGIBLE_BRANDING_*` keys. A non-allow-listed key can be stored but is never injected. Do not reintroduce prefix matching or a config-driven allow-list — both were explicitly rejected.
+- `TenantConfigurationInitFilter`, `@Order(LOWEST_PRECEDENCE)` so it runs *inside* the tenant scope established by `TenantContextInitFilter`. **Do not move this into `core-tenants`** — that would make `core-tenants` depend on `core-configurations` and create a cycle.
+
+Resolution precedence in `Configuration.get`: `RUNTIME (Configuration.set)` → **tenant thread map** → `ENVIRONMENT` → `DEPLOYMENT (.properties)` → `MODULE` → enum default. A tenant override beats env/properties; a programmatic `set` still wins.
+
+The recipe for making a new key tenant-overridable is in the root `CLAUDE.md` ("Making a new property tenant-overridable"). The short version: add the exact key to `ALLOWED_KEYS`, and make sure the consuming code reads it **lazily, per request, inside the tenant scope** — a value cached in a bean or a `static` field will never reflect an override.
+
+## 9. Configuration keys
+
+All in `modules/commons/commons-config/.../DirigibleConfig.java` unless noted.
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `DIRIGIBLE_MULTI_TENANT_MODE` | enum says `false`, but `commons-resources/dirigible-commons.properties:22` sets `true` | **Effectively `true`.** An env var beats the module properties, so `=false` in the environment works |
+| `DIRIGIBLE_TENANT_SUBDOMAIN_REGEX` | `^([^\.]+)\..+$` | Capture group 1 is the subdomain |
+| `DIRIGIBLE_TENANTS_PROVISIONING_FREQUENCY_SECONDS` | `900` | Onboarding latency knob |
+| `DIRIGIBLE_MULTI_TENANT_MODE_COGNITO_SINGLE_USER_POOL` | `false` | Enables `CognitoTenantFilter`'s `custom:tenant` check |
+| `DIRIGIBLE_MULTI_TENANT_MODE_KEYCLOAK_SINGLE_REALM` | `false` | Keycloak equivalent |
+| `DIRIGIBLE_DATABASE_DATASOURCE_NAME_DEFAULT` | `DefaultDB` | The name that gets tenant-prefixed |
+| `DIRIGIBLE_DATABASE_DATASOURCE_NAME_SYSTEM` | `SystemDB` | Never tenant-prefixed |
+| `DIRIGIBLE_CMS_INTERNAL_ROOT_FOLDER` | `target/dirigible/cms` | Tenant id is appended per tenant |
+| `DIRIGIBLE_REPOSITORY_LOCAL_ROOT_FOLDER` | `target` | Single shared repository root — **not** tenant-aware |
+| `DIRIGIBLE_BASIC_USERNAME` / `_PASSWORD` | base64 `admin` | Default-tenant admin only |
+
+Two traps: `DIRIGIBLE_MULTI_TENANT_MODE_SINGLE_USER_POOL` appears in `Configuration.getKeys()` but **nothing reads it** — the live key is `..._COGNITO_SINGLE_USER_POOL`. And `DIRIGIBLE_MS_SHAREPOINT_TENANT_ID` is unrelated (an Azure AD tenant).
+
+`MULTI_TENANT_MODE_ENABLED` is read **once in the constructor** of `TenantExtractor`, `CognitoTenantFilter` and `KeycloakTenantFilter` — flipping it at runtime has no effect on those beans. The ITs flip it in `@BeforeAll`, before the context boots.
+
+## 10. Multi-node / clustering status
+
+Cluster-ready: Quartz (`quartz.properties` → `JobStoreTX`, `isClustered=true`, `instanceId=AUTO`, on `SystemDB`), so `SynchronizationJob` and `TenantProvisioningJob` fire once cluster-wide; ActiveMQ persistence is a shared JDBC store; application data is schema-isolated in a shared DB.
+
+Not cluster-ready — the reasons a Dirigible instance is effectively **single-writer**:
+
+1. **Embedded ActiveMQ broker.** `engine-listeners/config/MessagingConfig` uses `vm://localhost` with `setPersistent(true)` and `JDBCPersistenceAdapter(SystemDB)`, and never disables the database locker. ActiveMQ's default locker takes an exclusive row lock on `ACTIVEMQ_LOCK` and `broker.start()` blocks until it wins, so the second instance's Spring context never finishes refreshing. The connector URL is a hardcoded constant.
+2. **`SynchronizationJob` is a cluster-singleton whose effects are node-local.** It fires on one node per interval and reconciles *that JVM's* runtime — Camel routes, JMS listeners, Quartz registrations, compiled client-Java classloaders, native-app processes. Other instances never reconcile and serve stale runtime.
+3. **Local filesystem repository.** `LocalRepository` is the only `IRepository`; `IRepository.DIRIGIBLE_REPOSITORY_PROVIDER_DATABASE = "database"` is a dead constant (the module was deleted). Change detection uses `WatchService`, unreliable on NFS/EFS.
+4. **Per-JVM caches with no invalidation channel** — `TENANT_CACHE`, `TenantConfigurationCache`, `DataSourceInitializer.DATASOURCES`, `AccessVerifier`'s ACL cache, `Configuration.RUNTIME_VARIABLES`, `CmsProviderInternalFactory.PROVIDERS`.
+5. **Boot races** — `spring.quartz.jdbc.initialize-schema=always` runs a script that opens with `DROP TABLE IF EXISTS QRTZ_*`; `JobsInitializer` does unschedule→delete→schedule and throws on collision; `SynchronizationProcessor.prepareSynchronizers()` calls `setRunningToAll(false)` on shared rows; `DefaultTenantInitializer`/`AdminUserInitializer` are check-then-insert; the 30 s startup provisioning runs on every node. Liquibase (`core-liquibase`) *is* safe — it serialises on `DATABASECHANGELOGLOCK`.
+6. **In-memory HTTP sessions** — no `spring-session` on the classpath; 8 h timeout; `SessionCreationPolicy.ALWAYS` under the cognito profile.
+
+Deploy accordingly: one instance, stop-then-start. `build/helm-charts/dirigible/values.yaml` (`replicaCount: 1`, `strategyType: Recreate`, `ReadWriteOnce`) is the upstream statement of the same conclusion — though the chart is otherwise stale (Tomcat paths, a v4-era health path) and should not be used as a deployment reference.
+
+## Where the blog is out of date
+
+The [2024 blog](https://www.dirigible.io/blogs/2024/03/26/multitenancy) still describes subdomain resolution, schema-per-tenant, the `{TENANT_ID}_` datasource prefix and the `{TENANT_ID}###` naming for jobs and destinations correctly. Two things have moved:
+
+- **Onboarding.** The blog shows raw `INSERT`s into `DIRIGIBLE_TENANTS` and `DIRIGIBLE_USERS`. There are now role-guarded REST endpoints — `POST /services/security/tenants` and `POST /services/security/users` — which is what automation should call.
+- **Per-tenant configuration did not exist then** (§8).
+
+Also note the blog's provisioning description ("30 seconds post-startup, then 15-minute intervals") is exactly right and still matches `TenantsInitializer` + `TenantProvisioningJob`.
+
+## Executable spec
+
+These ITs are the behavioural contract — read them before changing resolution or provisioning:
+
+| Test | Covers |
+| --- | --- |
+| `EnabledMultitenantModeIT` / `DisabledMultitenantModeIT` | Resolution with the mode on/off, including the `localhost`-falls-back-to-default behaviour |
+| `TenantDeterminationIT` | Host / `x-forwarded-host` matching, unknown-subdomain 404 |
+| `MultitenancyIT`, `MultitenancyHarmoniaIT` | End-to-end per-tenant data isolation |
+| `BpmnMultitenancyIT` | Flowable discriminator-based isolation |
+| `TenantConfigurationIT` | Per-tenant config set → resolve with precedence → clear |
+| `RestTransactionsIT` | Tenant-scoped transaction manager behaviour |
+
+All live under `tests/tests-integrations/src/main/java/.../tests/`.
+
+## Wrong turns and footguns
+
+- **Forgetting `TenantContext.execute(...)` on a background thread does not fail — it writes to the default tenant.** Always wrap async entry points; copy `JobHandler` / `AsynchronousMessageListener`.
+- **Don't wire the `tenantIdentifier` through `MultiTenantConnectionProviderImpl`** — isolation already happened in `getDefaultDataSource()`; doing both double-applies it.
+- **Don't add a tenant/DB dependency to `commons-config`**, and don't move `TenantConfigurationInitFilter` into `core-tenants` (module cycle).
+- **Don't widen `TenantConfigurationKeyPolicy` with prefixes or a config-driven list** — both were rejected; a tenant must never be able to shadow an infrastructure key.
+- **Synchronizer artefact `location`s are registry-relative; `IRepository` paths are repository-absolute.** Prepend `IRepositoryStructure.PATH_REGISTRY_PUBLIC` when reading/writing an artefact's file.
+- **`SqlFactory` quoting**: `create().table()` takes **pre-quoted** identifiers, while `select/insert/update/delete` and `where(...)` **auto-quote** — pass unquoted names there. A VARCHAR length must include its parens: `column(..., "(255)")`.
+- **A new provisioning step joins an unordered `Set`.** If order matters, make it explicit.


### PR DESCRIPTION
Documentation only. No code, no configuration, nothing implemented. Four markdown files plus a pointer from the root `CLAUDE.md`.

## What this adds

**1. `components/core/core-tenants/CLAUDE.md`** — the in-repo reference for how multitenancy actually works, following the existing module-guide convention (`core-liquibase`, `engine-java`, `engine-intent`, `engine-native-apps`). Scoped as a *cross-module* guide, because the behaviour is a contract between `core-base` (the SPI), `core-tenants` (resolution, entity, provisioning, users), `data-sources` (the actual isolation), `core-configurations`, and the engines that tenant-qualify their runtime names.

Covers: the resolution algorithm and its caching gotchas; the `TenantContext` scope API and the thread-hand-off rule; the datasource-name indirection and the one-Hikari-pool-per-tenant model; provisioning; the per-tenant replay in `BaseSynchronizer` and which eight synchronizers opt in; the Cognito/Keycloak `custom:tenant` filters; the config keys; the multi-node status; the ITs that serve as executable spec; and a footguns section.

**2. `AWS_MULTITENANCY_RESEARCH.md`** — a production AWS architecture for the **current release, with zero code changes**: schema-per-tenant on Aurora PostgreSQL, ECS Fargate, wildcard subdomains, Cognito single user pool, S3-backed CMS, cell-based scale-out, tenant lifecycle, cost model.

**3. `AWS_MULTITENANCY_TARGET_ARCHITECTURE.md`** — the architecture we'd actually *recommend*, written without that constraint. It answers a requirement the current model cannot express: **a user registered in one tenant being able to log into another tenant where they hold the necessary authorizations.** Makes Dirigible a claims-driven authorization consumer instead of adding a membership table — identity, tenant membership and per-tenant roles come from the IdP token.

**4. `AWS_MULTITENANCY_SETUP_GUIDE.md`** — the concrete how-to that implements #3: how many Cognito app clients and their exact config, single user pool vs pool per tenant, the pre-token-generation Lambda and DynamoDB membership store, the full Dirigible env-var table, a worked example with both token payloads, an onboarding runbook, and a validation checklist. Split into **Mode A** (configuration only — works on today's code) and **Mode B** (the fork hardening), with an honest Mode-A caveat table.

The root `CLAUDE.md` gains a `## Multitenancy` section linking these. The existing `Tenant-aware configuration` section is demoted to a subsection of it — content unchanged — since the per-tenant config layer is a sub-topic of the model it extends.

## The recommendation, in short

Make Dirigible a **claims-driven authorization consumer**: identity, tenant membership and per-tenant roles come from the IdP token, not from `DIRIGIBLE_USERS` / `DIRIGIBLE_USER_ROLE_ASSIGNMENTS`.

Identity design: **one Cognito user pool, one app client per tenant**, and a pre-token-generation Lambda (V2_0/V3_0) that maps `clientId → tenant` and emits only that tenant's roles via `groupsToOverride`. Three properties make this a smaller change than expected:

- The **existing** `cognito:groups` → authorities mapper becomes correct per tenant with no change to it, because the token is tenant-scoped at issuance.
- Roles need not be real Cognito groups, so the non-adjustable *100 groups per user* quota doesn't apply — membership lives in the control plane (DynamoDB).
- `JSESSIONID` is host-scoped, so each tenant subdomain gets its own session with its own authorities. That neutralises the fact that authorities are snapshotted at login rather than re-resolved per request.

Cross-tenant login then works via Cognito's documented default: the managed-login session cookie authenticates a user across all app clients in one pool, so the second tenant's OIDC dance needs no credential prompt but still yields a different role set. Pool-per-tenant is rejected — it's the configuration AWS names for *preventing* exactly this.

Also proposed: a `TenantIdentityResolver` SPI as the single new abstraction, and demoting the local user tables to a dev-only implementation behind it (which closes the cross-tenant admin gap by construction).

## Findings worth reviewing on their own merits

All verified against the code, with path references in the docs. These are independent of the proposal.

**Deployment / scaling**
- **The application is effectively single-writer.** `MessagingConfig` builds the embedded ActiveMQ broker on `vm://localhost` with `JDBCPersistenceAdapter(SystemDB)` and `setPersistent(true)`, never disabling the database locker — so `broker.start()` blocks on `ACTIVEMQ_LOCK` and a second instance's context never finishes refreshing. Separately, `SynchronizationJob` is a clustered-Quartz singleton whose effects are node-local (Camel routes, JMS listeners, Quartz registrations, client-Java classloaders live in *that* JVM), so non-winning instances never reconcile. Hence cells, not replicas. The Helm chart's `replicaCount: 1` + `Recreate` already encodes the same conclusion.
- **Hikari pool sizing is effectively hardcoded.** `DataSourceInitializer` calls `setMaximumPoolSize(20)` / `setMinimumIdle(10)` *after* the `HikariConfig(Properties)` constructor, overriding any `<DS>_HIKARI_*` value. With one pool per (instance, tenant), connection count becomes the capacity limit.

**Authorization**
- **`@EnableMethodSecurity(jsr250Enabled = true)` sits only on `BasicSecurityConfig`**, which is `@ConditionalOnProperty(basic.enabled=true)` — and every OIDC profile sets that false. Keycloak's bare `@EnableMethodSecurity` defaults `jsr250Enabled` to false. Read literally, **all 52 `@RolesAllowed` annotations are inert under the cognito/keycloak/snowflake/github profiles.** Labelled a **hypothesis** in the docs, not an assertion — confirming it is Phase 0 of the proposal.
- **M2M Bearer requests bypass the tenant membership check entirely** — both `*TenantFilter` clones guard on `instanceof OAuth2AuthenticationToken`, and a JWT request is a `JwtAuthenticationToken`.
- **`CognitoSecurityConfiguration` never adds `TenantContextInitFilter` to its chain**, unlike the basic/keycloak/snowflake configs. It runs only via Boot's servlet auto-registration, so its position relative to authentication is accidental.
- **`DIRIGIBLE_TRIAL_ENABLED` grants every platform role to every authenticated principal**, tenant-blind, in three places.
- **`TenantEndpoint` / `UsersEndpoint` don't tenant-scope reads** — an `ADMINISTRATOR` in any tenant can enumerate and modify every tenant's users. `RepositoryEndpoint`'s `/{*path}` CRUD is the same class of problem.
- **`security-client-registration`**: `GET` returns `clientSecret` in plaintext to any tenant's ADMINISTRATOR/DEVELOPER/OPERATOR; `registrationId` is the entity `name` while the REST path uses `id`, so the seeded default (named `"cognito"`) is unreachable through `CognitoLoginController`, which accepts only tenant subdomains; `REGISTRATIONS` is a `private static` non-thread-safe `HashMap` filled only as a side effect of `iterator()`.
- **`spring-boot-starter-oauth2-authorization-server` is pulled in transitively and never configured.** Its only effect is a stray auto-configured `JwtDecoder` that all three resource-server configs must defensively pin around.

**Isolation**
- **`JavaCompiledOutputDirectory` resolves to one global `dirigible/java-compiled/bin` for all tenants**, loaded by a single `ClientClassLoader` — client Java code is not tenant-isolated. This is *runtime*, not authoring, so it needs a decision regardless of the identity work. Same class of problem as `PublisherService` writing into the shared `/registry/public`.

**Stale / dead**
- `DIRIGIBLE_MASTER_REPOSITORY_*` is dead code — nothing in `components/` ever creates an `IMasterRepository`. The working content-seeding paths are `ClasspathExpander` and `DIRIGIBLE_REGISTRY_EXTERNAL_FOLDER`.
- `build/helm-charts/` is stale (Tomcat paths, `/services/v4/healthcheck`, `DIRIGIBLE_SCHEDULER_MEMORY_STORE` which nothing reads). Noted so it isn't used as a deployment reference.

## Notes for the reviewer

- **Nothing here asserts an unverified claim.** Four findings are labelled hypotheses and confined to the verification sections: the inert `@RolesAllowed`, whether HTTP Basic re-invokes `loadUserByUsername` per request, whether a cross-subdomain session replay is exploitable, and whether `Role.name` global uniqueness is enforced or merely implied by single-result queries. Each has a suggested experiment.
- The cheapest first step the docs propose costs nothing: a **failing integration test** asserting that `admin` in tenant A and `admin` in tenant B get distinct workspaces. None of the existing multitenancy ITs exercises a same-username-in-two-tenants scenario, which is why several latent collisions have gone unnoticed.
- Per a runtime-only-production decision, the IDE/authoring tier's user-scoped state is recorded as an accepted constraint rather than fixed — including `GitFileUtils.USER_WORKSPACE_SEGMENTS_COUNT = 3` / `_PROJECT_ = 4`, where inserting a tenant path segment causes **silent file mangling** in `ShareCommand` rather than an exception. Worth knowing before anyone reopens that area.
- The 2024 blog *"Multitenant applications with zero effort"* is mostly still accurate; the docs call out the two things that drifted (onboarding moved from raw `INSERT`s to the `services/security/` REST endpoints, and per-tenant configuration didn't exist then).
- Markdown only, so `formatter:validate` and the license check are unaffected; existing module `CLAUDE.md` files carry no license header either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
