### PR TITLE
fix(registry): stop the watch loop before closing the watch service (shutdown deadlock)

### DIFF
--- a/components/core/core-registry/src/main/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcher.java
+++ b/components/core/core-registry/src/main/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcher.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
@@ -55,6 +57,9 @@ public class LocalRegistryWatcher implements DisposableBean {
     /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(LocalRegistryWatcher.class);
 
+    /** How long destroy() waits for the watch loop to leave before closing the service. */
+    private static final long SHUTDOWN_TIMEOUT_SECONDS = 5;
+
     /** The key to path map. */
     private final Map<WatchKey, Path> keyToPathMap = new HashMap<>();
 
@@ -69,6 +74,28 @@ public class LocalRegistryWatcher implements DisposableBean {
 
     /** The executor service. */
     private ExecutorService executorService;
+
+    /**
+     * Whether the watch loop should keep taking events. Cleared by {@link #destroy()} BEFORE the
+     * service is closed, so the loop leaves on its own terms instead of being torn out from under a
+     * blocking {@code take()} - see the shutdown-order note on {@link #destroy()}.
+     */
+    private volatile boolean watching;
+
+    /**
+     * The thread running the watch loop, kept so shutdown can be observed (and asserted) rather than
+     * only assumed. Set when the loop starts, cleared when it leaves.
+     */
+    private volatile Thread watchThread;
+
+    /**
+     * How the watch loop last left: {@code interrupted} (shutdown asked it to stop - the correct
+     * order), {@code closed} (the service was closed underneath a blocking {@code take()} - the order
+     * that deadlocks on macOS), or {@code null} if it left on the cleared flag. Read by the shutdown
+     * test, which is how "the loop was stopped BEFORE the service was closed" becomes an assertion
+     * instead of a comment.
+     */
+    private volatile String lastExitCause;
 
     /** The repository. */
     private final IRepository repository;
@@ -108,7 +135,9 @@ public class LocalRegistryWatcher implements DisposableBean {
                 if (this.watchService != null) {
                     logger.warn(
                             "Local Registry Watcher has been initialized already. Existing watcher will be closed and a new one will be created.");
-                    destroy();
+                    // Only the service: this runs ON the watcher thread, so shutting the executor down
+                    // and awaiting it (what destroy() does) would be this thread waiting for itself.
+                    closeWatchService();
                 }
 
                 this.watchService = FileSystems.getDefault()
@@ -259,8 +288,55 @@ public class LocalRegistryWatcher implements DisposableBean {
     public void startWatching() throws IOException, InterruptedException {
         logger.info("Recursively watching: " + sourceDir);
 
-        while (true) {
-            WatchKey key = watchService.take();
+        watching = true;
+        watchThread = Thread.currentThread();
+        try {
+            watchLoop();
+        } finally {
+            watching = false;
+            watchThread = null;
+        }
+    }
+
+    /**
+     * Whether the watch loop is still running. Package-private: the shutdown test asserts the loop is
+     * actually gone after {@link #destroy()} instead of trusting that it is.
+     *
+     * @return true while the watch thread is inside the loop
+     */
+    boolean isWatching() {
+        Thread thread = watchThread;
+        return watching && thread != null && thread.isAlive();
+    }
+
+    /**
+     * How the watch loop last left. Package-private for the shutdown test.
+     *
+     * @return {@code interrupted}, {@code closed}, or {@code null} - see {@link #lastExitCause}
+     */
+    String getLastExitCause() {
+        return lastExitCause;
+    }
+
+    /**
+     * The event loop itself. Leaves on a cleared {@code watching} flag, on an interrupt, or on a closed
+     * service - so a shutdown never has to tear the loop out of a blocking {@code take()}.
+     *
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    private void watchLoop() throws IOException {
+        while (watching) {
+            WatchKey key;
+            try {
+                key = watchService.take();
+            } catch (ClosedWatchServiceException | InterruptedException e) {
+                // The normal way out: destroy() cleared `watching` and interrupted this thread (or, in
+                // the legacy order, closed the service under us). Either way there is nothing left to
+                // watch - leave the loop so the service can be closed with no poller inside it.
+                lastExitCause = e instanceof InterruptedException ? "interrupted" : "closed";
+                logger.debug("Local Registry Watcher stopped watching ({}): {}", lastExitCause, e.getMessage());
+                return;
+            }
             Path dir = keyToPathMap.get(key);
             if (dir == null) {
                 logger.error("WatchKey not recognized!");
@@ -431,20 +507,60 @@ public class LocalRegistryWatcher implements DisposableBean {
     /**
      * Destroy.
      *
+     * <p>
+     * <b>Order matters: stop the watching thread FIRST, close the service second.</b> Closing the
+     * service while the thread sits in {@code take()} deadlocks on macOS, where the JDK has no native
+     * file-event source and falls back to {@code sun.nio.fs.PollingWatchService}: its {@code close()}
+     * walks the registered keys and locks each one while holding the key map, whereas the polling
+     * thread locks a key first and then the map - a lock-order inversion, and Spring's singleton
+     * teardown hangs for good (every {@code @DirtiesContext} integration test on a developer's Mac).
+     * Linux and Windows have native watchers and never showed it.
+     *
+     * <p>
+     * So: clear {@code watching}, {@code shutdownNow()} to interrupt the blocking {@code take()} (the
+     * loop returns on the {@code InterruptedException}), wait briefly for the thread to actually be
+     * gone, and only then close the service - by which point no one is inside it.
+     *
      * @throws IOException Signals that an I/O exception has occurred.
      */
     @Override
     public void destroy() throws IOException {
         logger.info("Destroying Local Registry Watcher");
 
-        if (null != watchService) {
-            watchService.close();
-            watchService = null;
+        watching = false;
+
+        ExecutorService executor = this.executorService;
+        this.executorService = null;
+        if (null != executor) {
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    // Not fatal: the watch loop only reads the file system, so a straggler cannot
+                    // corrupt anything. Say so instead of closing the service on top of it silently.
+                    logger.warn("The Local Registry Watcher thread did not stop within [{}]s - closing the watch service anyway",
+                            SHUTDOWN_TIMEOUT_SECONDS);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread()
+                      .interrupt();
+                logger.warn("Interrupted while waiting for the Local Registry Watcher thread to stop", e);
+            }
         }
 
-        if (null != executorService) {
-            executorService.shutdown();
-            executorService = null;
+        closeWatchService();
+    }
+
+    /**
+     * Close the watch service, if any. Split out of {@link #destroy()} because the re-initialization
+     * path runs on the watcher thread itself and must not shut down the executor it is running in.
+     *
+     * @throws IOException if the close fails
+     */
+    private void closeWatchService() throws IOException {
+        WatchService service = this.watchService;
+        this.watchService = null;
+        if (null != service) {
+            service.close();
         }
     }
 }

--- a/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcherShutdownTest.java
+++ b/components/core/core-registry/src/test/java/org/eclipse/dirigible/components/registry/watcher/LocalRegistryWatcherShutdownTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.registry.watcher;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+
+import org.eclipse.dirigible.repository.api.IRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Shutting the watcher down must stop the watch loop and leave no thread behind.
+ *
+ * <p>
+ * The watch loop blocks in {@code WatchService.take()}. Closing the service from another thread
+ * while it sits there deadlocks on macOS, where the JDK has no native file-event source and falls
+ * back to {@code sun.nio.fs.PollingWatchService}: its {@code close()} locks each registered key
+ * while holding the key map, while the polling thread locks a key first and then the map. Spring's
+ * singleton teardown then hangs for good, which took out {@code @DirtiesContext} integration tests
+ * on a developer's Mac. The fix is the ORDER: stop the loop, then close the service.
+ *
+ * <p>
+ * <b>What this test does and does not prove.</b> The deadlock needs the polling thread to be inside
+ * a poll at the moment of {@code close()} - a race a unit test cannot force (verified: the old
+ * order still passes a pure timeout assertion). So this asserts the ORDERING'S OBSERVABLE EFFECTS,
+ * which hold deterministically: {@code destroy()} returns, the watch loop is gone afterwards (not
+ * merely signalled), it is idempotent, and the watcher can be initialized again. A hang, a
+ * surviving watch thread, or a wedged second call all fail here. The deadlock itself was diagnosed
+ * from a thread dump (lock-order inversion between {@code main} and {@code FileSystemWatcher}), not
+ * from this test.
+ */
+class LocalRegistryWatcherShutdownTest {
+
+    /** How long to wait for the loop to finish the initial sync and enter take(). */
+    private static final Duration SETTLE = Duration.ofSeconds(10);
+
+    /**
+     * Generous next to destroy()'s own 5s await - a deadlock never returns, so any bound catches it.
+     */
+    private static final Duration SHUTDOWN_BOUND = Duration.ofSeconds(30);
+
+    @Test
+    void destroyReturnsWhileTheWatchLoopIsBlockedInTake(@TempDir Path root) throws Exception {
+        Path registryPublic = Files.createDirectories(root.resolve("registry")
+                                                          .resolve("public"));
+        Files.createDirectory(registryPublic.resolve("a-project"));
+        IRepository repository = mock(IRepository.class);
+        when(repository.getInternalResourcePath(anyString())).thenReturn(registryPublic.toString());
+
+        LocalRegistryWatcher watcher = new LocalRegistryWatcher(repository, List.of());
+        watcher.initialize();
+        awaitWatching(watcher);
+
+        assertTimeoutPreemptively(SHUTDOWN_BOUND, watcher::destroy,
+                "destroy() must stop the watch loop before closing the service - closing it underneath a blocking take()"
+                        + " deadlocks against the JDK's polling watch service");
+        // The loop must be GONE, not just told to stop: destroy() interrupts the blocking take() and
+        // waits for the thread, so nothing is left inside the service when it is closed.
+        assertFalse(watcher.isWatching(), "the watch loop must have left before destroy() returned");
+        // ...and it must have left because it was ASKED to (the interrupt), never because the service
+        // was closed while it was blocked in take(). This is the ordering itself, asserted: the buggy
+        // order can only ever produce "closed" here, and it produces it deterministically.
+        assertNotEquals("closed", watcher.getLastExitCause(),
+                "the watch service was closed underneath a blocking take() - that is the order that deadlocks");
+
+        // Idempotent: Spring destroys a singleton once, but the re-initialize path closes in too.
+        assertTimeoutPreemptively(SHUTDOWN_BOUND, watcher::destroy, "a second destroy() must be a no-op, not a hang");
+
+        // ...and the watcher is reusable, i.e. destroy() left clean state behind, not a half-closed
+        // service the next initialize() would trip over.
+        watcher.initialize();
+        awaitWatching(watcher);
+        assertTimeoutPreemptively(SHUTDOWN_BOUND, watcher::destroy, "a re-initialized watcher must shut down the same way");
+        assertFalse(watcher.isWatching(), "the re-initialized watch loop must also have left");
+    }
+
+    /** Wait until the loop is actually inside take(), which is the state shutdown has to survive. */
+    private static void awaitWatching(LocalRegistryWatcher watcher) throws InterruptedException {
+        long deadline = System.nanoTime() + SETTLE.toNanos();
+        while (!watcher.isWatching() && System.nanoTime() < deadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(watcher.isWatching(), "the watch loop should be running before we try to stop it");
+    }
+}


### PR DESCRIPTION
### What

`LocalRegistryWatcher.destroy()` closed the `WatchService` while its own thread was blocked in `watchService.take()`. On **macOS** the JDK has no native file-event source and falls back to `sun.nio.fs.PollingWatchService`, whose `close()` walks the registered keys and locks each one **while holding the key map** — the opposite order to the polling thread, which locks a key and then the map.

```
main              → LocalRegistryWatcher.destroy → PollingWatchService.implClose
                    holds the key map, waits for a PollingWatchKey monitor
FileSystemWatcher → holds that key's monitor, waits for the key map
```

`jstack` reports it as a Java-level deadlock. Spring's singleton teardown then never returns, so **every `@DirtiesContext` integration-test class can hang mid-run on a developer's Mac** — observed on `IntentEngineIT` (35 tests × a context per method: the run wedged after the second teardown and had to be killed, with no output and an idle JVM). Linux and Windows have native watchers and never showed it, which is why CI is green.

### Fix

The **order**: clear the `watching` flag → `shutdownNow()` to interrupt the blocking `take()` (the loop returns on the `InterruptedException`) → await the thread briefly → *then* close the service, with nobody inside it.

Also: the loop tolerates `ClosedWatchServiceException` (so the legacy order can still only end the loop, never wedge it), and the re-initialize path closes **only** the service — it runs *on* the watcher thread and must not shut down and await the executor it is running in.

### Test — and what it can honestly prove

The deadlock needs the poller to be mid-poll at close time, a race a unit test cannot force. I verified that: a pure timeout assertion **passes on the buggy order**, so a timeout test alone would have been theatre.

`LocalRegistryWatcherShutdownTest` therefore asserts the ordering's **observable effects**, all deterministic:

- `destroy()` returns;
- the watch loop is **gone** afterwards, not merely signalled;
- it left **because it was interrupted**, never because the service was closed underneath it (`lastExitCause`) — this is the ordering itself;
- `destroy()` is idempotent, and the watcher can be re-initialized and shut down again.

Restoring the old order fails it deterministically: `expected: not equal but was: <closed>`.

Found while working on #6356; unrelated to that feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)