### PR TITLE
fix(intent): humanize treats hyphens/underscores as word separators

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentNaming.java
@@ -221,8 +221,10 @@ public final class IntentNaming {
     /**
      * Turn a camel-/Pascal-case identifier into a human-readable Title Case label by splitting on case
      * boundaries ({@code librarianReview} -> {@code Librarian Review}, {@code LoanApproval} ->
-     * {@code Loan Approval}). Used for BPMN display names (process and task {@code name}) while the
-     * machine ids stay the compact identifier.
+     * {@code Loan Approval}). Hyphens and underscores are word separators too, so kebab-case project
+     * names read naturally ({@code sales-invoices} -> {@code Sales Invoices}, not
+     * {@code Sales-invoices}). Used for BPMN display names (process and task {@code name}) and as the
+     * default app/brand title, while the machine ids stay the compact identifier.
      *
      * @param name the identifier to humanize (may be null)
      * @return the spaced Title Case label, empty for null/empty input
@@ -234,6 +236,19 @@ public final class IntentNaming {
         String override = HUMANIZE_OVERRIDES.get(name.toLowerCase(Locale.ROOT));
         if (override != null) {
             return override;
+        }
+        if (name.indexOf('-') >= 0 || name.indexOf('_') >= 0) {
+            StringBuilder joined = new StringBuilder(name.length() + 8);
+            for (String segment : name.split("[-_]+")) {
+                if (segment.isEmpty()) {
+                    continue;
+                }
+                if (joined.length() > 0) {
+                    joined.append(' ');
+                }
+                joined.append(humanize(segment));
+            }
+            return joined.toString();
         }
         StringBuilder out = new StringBuilder(name.length() + 8);
         for (int i = 0; i < name.length(); i++) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntentNamingTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/IntentNamingTest.java
@@ -59,6 +59,25 @@ class IntentNamingTest {
     }
 
     @Test
+    void humanizeTreatsHyphensAndUnderscoresAsWordSeparators() {
+        // A kebab-case project name is the default app/brand title - it must read as a product
+        // name ("Sales Invoices"), not a half-capitalized identifier ("Sales-invoices").
+        assertEquals("Sales Invoices", IntentNaming.humanize("sales-invoices"));
+        assertEquals("Customer Payments", IntentNaming.humanize("customer-payments"));
+        assertEquals("Payment Methods", IntentNaming.humanize("payment_methods"));
+        assertEquals("Products", IntentNaming.humanize("products"));
+        assertEquals("A B", IntentNaming.humanize("a--b"));
+    }
+
+    @Test
+    void humanizeKeepsCamelCaseAndOverrideBehavior() {
+        assertEquals("Librarian Review", IntentNaming.humanize("librarianReview"));
+        assertEquals("Loan Approval", IntentNaming.humanize("LoanApproval"));
+        assertEquals("Unit of Measure", IntentNaming.humanize("UoM"));
+        assertEquals("", IntentNaming.humanize(null));
+    }
+
+    @Test
     void upperSnakeDoesNotLeaveDanglingOrDoubledUnderscores() {
         assertEquals("A_B", IntentNaming.upperSnake("a--b"));
         assertEquals("AB", IntentNaming.upperSnake("ab-"));


### PR DESCRIPTION
## What

`IntentNaming.humanize()` splits camel-case boundaries but ignored `-`/`_`, so a kebab-case project name — the default app/brand title of the generated Harmonia shell (`appTitle` falls back to the project name), the page `<title>`, and BPMN display names — rendered half-capitalized: **"Sales-invoices"**, **"Customer-payments"**.

`humanize()` now treats hyphens and underscores as word separators: each segment is humanized on its own (overrides such as `uom` → "Unit of Measure" still apply) and segments are joined with spaces:

- `sales-invoices` → **Sales Invoices**
- `customer-payments` → **Customer Payments**
- `payment_methods` → **Payment Methods**
- camel/Pascal inputs unchanged (`LoanApproval` → **Loan Approval**)

An explicit `title:` in the intent still wins — this only fixes the derived default.

## Verification

- New `IntentNamingTest` cases: hyphen/underscore splitting, override + camel behavior preserved, null/empty safe.
- Full `engine-intent` suite: 228 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)