### PR TITLE
fix(intent/edm): color entities by type in the EDM modeler (#6333)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -1980,9 +1980,12 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             int y = pos[1];
             int height = pos[2];
 
+            String cellStyle = entityCellStyle(entity.get("type"));
             sb.append("   <mxCell id=\"")
               .append(entityCellId.get(name))
-              .append("\" style=\"entity\" parent=\"1\" vertex=\"1\">\n");
+              .append("\" style=\"")
+              .append(cellStyle)
+              .append("\" parent=\"1\" vertex=\"1\">\n");
             appendEntityValue(sb, entity);
             sb.append("    <mxGeometry x=\"")
               .append(x)
@@ -1999,12 +2002,18 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
               .append("\" as=\"alternateBounds\"/></mxGeometry>\n");
             sb.append("   </mxCell>\n");
 
+            // A PROJECTION entity's property rows carry the dedicated projectionproperty style, exactly
+            // as the EDM editor serializes them; PRIMARY/DEPENDENT/SETTING children keep the default
+            // vertex style (the editor does not restyle their children either).
+            String propStyleAttr = "projection".equals(cellStyle) ? " style=\"projectionproperty\"" : "";
             int propIndex = 0;
             for (Map<String, Object> property : properties) {
                 sb.append("   <mxCell id=\"")
                   .append(propertyCellId.get(name)
                                         .get(property.get("name")))
-                  .append("\" parent=\"")
+                  .append("\"")
+                  .append(propStyleAttr)
+                  .append(" parent=\"")
                   .append(entityCellId.get(name))
                   .append("\" vertex=\"1\" connectable=\"0\">\n");
                 appendPropertyValue(sb, property);
@@ -2138,6 +2147,27 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> propertiesOf(Map<String, Object> entity) {
         return (List<Map<String, Object>>) entity.getOrDefault("properties", List.of());
+    }
+
+    /**
+     * The mxGraph cell style string the EDM editor colors an entity by. The editor keys the cell colour
+     * on the {@code style} attribute alone (blue {@code entity} / darker-blue {@code dependent} / grey
+     * {@code setting} / purple {@code projection}), reconciling it from {@code entityType} only when
+     * the entity dialog re-saves - never on load. So an intent-generated {@code .edm} must emit the
+     * same per-type style a hand-modeled one carries, or every entity loads as the default blue
+     * {@code entity}.
+     */
+    private static String entityCellStyle(Object entityType) {
+        if ("DEPENDENT".equals(entityType)) {
+            return "dependent";
+        }
+        if ("SETTING".equals(entityType)) {
+            return "setting";
+        }
+        if ("PROJECTION".equals(entityType)) {
+            return "projection";
+        }
+        return "entity";
     }
 
     /**

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -126,10 +126,38 @@ class EdmIntentGeneratorTest {
                 "the cross-model Country cell must be entityType=PROJECTION, was: " + countryCell);
         assertTrue(countryCell.contains("projectionReferencedEntity=\"Country\""), "the projection cell must carry its referenced entity");
 
-        // A locally-owned entity stays a plain cell (no entityType=PROJECTION).
+        // The enclosing <mxCell> must carry style="projection" - the EDM editor colors an entity purely
+        // from the cell style on load, so without it the projection renders as the default blue (#6333).
+        assertTrue(mxCellTagFor(edm, "Country").contains("style=\"projection\""),
+                "the PROJECTION cell must carry style=projection so the modeler colors it purple");
+
+        // A locally-owned entity stays a plain cell (no entityType=PROJECTION) styled as the default blue.
         int owned = edm.indexOf("<Entity name=\"Customer\"");
         String customerCell = edm.substring(owned, edm.indexOf("/>", owned));
         assertTrue(!customerCell.contains("entityType=\"PROJECTION\""), "an owned entity must not be a projection cell");
+        assertTrue(mxCellTagFor(edm, "Customer").contains("style=\"entity\""), "an owned PRIMARY entity must keep style=entity");
+    }
+
+    @Test
+    void entityCellsCarryTheModelerStylePerType() {
+        // The EDM editor colors each entity solely from the mxCell style attribute (reconciled from
+        // entityType only when the entity dialog re-saves, never on load). So an intent-generated .edm must
+        // emit the same per-type style a hand-modeled one carries, or every entity loads as the default
+        // blue "entity" style regardless of type (#6333). sales-invoices exercises all four types.
+        IntentModel parsed = IntentParser.parse(readResource("/billing/sales-invoices.intent"));
+        String edm = EdmIntentGenerator.buildEdmXmlForTest(parsed, "sales-invoices");
+
+        assertTrue(mxCellTagFor(edm, "SalesInvoice").contains("style=\"entity\""), "a PRIMARY entity is styled entity (blue)");
+        assertTrue(mxCellTagFor(edm, "SalesInvoiceItem").contains("style=\"dependent\""),
+                "a composition-child DEPENDENT entity is styled dependent (darker blue)");
+        assertTrue(mxCellTagFor(edm, "PaymentMethod").contains("style=\"setting\""), "a SETTING entity is styled setting (grey)");
+        assertTrue(mxCellTagFor(edm, "CustomerPayment").contains("style=\"projection\""),
+                "a cross-model PROJECTION entity is styled projection (purple)");
+
+        // A PROJECTION entity's property rows carry the dedicated projectionproperty style, matching the
+        // editor's own serialization; the other three types keep the default (unstyled) child cells.
+        assertTrue(edm.contains("style=\"projectionproperty\""),
+                "a PROJECTION entity's property cells must carry style=projectionproperty");
     }
 
     @Test
@@ -837,6 +865,18 @@ class EdmIntentGeneratorTest {
                        .filter(e -> name.equals(e.get("name")))
                        .findFirst()
                        .orElse(null);
+    }
+
+    /**
+     * The opening {@code <mxCell ...>} tag that wraps the {@code <Entity name="<name>">} value cell in
+     * the emitted EDM diagram - the tag carrying the {@code style} attribute the modeler colors the
+     * entity by.
+     */
+    private static String mxCellTagFor(String edm, String name) {
+        int entityIdx = edm.indexOf("<Entity name=\"" + name + "\"");
+        assertTrue(entityIdx >= 0, "the diagram cell for entity [" + name + "] must be present");
+        int cellStart = edm.lastIndexOf("<mxCell", entityIdx);
+        return edm.substring(cellStart, edm.indexOf('>', cellStart) + 1);
     }
 
     @SuppressWarnings("unchecked")

--- a/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
+++ b/components/ui/editor-entity/src/main/resources/META-INF/dirigible/editor-entity/js/editor.js
@@ -1277,6 +1277,20 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 			let parent = graph.getDefaultParent();
 			let childCount = graph.model.getChildCount(parent);
 
+			// Canonical mxCell style per entity type - the modeler colors an entity from its cell style,
+			// and this is the single source that maps the semantic entityType to that style.
+			const ENTITY_TYPE_STYLES = {
+				PRIMARY: { entity: 'entity' },
+				DEPENDENT: { entity: 'dependent' },
+				SETTING: { entity: 'setting' },
+				REPORT: { entity: 'report' },
+				FILTER: { entity: 'filter' },
+				COPIED: { entity: 'copied', property: 'copiedproperty' },
+				PROJECTION: { entity: 'projection', property: 'projectionproperty' },
+				EXTENSION: { entity: 'extension', property: 'extensionproperty' },
+			};
+			let restyled = false;
+
 			// Base64 deserialization of the encoded properties
 			for (let i = 0; i < childCount; i++) {
 				let child = graph.model.getChildAt(parent, i);
@@ -1306,7 +1320,36 @@ angular.module('ui.entity-data.modeler', ['blimpKit', 'platformView', 'Workspace
 						child.value.perspectiveName = "Reports";
 						child.value.perspectiveLabel = "Reports";
 					}
+
+					// Backward compatibility: color each entity from its type. Older / intent-generated
+					// models persisted style="entity" on every cell regardless of entityType, so the
+					// modeler rendered SETTING/DEPENDENT/PROJECTION entities as the default blue. The
+					// entityType is the source of truth - re-derive the cell style from it on load
+					// (mirrors the entity dialog's re-save styling in the edm.editor.entity handler).
+					// Only cells that declare a concrete entityType are touched, so cells without one
+					// (e.g. plain filters) keep their persisted style untouched.
+					if (child.value.entityType) {
+						let derived = ENTITY_TYPE_STYLES[child.value.entityType];
+						if (derived) {
+							if (child.style !== derived.entity) {
+								child.style = derived.entity;
+								restyled = true;
+							}
+							if (derived.property && child.children) {
+								child.children.forEach((prop) => {
+									if (prop.style !== derived.property) {
+										prop.style = derived.property;
+										restyled = true;
+									}
+								});
+							}
+						}
+					}
 				}
+			}
+
+			if (restyled) {
+				graph.refresh();
 			}
 		}
 


### PR DESCRIPTION
## Problem

Closes #6333.

Opening an intent-generated `.edm` in the Entity Data Modeler rendered **every** entity in the default blue, regardless of type: SETTING should be grey, PROJECTION purple, composition-child DEPENDENT darker-blue, PRIMARY blue. A hand-modeled `.edm` colors them correctly; an intent-generated one did not.

## Root cause

The modeler colors each entity **solely from the mxCell `style` attribute** on load (`configureStylesheet` in `editor-entity/js/widgets.js` registers `entity`=blue, `dependent`=darker-blue, `setting`=grey, `projection`=purple). It reconciles the style from the `entityType` value attribute **only when the entity dialog re-saves** — never on load.

`EdmIntentGenerator` hardcoded `style="entity"` on every diagram cell while writing the correct `entityType` value attribute, so the value attribute was right but the cell always loaded blue.

## Fix (two complementary parts)

1. **Generator — correct the source** (`EdmIntentGenerator`): emit the per-type mxCell style (`dependent`/`setting`/`projection`, else `entity`) that a hand-modeled `.edm` carries, plus `projectionproperty` on PROJECTION property rows. New `.edm` files are now byte-faithful to hand-modeled ones.

2. **Modeler — don't strand existing files** (`editor-entity/js/editor.js`): in `deserializeFilter`'s existing *"backward compatibility with old models"* pass, re-derive each entity cell's style from its `entityType` (the source of truth) on load. This colors **already-generated / cloned** projects correctly with **no regeneration**. Only cells that declare a concrete `entityType` are touched, so plain filters keep their persisted style. This mirrors the same idiom the file already uses (the `SETTING → Settings` perspective backfill).

## Tests

`EdmIntentGeneratorTest` extended:
- existing projection test now also asserts `style="projection"` and `style="entity"` for the owned PRIMARY;
- new `entityCellsCarryTheModelerStylePerType` asserts all four styles (`entity`/`dependent`/`setting`/`projection`) + the `projectionproperty` child style, driven off the `sales-invoices` fixture which exercises every type.

All 27 tests pass; `mvn formatter:format` clean; release-profile javadoc build succeeds.

## Verification

Rebuilt the fat jar and restarted a local instance; opening the cloned `kf-mod-*` projects' `.edm` files now renders SETTING grey, PROJECTION purple, DEPENDENT darker-blue, PRIMARY blue — without re-generating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)