### PR TITLE
feat(intent): checks: kind: guard - aggregate precondition (block, config-gated)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -28,6 +28,7 @@ import org.eclipse.dirigible.components.intent.generator.IntentNaming;
 import org.eclipse.dirigible.components.intent.generator.IntentSettings;
 import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
 import org.eclipse.dirigible.components.intent.generator.TriggerSupport;
+import org.eclipse.dirigible.components.intent.model.AggregateIntent;
 import org.eclipse.dirigible.components.intent.model.CalendarIntent;
 import org.eclipse.dirigible.components.intent.model.CustomWidgetIntent;
 import org.eclipse.dirigible.components.intent.model.DependsOnIntent;
@@ -534,7 +535,7 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 entityMap.put("labelExpression", entity.getLabel());
                 entityMap.put("labelParts", buildLabelParts(entity, byName));
             }
-            List<Map<String, Object>> checkMaps = buildChecks(entity, byName);
+            List<Map<String, Object>> checkMaps = buildChecks(entity, byName, model.getAggregates());
             if (!checkMaps.isEmpty()) {
                 // Declarative validations. A List, so it lives only in the .model twin (the scalar-only
                 // .edm XML skips it via the Iterable guard), consumed by the DAO/REST templates.
@@ -1367,7 +1368,8 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
      * back-reference FK property, and the EntityStatus gate property - everything the DAO/REST
      * templates need without re-deriving model structure.
      */
-    private static List<Map<String, Object>> buildChecks(EntityIntent entity, Map<String, EntityIntent> byName) {
+    private static List<Map<String, Object>> buildChecks(EntityIntent entity, Map<String, EntityIntent> byName,
+            List<AggregateIntent> aggregates) {
         List<Map<String, Object>> checkMaps = new ArrayList<>();
         if (entity.getChecks() == null) {
             return checkMaps;
@@ -1376,6 +1378,44 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
             Map<String, Object> checkMap = new LinkedHashMap<>();
             checkMap.put("kind", check.getKind());
             checkMap.put("message", check.getMessage() == null ? "Validation failed" : check.getMessage());
+            if ("guard".equals(check.getKind())) {
+                // Aggregate guard: recompute the named aggregate's keyed sum from THIS entity's store
+                // (the aggregate's `of` must be this entity - v1 self-referential) and block a write
+                // whose post-state would drop the sum below `minimum`. Race-free: recomputed from the
+                // source rows, not the async-maintained target.
+                AggregateIntent agg = null;
+                if (aggregates != null) {
+                    for (AggregateIntent a : aggregates) {
+                        if (a.getName() != null && a.getName()
+                                                    .equals(check.getAggregate())) {
+                            agg = a;
+                            break;
+                        }
+                    }
+                }
+                if (agg == null || agg.getOf() == null || !agg.getOf()
+                                                              .equals(entity.getName())
+                        || agg.getSum() == null || agg.getBy()
+                                                      .isEmpty()) {
+                    continue; // unresolved / not self-referential / no sum - skip (v1 scope)
+                }
+                List<Map<String, String>> keys = new ArrayList<>();
+                for (String key : agg.getBy()) {
+                    Map<String, String> pair = new LinkedHashMap<>();
+                    pair.put("key", IntentNaming.pascalCase(key));
+                    keys.add(pair);
+                }
+                checkMap.put("keys", keys);
+                checkMap.put("sumField", IntentNaming.pascalCase(agg.getSum()));
+                FieldIntent guardPk = primaryKeyOf(entity);
+                checkMap.put("pk", guardPk == null ? "Id" : IntentNaming.pascalCase(guardPk.getName()));
+                checkMap.put("minimum", check.getMinimum() == null ? "0"
+                        : check.getMinimum()
+                               .toPlainString());
+                checkMap.put("enabledBy", check.getEnabledBy() == null ? "" : check.getEnabledBy());
+                checkMaps.add(checkMap);
+                continue;
+            }
             if ("exactlyOne".equals(check.getKind())) {
                 checkMap.put("fields", check.getFields()
                                             .stream()

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/CheckIntent.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/model/CheckIntent.java
@@ -41,9 +41,52 @@ public class CheckIntent {
     private Integer status;
     /** The user-facing message when the check fails. */
     private String message;
+    /**
+     * {@code guard}: the name of an {@code aggregates:} entry whose {@code of} is THIS entity. The
+     * guard recomputes that keyed sum from the store for the incoming record's key-tuple (race-free,
+     * unlike the async-maintained target) and blocks the write when the post-state would break
+     * {@link #minimum} - the negative-stock / credit-limit precondition. v1: the guarded entity is the
+     * aggregate source.
+     */
+    private String aggregate;
+    /**
+     * {@code guard}: the recomputed sum (prior rows + this row) must stay {@code >= minimum} (default
+     * 0).
+     */
+    private java.math.BigDecimal minimum;
+    /**
+     * {@code guard} (optional): a configuration key gating the guard - it is enforced only when
+     * {@code Configurations.get(enabledBy)} equals {@code "true"} (case-insensitive). Omitted = always
+     * on.
+     */
+    private String enabledBy;
 
     public String getKind() {
         return kind;
+    }
+
+    public String getAggregate() {
+        return aggregate;
+    }
+
+    public void setAggregate(String aggregate) {
+        this.aggregate = aggregate;
+    }
+
+    public java.math.BigDecimal getMinimum() {
+        return minimum;
+    }
+
+    public void setMinimum(java.math.BigDecimal minimum) {
+        this.minimum = minimum;
+    }
+
+    public String getEnabledBy() {
+        return enabledBy;
+    }
+
+    public void setEnabledBy(String enabledBy) {
+        this.enabledBy = enabledBy;
     }
 
     public void setKind(String kind) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -1448,7 +1448,7 @@ public final class IntentParser {
             }
             if (entity.getChecks() != null) {
                 for (CheckIntent check : entity.getChecks()) {
-                    validateCheck(entity, check, byName, issues);
+                    validateCheck(entity, check, byName, model.getAggregates(), issues);
                 }
             }
         }
@@ -1705,9 +1705,42 @@ public final class IntentParser {
      * mandatory - without it the check would forbid drafting the document item by item.
      */
     private static void validateCheck(EntityIntent entity, CheckIntent check, java.util.Map<String, EntityIntent> byName,
-            List<String> issues) {
+            List<org.eclipse.dirigible.components.intent.model.AggregateIntent> aggregates, List<String> issues) {
         String subject = "entity [" + entity.getName() + "] check [" + (check.getKind() == null ? "?" : check.getKind()) + "]";
         String kind = check.getKind();
+        if ("guard".equals(kind)) {
+            // An aggregate guard names an aggregates: entry whose `of` is THIS entity (v1: the guarded
+            // entity is the aggregate source, so the sum is recomputed race-free from the local store).
+            if (check.getAggregate() == null || check.getAggregate()
+                                                     .isBlank()) {
+                issues.add(subject + " requires `aggregate`: the name of an aggregates: entry over this entity");
+                return;
+            }
+            org.eclipse.dirigible.components.intent.model.AggregateIntent agg = null;
+            if (aggregates != null) {
+                for (org.eclipse.dirigible.components.intent.model.AggregateIntent a : aggregates) {
+                    if (check.getAggregate()
+                             .equals(a.getName())) {
+                        agg = a;
+                        break;
+                    }
+                }
+            }
+            if (agg == null) {
+                issues.add(subject + " references unknown aggregate [" + check.getAggregate() + "]");
+                return;
+            }
+            if (!entity.getName()
+                       .equals(agg.getOf())) {
+                issues.add(subject + " aggregate [" + check.getAggregate() + "] is over [" + agg.getOf()
+                        + "], not this entity - v1 supports only a guard on the aggregate's own source entity");
+            }
+            if (agg.getSum() == null || agg.getSum()
+                                           .isBlank()) {
+                issues.add(subject + " aggregate [" + check.getAggregate() + "] must be a `sum` aggregate to guard");
+            }
+            return;
+        }
         if ("exactlyOne".equals(kind)) {
             if (check.getFields() == null || check.getFields()
                                                   .size() < 2) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -472,6 +472,66 @@ class EdmIntentGeneratorTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void guardCheckEmitsKeyedAggregateGuard() {
+        String yaml = """
+                name: inventory
+                entities:
+                  - name: Product
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: Store
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                  - name: StockMovement
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: quantity, type: decimal }
+                    relations:
+                      - { name: Product, kind: manyToOne, to: Product }
+                      - { name: Store, kind: manyToOne, to: Store }
+                    checks:
+                      - kind: guard
+                        aggregate: onHand
+                        minimum: 0
+                        message: Insufficient stock
+                        enabledBy: INVENTORY_BLOCK_NEGATIVE_STOCK
+                  - name: ProductAvailability
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: onHand, type: decimal }
+                    relations:
+                      - { name: Product, kind: manyToOne, to: Product }
+                      - { name: Store, kind: manyToOne, to: Store }
+                aggregates:
+                  - name: onHand
+                    of: StockMovement
+                    op: sum
+                    sum: quantity
+                    by: [Product, Store]
+                    into: ProductAvailability
+                    field: onHand
+                """;
+        Map<String, Object> model = EdmIntentGenerator.buildModelJsonForTest(IntentParser.parse(yaml), "inventory");
+        Map<String, Object> movement = entityByName(entities(model), "StockMovement");
+        List<Map<String, Object>> checks = (List<Map<String, Object>>) movement.get("checks");
+        assertEquals(1, checks.size());
+        Map<String, Object> guard = checks.get(0);
+        assertEquals("guard", guard.get("kind"));
+        assertEquals("Quantity", guard.get("sumField"));
+        assertEquals("Id", guard.get("pk"));
+        assertEquals("0", guard.get("minimum"));
+        assertEquals("Insufficient stock", guard.get("message"));
+        assertEquals("INVENTORY_BLOCK_NEGATIVE_STOCK", guard.get("enabledBy"));
+        List<Map<String, String>> keys = (List<Map<String, String>>) guard.get("keys");
+        assertEquals(2, keys.size());
+        assertEquals("Product", keys.get(0)
+                                    .get("key"));
+        assertEquals("Store", keys.get(1)
+                                  .get("key"));
+    }
+
+    @Test
     void securedByDefaultEmitsGenerateDefaultRolesAndRoleNames() {
         String yaml = """
                 name: library

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -69,12 +69,43 @@ package gen.${javaGenFolderName}.data.${javaPerspectiveName};
         }
 #end
 #end
+## Aggregate guard (intent `checks: kind: guard`): reject a create/update whose post-state would drop
+## a keyed aggregate sum below its minimum (negative stock, credit limit). Recomputed synchronously from
+## THIS entity's store for the incoming row's key-tuple (race-free, not the async-maintained target),
+## excluding this row on update, then adding the incoming value. Optionally gated by a config key.
+#macro(aggregateGuardCheck)
+#if($guardChecks && $guardChecks.size() > 0)
+#foreach($guard in $guardChecks)
+#if($guard.enabledBy && $guard.enabledBy != "")
+        if ("true".equalsIgnoreCase(org.eclipse.dirigible.sdk.core.Configurations.get("${guard.enabledBy}", ""))) {
+#end
+        {
+            java.math.BigDecimal guardSum = java.math.BigDecimal.ZERO;
+            for (${name}Entity aggRow : findAll(Criteria.create()#foreach($k in $guard.keys).eq("${k.key}", entity.${k.key})#end)) {
+                if (entity.${guard.pk} != null && entity.${guard.pk}.equals(aggRow.${guard.pk})) {
+                    continue;
+                }
+                if (aggRow.${guard.sumField} != null) {
+                    guardSum = guardSum.add(aggRow.${guard.sumField});
+                }
+            }
+            java.math.BigDecimal guardIncoming = entity.${guard.sumField} == null ? java.math.BigDecimal.ZERO : entity.${guard.sumField};
+            if (guardSum.add(guardIncoming).compareTo(new java.math.BigDecimal("${guard.minimum}")) < 0) {
+                throw new ValidationException("${guard.message}");
+            }
+        }
+#if($guard.enabledBy && $guard.enabledBy != "")
+        }
+#end
+#end
+#end
+#end
 import org.eclipse.dirigible.components.data.store.java.repository.JavaRepository;
 import org.eclipse.dirigible.sdk.component.Component;
 import org.eclipse.dirigible.sdk.component.Repository;
 import org.eclipse.dirigible.sdk.messaging.Producer;
 import org.eclipse.dirigible.sdk.utils.Json;
-#if(($documentChecks && $documentChecks.size() > 0) || $rollupGuard)
+#if(($documentChecks && $documentChecks.size() > 0) || $rollupGuard || ($guardChecks && $guardChecks.size() > 0))
 import org.eclipse.dirigible.sdk.db.ValidationException;
 #end
 #if($multilingual == "true")
@@ -109,6 +140,10 @@ import gen.${javaGenFolderName}.data.${rollupGuard.parentPerspective}.${rollupGu
 ## Document checks need Criteria to load the items; deduped against the other importers above.
 import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
 #end
+#if($guardChecks && $guardChecks.size() > 0 && $multilingual != "true" && !$documentMaster && !$rollupGuard && !($documentChecks && $documentChecks.size() > 0))
+## Aggregate guards recompute the keyed sum via Criteria; deduped against every importer above.
+import org.eclipse.dirigible.components.data.store.java.repository.Criteria;
+#end
 #if($documentItem)
 import gen.${javaGenFolderName}.data.${documentItem.javaParentPerspective}.${documentItem.parentEntity}Repository;
 #end
@@ -133,6 +168,7 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
     @Override
     public ${name}Entity save(${name}Entity entity) {
 #rollupGuardCheck()
+#aggregateGuardCheck()
 #if($hasLabel)
         computeName(entity);
 #end
@@ -192,6 +228,7 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
     @Override
     public ${name}Entity update(${name}Entity entity) {
 #rollupGuardCheck()
+#aggregateGuardCheck()
 #if($hasLabel)
         computeName(entity);
 #end

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
@@ -77,10 +77,12 @@ export function process(model, parameters) {
         e.referencedProjections = [];
 
         // Declarative checks (intent `checks:`): split by scope for the templates - row-level
-        // exactlyOne goes to the REST validate(), document-level (status-gated) to the repository.
+        // exactlyOne goes to the REST validate(), document-level (status-gated) to the repository,
+        // and guard (aggregate precondition) to the repository's create/update guard block.
         if (e.checks && e.checks.length) {
             e.rowChecks = e.checks.filter(c => c.kind === 'exactlyOne');
-            e.documentChecks = e.checks.filter(c => c.kind !== 'exactlyOne');
+            e.guardChecks = e.checks.filter(c => c.kind === 'guard');
+            e.documentChecks = e.checks.filter(c => c.kind !== 'exactlyOne' && c.kind !== 'guard');
         }
 
         const dataOrderByProperties = e.properties.filter(p => p.dataOrderBy !== undefined);


### PR DESCRIPTION
## checks: kind: guard - aggregate precondition (block outcome, config-gated)

Builds on the merged `aggregates:` primitive (#6407). A guard check blocks a create/update whose
**post-state would drop a keyed aggregate sum below a minimum** - the negative-stock / credit-limit
precondition.

```yaml
entities:
  - name: StockMovement
    fields:
      - { name: id, type: integer, primaryKey: true, generated: true }
      - { name: quantity, type: decimal }
    relations:
      - { name: Product, kind: manyToOne, to: Product }
      - { name: Store, kind: manyToOne, to: Store }
    checks:
      - kind: guard
        aggregate: onHand        # an aggregates: entry whose `of` is THIS entity
        minimum: 0               # recomputed(prior sum + this row) must stay >= minimum
        message: "Insufficient stock for this movement"
        enabledBy: BLOCK_NEGATIVE_STOCK   # optional; enforced only when the config == "true"
aggregates:
  - name: onHand
    of: StockMovement
    op: sum
    sum: quantity
    by: [Product, Store]
    into: ProductAvailability
    field: onHand
```

### How it works
The guard names an `aggregates:` entry over the **same** entity, so the sum is recomputed
**synchronously from the local store** for the incoming row's key-tuple (race-free - it does NOT read
the async-maintained target) - the same technique as the existing capacity `rollupGuard`. On
create/update it recomputes the prior sum (excluding this row), adds the incoming value, and throws
`ValidationException` (mapped to 4xx) when the result is below `minimum`. `enabledBy` wraps the whole
check in a `Configurations.get(key) == "true"` gate.

- `CheckIntent` - `aggregate` / `minimum` / `enabledBy` fields for `kind: guard`.
- `IntentParser.validateCheck` - the guard must name an existing `sum` aggregate over this entity.
- `EdmIntentGenerator.buildChecks` - resolves the guard to keys + `sumField` + pk + `minimum` +
  `enabledBy` on the entity's `checks` map.
- `parameterUtils.js` - splits `guardChecks` out to the repository (beside `documentChecks`).
- `Repository.java.template` - the `aggregateGuardCheck` macro at both save + update sites; imports
  deduped against the existing `rollupGuard` / document-check importers.

### Verification
- **engine-intent 86 tests** green, incl. the new `guardCheckEmitsKeyedAggregateGuard` (emission +
  both keys + `enabledBy`) and the parser suite (bad-aggregate / not-self-referential rejected).
- **Boot-verified end-to-end** on a real instance (client-Java synchronizer, generated
  `StockMovementRepository` carrying the config-gated guard in save + update):
  - **gate ON** (`-DBLOCK_NEGATIVE_STOCK=true`): `+10` ok (200), `-15` **BLOCKED (400)**, `-5` ok
    (200) -> `onHand = 5`;
  - **gate OFF** (reboot, same data): the same negative write **succeeds (200)** -> `onHand = -5`,
    proving both the block enforcement AND that `enabledBy` genuinely gates (not always-on).

### Scope / follow-ups (v1)
- The guarded entity is the aggregate's own source entity (covers negative-stock + credit-limit).
- `outcome` is `block` (throw 4xx). `task: <name>` (route to a hold task) and `reject: <status>`
  (auto-reject) are follow-ups - they need BPMN routing / a status flip.
- A guard whose keys live on a *different* entity than the aggregate source (read the materialized
  target instead of recomputing) is a follow-up.
