### PR TITLE
fix(intent): recompute the tuple an aggregate row LEFT when a grouping key moves

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGenerator.java
@@ -535,6 +535,33 @@ public class EdmIntentGenerator implements IntentTargetGenerator {
                 entityMap.put("labelExpression", entity.getLabel());
                 entityMap.put("labelParts", buildLabelParts(entity, byName));
             }
+            // An entity that is the SOURCE of an aggregate carries its grouping keys (the union across
+            // every aggregate over it) plus its pk, so the DAO can notice on update that a key MOVED and
+            // let the aggregate repair the tuple the row left behind. Recomputing the tuple it moved
+            // INTO is already event-driven; the tuple it left has no event of its own.
+            List<Map<String, String>> aggregateKeys = new ArrayList<>();
+            Set<String> seenAggregateKeys = new LinkedHashSet<>();
+            if (model.getAggregates() != null) {
+                for (AggregateIntent a : model.getAggregates()) {
+                    if (a.getOf() == null || !a.getOf()
+                                               .equals(entity.getName())) {
+                        continue;
+                    }
+                    for (String key : a.getBy()) {
+                        String fk = IntentNaming.pascalCase(key);
+                        if (seenAggregateKeys.add(fk)) {
+                            Map<String, String> pair = new LinkedHashMap<>();
+                            pair.put("key", fk);
+                            aggregateKeys.add(pair);
+                        }
+                    }
+                }
+            }
+            if (!aggregateKeys.isEmpty()) {
+                entityMap.put("aggregateKeys", aggregateKeys);
+                FieldIntent aggregatePk = primaryKeyOf(entity);
+                entityMap.put("aggregateSourcePk", aggregatePk == null ? "Id" : IntentNaming.pascalCase(aggregatePk.getName()));
+            }
             List<Map<String, Object>> checkMaps = buildChecks(entity, byName, model.getAggregates());
             if (!checkMaps.isEmpty()) {
                 // Declarative validations. A List, so it lives only in the .model twin (the scalar-only

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/edm/EdmIntentGeneratorTest.java
@@ -559,6 +559,18 @@ class EdmIntentGeneratorTest {
                                   .get("key"));
         // No authored outcome = block: the write fails. The two non-blocking outcomes are asserted below.
         assertEquals("block", guard.get("outcome"));
+
+        // The aggregate's SOURCE entity carries its grouping keys + pk, so the DAO can detect that a
+        // key moved and let the aggregate repair the tuple the row left (there is no event for it).
+        List<Map<String, String>> sourceKeys = (List<Map<String, String>>) movement.get("aggregateKeys");
+        assertEquals(2, sourceKeys.size(), "the aggregate source must carry every grouping key");
+        assertEquals("Product", sourceKeys.get(0)
+                                          .get("key"));
+        assertEquals("Store", sourceKeys.get(1)
+                                        .get("key"));
+        assertEquals("Id", movement.get("aggregateSourcePk"));
+        // The TARGET is not a source, so it carries no rekey metadata.
+        assertNull(entityByName(entities(model), "ProductAvailability").get("aggregateKeys"));
     }
 
     /**

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -241,6 +241,16 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
     public ${name}Entity update(${name}Entity entity) {
 #rollupGuardCheck()
 #aggregateGuardCheck()
+#if($aggregateKeys && $aggregateKeys.size() > 0)
+        // Aggregate rekey: this entity groups an aggregate, so a change to one of its grouping keys
+        // MOVES the row between tuples. The tuple it moves into is recomputed off the "-updated" event
+        // like any other change; the tuple it LEAVES has no event of its own, so capture the previous
+        // row here and publish it on the dedicated "-rekeyed" topic after the write (below). Only the
+        // aggregate handlers listen there, so no other reaction sees a second event.
+        ${name}Entity aggregatePrevious = findById(entity.${aggregateSourcePk});
+        boolean aggregateRekeyed = aggregatePrevious != null && (false#foreach($k in $aggregateKeys)
+                || !java.util.Objects.equals(aggregatePrevious.${k.key}, entity.${k.key})#end);
+#end
 #if($hasLabel)
         computeName(entity);
 #end
@@ -262,6 +272,14 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
         ${name}Entity updated = super.update(entity);
         // Publish the update event (suffixed topic) so intent reactions under gen/events can react.
         Producer.sendToTopic("${projectName}-${perspectiveName}-${name}-updated", Json.stringify(updated));
+#if($aggregateKeys && $aggregateKeys.size() > 0)
+        if (aggregateRekeyed) {
+            // Published AFTER the write, carrying the PREVIOUS row: the aggregate handler recomputes
+            // that row's old key-tuple from the store, which no longer contains this row, so the total
+            // it left behind drops instead of staying stale.
+            Producer.sendToTopic("${projectName}-${perspectiveName}-${name}-rekeyed", Json.stringify(aggregatePrevious));
+        }
+#end
 #if($documentItem)
         // Keep the document consistent: synchronously recompute the master's totals (no async roll-up).
         new ${documentItem.parentEntity}Repository().recalculate(updated.${documentItem.fkProperty});

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Aggregate.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Aggregate.java.template
@@ -19,9 +19,14 @@ import gen.${javaGenFolderName}.data.${targetJavaPerspective}.${targetEntity}Rep
  * each source ${sourceEntity} event the target row for the incoming row's key-tuple is upserted and the
  * aggregate recomputed from the store over every source row sharing that tuple (self-healing +
  * idempotent - re-delivery or replay converges to the same value). A source row with any grouping key
- * null is ignored (it belongs to no tuple). v1: same-model source + target, sum/count into a decimal
- * target field; a key change on update recomputes the NEW tuple (append-only ledgers - the primary use
- * - never edit keys, so the old-tuple recompute is a documented follow-up).
+ * null is ignored (it belongs to no tuple).
+ *
+ * A key change MOVES a row between tuples, and both sides are repaired: the tuple it moved into is
+ * recomputed off the "-updated" event like any other change, while the DAO publishes the PREVIOUS row
+ * on "-rekeyed" (only when a grouping key actually moved), which the OnRekey copy of this handler
+ * recomputes - the former tuple no longer contains the row, so its total drops instead of going stale.
+ * A tuple whose last contributing row leaves keeps its target row with a zero total; the row is not
+ * deleted. v1: same-model source + target, sum/count into a decimal target field.
  */
 @Component("${javaGenFolderName}_${className}")
 public class ${className} implements MessageHandler {

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1113,10 +1113,16 @@ export function generateFiles(model, parameters, templateSources) {
                     // so the template stays shape-only. v1: same-model, uniform BigDecimal accumulation
                     // into a decimal target field (sum adds the field, count adds ONE).
                     if (model.aggregates) {
+                        // The -rekeyed variant is this same handler fed the PREVIOUS row: the DAO
+                        // publishes that topic only when a grouping key actually moved, and
+                        // recomputing the former tuple from the store (which no longer contains the
+                        // row) drops the total it left behind. Without it, editing a grouping key
+                        // leaves a stale aggregate on the tuple the row moved out of.
                         const aggVariants = [
                             { suffix: "", cls: "OnCreate" },
                             { suffix: "-updated", cls: "OnUpdate" },
-                            { suffix: "-deleted", cls: "OnDelete" }
+                            { suffix: "-deleted", cls: "OnDelete" },
+                            { suffix: "-rekeyed", cls: "OnRekey" }
                         ];
                         for (let i = 0; i < model.aggregates.length; i++) {
                             const ag = model.aggregates[i];

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -634,11 +634,29 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertFalse(ledgerAggregate.contains("targets.update(target)"),
                 "a keyed aggregate must not merge the whole materialised row back (lost update)");
 
+        // A grouping-key change MOVES a row between tuples. The tuple it moved into is recomputed off
+        // the "-updated" event; the tuple it LEFT has no event of its own, so the DAO publishes the
+        // PREVIOUS row on "-rekeyed" (only when a key actually moved) and a fourth copy of the handler
+        // recomputes that former tuple - otherwise it keeps the moved row's contribution forever.
+        String ledgerRepository = contentOf("gen/emission/data/ledger/LedgerRepository.java");
+        assertTrue(
+                ledgerRepository.contains("aggregatePrevious = findById(entity.Id)")
+                        && ledgerRepository.contains("java.util.Objects.equals(aggregatePrevious.Person, entity.Person)")
+                        && ledgerRepository.contains("java.util.Objects.equals(aggregatePrevious.Unit, entity.Unit)"),
+                "an aggregate source must compare EVERY grouping key against the previous row on update");
+        assertTrue(
+                ledgerRepository.contains("if (aggregateRekeyed)")
+                        && ledgerRepository.contains("-rekeyed\", Json.stringify(aggregatePrevious)"),
+                "a moved grouping key must publish the PREVIOUS row on the -rekeyed topic");
+        String ledgerRekey = contentOf("gen/events/emission/LedgerTotalAggregateOnRekey.java");
+        assertTrue(ledgerRekey.contains("-Ledger-rekeyed"), "the rekey handler must bind the source's -rekeyed topic");
+        assertTrue(ledgerRekey.contains("targets.updateDerived("),
+                "the rekey handler must repair the former tuple through the targeted derived write");
+
         // checks: kind: guard - the aggregate precondition, one assertion per outcome. The guard
         // recomputes the keyed sum from the GUARDED entity's own store (race-free, not the async
         // aggregate target), then acts. block fails the write behind its config gate; task and reject
         // both PERSIST the row and mark it instead of throwing.
-        String ledgerRepository = contentOf("gen/emission/data/ledger/LedgerRepository.java");
         assertTrue(ledgerRepository.contains("Criteria.create().eq(\"Person\", entity.Person).eq(\"Unit\", entity.Unit)"),
                 "a guard must recompute its aggregate over the incoming row's full key-tuple");
         assertTrue(ledgerRepository.contains("throw new ValidationException(\"Insufficient balance\")"),


### PR DESCRIPTION
> **Stacked on #6418** (which is stacked on #6417). Retarget down the stack as each merges.

## The defect

A keyed aggregate recomputed the tuple a source row moved **into** and left the tuple it came **from** holding that row's contribution forever. Edit a movement's `Store`, or a booking's `Person`, and the old tuple keeps a total that no longer has any rows behind it.

#6407 shipped this knowingly as a follow-up, on the grounds that the primary use is append-only ledgers. It matters more now than it did then: **`checks: kind: guard` reads these totals** (#6416, #6418), so a stale tuple is a wrong *decision*, not merely a wrong screen.

## Why the fix has to live in the DAO

The old keys are not in the `-updated` payload, and they cannot be reconstructed after the write - nothing records where the row used to be. So they are captured in the one place they still exist: **in the repository, immediately before the write.**

| Piece | Change |
| --- | --- |
`EdmIntentGenerator` | an entity that is the SOURCE of an aggregate now carries `aggregateKeys` (the union of grouping keys across every aggregate over it) and `aggregateSourcePk` |
`Repository.java.template` `update()` | re-reads the row, compares every grouping key, and after a successful write publishes the PREVIOUS row on `<project>-<perspective>-<Entity>-rekeyed` - **only when a key actually moved**, so the ordinary update path costs one read and no extra event |
`generateUtils.js` | a fourth handler variant, `<Name>AggregateOnRekey`, bound to that topic |

The fourth variant needs **no new template**: recomputing "the tuple of the row in the payload" is already exactly the repair, because by the time the event is handled the store no longer contains that row under those keys. Feeding the old row to the existing handler drops the total it left behind.

**A dedicated topic** rather than a second `-updated` or a synthetic `-deleted`: only aggregate handlers subscribe to `-rekeyed`, so no roll-up, notification or integration sees a phantom event for a row that still exists.

## Scope stated honestly

- A tuple whose **last** contributing row leaves keeps its target row with a zero total; the row is not deleted. Unchanged from the delete path.
- A grouping key changed through a **targeted write** (`updateProperty` / `updateProperties`, i.e. a workflow setter) still moves no tuple, because those paths raise no entity event at all. That is a pre-existing property of targeted writes, not something this PR introduces - and it is why the fix hooks `update()` rather than the store layer.

## Verification

- engine-intent **226/226**, including that the aggregate **source** carries every grouping key plus its pk and that the aggregate **target** carries none of that metadata.
- **`IntentEmissionCoverageIT` green**: the generated repository compares EVERY grouping key against the previous row (`Person` and `Unit` for the fixture's two-key aggregate) and publishes it on `-rekeyed`; the `LedgerTotalAggregateOnRekey` handler binds that topic and repairs the former tuple through the targeted derived write. 0 javac errors, so the fourth handler compiles and registers.

Not verified: a live rekey round-trip (create in tuple A, move to tuple B, assert A drops and B rises). The emission plus the handler's existing runtime coverage is the layer reached here; the live check belongs with the inventory adoption, where a real two-key aggregate exists.

## Docs

The spec proposal (IntentFile/intent-specification#1) lists this limitation under *Planned* for version 1.1; both it and the two doc sites are being updated in the same effort now that the behaviour is specified rather than deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
