### PR TITLE
feat(intent): a roll-up may maintain a field on a cross-model parent

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -93,7 +93,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
         List<Map<String, Object>> schedules = buildSchedules(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> integrations = buildIntegrations(model, byName, compositionParents, settings);
         List<Map<String, Object>> inbound = buildInbound(model, byName, compositionParents, settings);
-        List<Map<String, Object>> rollups = buildRollups(model, byName, compositionParents, settings);
+        List<Map<String, Object>> rollups = buildRollups(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> expansions = buildExpansions(model, byName, compositionParents, settings);
         List<Map<String, Object>> settlements = buildSettlements(model, byName, compositionParents, settings, context);
         List<Map<String, Object>> generates = buildGenerates(model, byName, compositionParents, settings, context);
@@ -396,7 +396,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     }
 
     private static List<Map<String, Object>> buildRollups(IntentModel model, Map<String, EntityIntent> byName,
-            Map<String, String> compositionParents, IntentSettings settings) {
+            Map<String, String> compositionParents, IntentSettings settings, IntentGenerationContext context) {
         List<Map<String, Object>> rollups = new ArrayList<>();
         for (RollupIntent rollup : model.getRollups()) {
             if (rollup.getName() == null || rollup.getName()
@@ -406,7 +406,32 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             EntityIntent child = byName.get(rollup.getEntity());
             RelationIntent via = child == null ? null : toOneRelation(child, rollup.getVia());
             EntityIntent parent = via == null ? null : byName.get(via.getTo());
-            if (parent == null) {
+            // A CROSS-MODEL parent: the child is local (it owns the event this handler binds to), the
+            // parent is owned by another model and reached through `uses`. Its coordinates therefore come
+            // from the OWNER's .model, exactly as a cross-model relation target does - the local byName
+            // has no entry for it, which is why such a roll-up used to be impossible to express.
+            boolean crossModelParent = via != null && via.getModel() != null && !via.getModel()
+                                                                                    .isBlank();
+            CrossModelSupport.TargetInfo parentTarget = null;
+            if (crossModelParent) {
+                UsesIntent uses = findUses(model, via.getModel());
+                if (uses == null) {
+                    reportDroppedGlue(context, "Roll-up [" + rollup.getName() + "] reaches its parent through model [" + via.getModel()
+                            + "], which is not declared in uses - not generated");
+                    continue;
+                }
+                parentTarget = CrossModelSupport.resolve(context, uses, via.getTo());
+                String counter = IntentNaming.pascalCase(rollup.getField());
+                if (parentTarget.resolved() && parentTarget.propertyNames() != null && !parentTarget.propertyNames()
+                                                                                                    .contains(counter)) {
+                    // The owner model WAS read and carries no such property. The parser cannot catch this
+                    // (the entity is not local), so surface it here rather than emit a handler that would
+                    // fail the client-Java batch.
+                    reportDroppedGlue(context, "Roll-up [" + rollup.getName() + "] field [" + rollup.getField()
+                            + "] is not a property of cross-model parent [" + via.getModel() + ":" + via.getTo() + "] - not generated");
+                    continue;
+                }
+            } else if (parent == null) {
                 continue; // parser already reported the bad reference
             }
             if (!settings.shouldGenerate("rollups", rollup.getName())) {
@@ -441,8 +466,13 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             base.put("childPerspective",
                     child.isSetting() ? "Settings" : IntentEntities.resolvePerspective(rollup.getEntity(), compositionParents));
             base.put("parentEntity", via.getTo());
-            base.put("parentPerspective",
-                    parent.isSetting() ? "Settings" : IntentEntities.resolvePerspective(via.getTo(), compositionParents));
+            // A cross-model parent's perspective comes from the owner's model (resolved above); a local
+            // one from this model's own composition/setting layout.
+            base.put("parentPerspective", crossModelParent ? parentTarget.perspectiveName()
+                    : parent.isSetting() ? "Settings" : IntentEntities.resolvePerspective(via.getTo(), compositionParents));
+            // Empty for a local parent - generateUtils then falls back to this project's gen folder.
+            base.put("parentModel", crossModelParent ? via.getModel() : "");
+            base.put("parentCrossModel", crossModelParent);
             base.put("fkProperty", fkProperty);
             base.put("countField", IntentNaming.pascalCase(rollup.getField()));
             base.put("op", op);
@@ -759,7 +789,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
 
     /** Test hook: build the {@code rollups} glue collection without a repository. */
     static List<Map<String, Object>> buildRollupsForTest(IntentModel model) {
-        return buildRollups(model, IntentEntities.byName(model), IntentEntities.compositionParents(model), IntentSettings.parse("{}"));
+        return buildRollups(model, IntentEntities.byName(model), IntentEntities.compositionParents(model), IntentSettings.parse("{}"),
+                null);
     }
 
     /** Test hook: build the {@code waits} glue collection without a repository. */

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/parser/IntentParser.java
@@ -831,10 +831,34 @@ public final class IntentParser {
                 issues.add("rollup [" + name + "] via [" + rollup.getVia() + "] is not a to-one relation of [" + rollup.getEntity() + "]");
                 continue;
             }
-            EntityIntent parent = byName.get(via.getTo());
-            FieldIntent counter = parent == null ? null : fieldByName(parent, rollup.getField());
             boolean sum = "sum".equals(rollup.getOp());
             boolean latest = "latest".equals(rollup.getOp());
+            if (via.getModel() != null && !via.getModel()
+                                              .isBlank()) {
+                // A CROSS-MODEL parent (the roll-up maintains a field on an entity another model owns).
+                // Its properties are not in this document, so they are validated at GENERATION time
+                // against the owner's model - the same split every cross-model reference uses. Only the
+                // capacity/balance/status variants stay local-only: they need the parent's own status
+                // seeds and stamp a capacity guard that reads the parent's table, which is a deeper
+                // change than resolving coordinates.
+                if (rollup.getCapacity() != null || rollup.getBalance() != null || rollup.getStatus() != null) {
+                    issues.add("rollup [" + name + "] maintains a cross-model parent [" + via.getModel() + ":" + via.getTo()
+                            + "], so capacity / balance / status are not supported - keep those in the model that owns the parent");
+                }
+                if (sum && (rollup.getOf() == null || rollup.getOf()
+                                                            .isBlank())) {
+                    issues.add("rollup [" + name + "] with op: sum requires `of`");
+                }
+                if (latest && (rollup.getOf() == null || rollup.getOf()
+                                                               .isBlank()
+                        || rollup.getBy() == null || rollup.getBy()
+                                                           .isBlank())) {
+                    issues.add("rollup [" + name + "] with op: latest requires both `of` and `by`");
+                }
+                continue;
+            }
+            EntityIntent parent = byName.get(via.getTo());
+            FieldIntent counter = parent == null ? null : fieldByName(parent, rollup.getField());
             if (counter == null) {
                 issues.add("rollup [" + name + "] field [" + rollup.getField() + "] is not a field of parent [" + via.getTo() + "]");
             } else if (sum && !NUMERIC_TYPES.contains(counter.getType())) {

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueRollupCrossModelTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueRollupCrossModelTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.eclipse.dirigible.components.intent.parser.IntentValidationException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A roll-up whose PARENT is owned by another model: the child owns the event the handler binds to,
+ * while the parent's package and perspective come from the owner's model. This was impossible
+ * before - the parser rejected the roll-up because the parent entity is not in the local document,
+ * so the canonical case (actual hours summed from a time-tracking model onto a project the projects
+ * model owns) had no declarative form at all.
+ *
+ * With a null generation context the cross-model resolution falls back to the naming-convention
+ * defaults, which is deterministic and enough to assert the emitted coordinates.
+ */
+class GlueRollupCrossModelTest {
+
+    private static final String YAML = """
+            name: timesheets
+            uses:
+              - { model: projects }
+            entities:
+              - name: DayAllocation
+                fields:
+                  - { name: id,    type: integer, primaryKey: true, generated: true }
+                  - { name: hours, type: decimal }
+                relations:
+                  - { name: Project, kind: manyToOne, to: Project, model: projects }
+            rollups:
+              - { name: projectActualHours, entity: DayAllocation, via: Project, field: actualHours,
+                  op: sum, of: hours }
+            """;
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void aCrossModelParentResolvesToTheOwnerModelsPackage() {
+        IntentModel model = IntentParser.parse(YAML);
+        List<Map<String, Object>> rollups = GlueIntentGenerator.buildRollupsForTest(model);
+
+        // create + update + delete variants of the same roll-up.
+        assertTrue(rollups.size() >= 1, "a cross-model roll-up must be emitted, got: " + rollups.size());
+        Map<String, Object> first = rollups.get(0);
+        assertEquals("DayAllocation", first.get("childEntity"));
+        assertEquals("Project", first.get("parentEntity"));
+        assertEquals("Project", first.get("fkProperty"));
+        assertEquals("ActualHours", first.get("countField"));
+        assertEquals("sum", first.get("op"));
+        assertEquals("Hours", first.get("sumField"));
+        // The parent is reached through `uses: projects`, so the handler must import from THAT model's
+        // generated package - an unset parentModel would silently emit the local one and fail to compile.
+        assertEquals(Boolean.TRUE, first.get("parentCrossModel"));
+        assertEquals("projects", first.get("parentModel"));
+    }
+
+    @Test
+    void aLocalParentCarriesNoCrossModelCoordinates() {
+        String local = """
+                name: library
+                entities:
+                  - name: Member
+                    fields:
+                      - { name: id,        type: integer, primaryKey: true, generated: true }
+                      - { name: loanCount, type: integer }
+                  - name: Loan
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                    relations:
+                      - { name: Member, kind: manyToOne, to: Member }
+                rollups:
+                  - { name: memberLoanCount, entity: Loan, via: Member, field: loanCount }
+                """;
+        Map<String, Object> first = GlueIntentGenerator.buildRollupsForTest(IntentParser.parse(local))
+                                                       .get(0);
+        assertEquals(Boolean.FALSE, first.get("parentCrossModel"));
+        assertEquals("", first.get("parentModel"), "a local parent must leave the model empty so the local gen folder is used");
+    }
+
+    @Test
+    void capacityBalanceAndStatusStayLocalOnly() {
+        // These stamp a capacity guard that reads the parent's table and reference the parent's own
+        // status seeds; supporting them across models is a deeper change than resolving coordinates, so
+        // they are rejected with a message that says where to put them instead.
+        String withCapacity = YAML.replace("op: sum, of: hours }", "op: sum, of: hours, capacity: budgetHours, balance: remainingHours }");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(withCapacity));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("capacity / balance / status are not supported")),
+                "expected a cross-model capacity issue, got: " + ex.getIssues());
+    }
+
+    @Test
+    void aParentModelThatIsNotDeclaredInUsesIsRejected() {
+        String undeclared = YAML.replace("uses:\n  - { model: projects }\n", "");
+        IntentValidationException ex = assertThrows(IntentValidationException.class, () -> IntentParser.parse(undeclared));
+        assertTrue(ex.getIssues()
+                     .stream()
+                     .anyMatch(i -> i.contains("projects")),
+                "an undeclared parent model must be reported, got: " + ex.getIssues());
+    }
+}

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/Rollup.java.template
@@ -8,11 +8,13 @@ import org.eclipse.dirigible.sdk.utils.Json;
 
 import gen.${javaGenFolderName}.data.${javaChildPerspective}.${childEntity}Entity;
 import gen.${javaGenFolderName}.data.${javaChildPerspective}.${childEntity}Repository;
-import gen.${javaGenFolderName}.data.${javaParentPerspective}.${parentEntity}Entity;
-import gen.${javaGenFolderName}.data.${javaParentPerspective}.${parentEntity}Repository;
+import gen.${parentGenFolder}.data.${javaParentPerspective}.${parentEntity}Entity;
+import gen.${parentGenFolder}.data.${javaParentPerspective}.${parentEntity}Repository;
 
 /**
- * Maintains the ${parentEntity} roll-up field(s) over ${childEntity} rows.
+ * Maintains the ${parentEntity} roll-up field(s) over ${childEntity} rows. The parent may be owned by
+ * ANOTHER model (a cross-model roll-up): the child owns the event, the parent's package and
+ * perspective come from the owner's model, and the write goes through the owner's repository.
  *
  * Generated from the intent rollups block - do not edit; it is re-generated with the application. Every
  * roll-up that shares this child entity + parent relation is COALESCED into this single handler, so one

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -887,6 +887,11 @@ export function generateFiles(model, parameters, templateSources) {
                                 javaChildPerspective: sanitizeJavaIdentifier(first.childPerspective),
                                 parentEntity: first.parentEntity,
                                 javaParentPerspective: sanitizeJavaIdentifier(first.parentPerspective),
+                                // A cross-model roll-up writes into the OWNER model's generated package;
+                                // a local one stays in this project's gen folder.
+                                parentGenFolder: first.parentCrossModel
+                                    ? sanitizeJavaIdentifier(first.parentModel)
+                                    : parameters.javaGenFolderName,
                                 fkProperty: first.fkProperty,
                                 topicSuffix: first.topicSuffix || "",
                                 criteriaExpression: first.criteriaExpression,


### PR DESCRIPTION
## The gap

A roll-up whose parent lives in another model was not merely unimplemented - it **failed validation**. `validateRollups` resolved the parent through the local `byName`, and a cross-model parent is not in the local document, so the intent was rejected with *"field is not a field of parent"*.

So the canonical case had no declarative form at all: hours summed from a time-tracking model onto a project that the projects model owns. Downstream that total is currently either hand-maintained or simply absent.

## The shape

The child stays **local** - it owns the event the handler binds to - while the parent's coordinates come from the owner's model, exactly as any cross-model relation target does:

```yaml
uses:
  - { model: projects }
entities:
  - name: DayAllocation
    relations:
      - { name: Project, kind: manyToOne, to: Project, model: projects }
rollups:
  - { name: projectActualHours, entity: DayAllocation, via: Project, field: actualHours, op: sum, of: hours }
```

| Piece | Change |
| --- | --- |
`IntentParser.validateRollups` | a cross-model `via` defers the parent-field check to generation (the standard local-vs-cross-model split) while still validating the op's own requirements locally, so a typo in `of` / `by` is caught immediately |
`GlueIntentGenerator.buildRollups` | now takes the `IntentGenerationContext` - it was the **only** builder without it, which is precisely why cross-model resolution was impossible here - and resolves the parent via `CrossModelSupport` |
`Rollup.java.template` | imports the parent from `${parentGenFolder}` instead of the local gen folder |
`generateUtils.js` | forwards `parentGenFolder`, defaulting to this project for a local parent |

## Two limits, surfaced rather than silent

- **`capacity` / `balance` / `status` stay local-only.** They read the parent's own limit and status seeds and stamp the capacity guard on the child. Authoring them against a cross-model parent is now a validation error that names where to put them instead, rather than quietly generating a partial roll-up.
- **An undeclared model, or a field the owner's model does not have,** is reported through `reportDroppedGlue` into the generate response's issues - the #6391 pattern - instead of emitting a handler that would fail the all-or-nothing client-Java batch.

## Verification

- engine-intent **230/230**, including a new `GlueRollupCrossModelTest`: the emitted cross-model coordinates, that a local parent carries none of them, and both rejection paths.
- **`IntentEmissionCoverageIT` green** on this base. It is the gate that matters for the template edit: an unforwarded `${parentGenFolder}` would render literally, break the emitted imports, and take the whole client-Java batch down - so the layer-2 REST assertions would fail.
- `formatter:validate` clean.
- `IntentEngineIT` (which asserts the local roll-up handler shape this template edit touches) is running locally as I open this; the PR gate runs it too, so CI is the second independent check.

## Not verified

**A live two-model compile of an emitted cross-model roll-up.** No integration test in this repo publishes two models, so cross-model generation has no IT coverage at all - the emitted coordinates are proven at the unit layer, and the local path by the ITs. The precedent for this class (#6391, cross-model notify recipients) was manual boot verification, which belongs with the first real adoption where two models exist. A two-project IT fixture would close it for every cross-model construct at once and is worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
