### PR TITLE
fix: log instead of printing to stdout/stderr in platform code

### DIFF
--- a/components/data/data-store/src/main/java/org/eclipse/dirigible/components/data/store/parser/EntityParser.java
+++ b/components/data/data-store/src/main/java/org/eclipse/dirigible/components/data/store/parser/EntityParser.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -34,6 +36,8 @@ import org.eclipse.dirigible.parsers.typescript.TypeScriptParserBaseVisitor;
  * Main parser class to generate EntityMetadata from TypeScript code.
  */
 public class EntityParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntityParser.class);
 
     /** The Constant ENTITIES. */
     public static final Map<String, EntityMetadata> ENTITIES = Collections.synchronizedMap(new HashMap<String, EntityMetadata>());
@@ -449,7 +453,7 @@ public class EntityParser {
                         try {
                             columnDetails.setLength(Integer.parseInt(length));
                         } catch (NumberFormatException e) {
-                            System.err.println("Warning: Could not parse length value: " + length);
+                            LOGGER.warn("Could not parse the length value [{}] - ignoring it", length);
                         }
                     }
 

--- a/components/engine/engine-template-velocity/src/main/java/org/eclipse/dirigible/components/engine/template/velocity/VelocityGenerationEngine.java
+++ b/components/engine/engine-template-velocity/src/main/java/org/eclipse/dirigible/components/engine/template/velocity/VelocityGenerationEngine.java
@@ -12,6 +12,8 @@ package org.eclipse.dirigible.components.engine.template.velocity;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.dirigible.components.engine.template.TemplateEngine;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +27,8 @@ import java.util.Map;
  */
 @Component
 public class VelocityGenerationEngine implements TemplateEngine {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VelocityGenerationEngine.class);
 
     /** The Constant ENGINE_NAME. */
     public static final String ENGINE_NAME = "velocity";
@@ -41,8 +45,7 @@ public class VelocityGenerationEngine implements TemplateEngine {
             engine.setProperty(RuntimeConstants.VM_PERM_ALLOW_INLINE_REPLACE_GLOBAL, true);
             engine.init();
         } catch (Throwable e) {
-            // if (logger.isErrorEnabled()) {logger.error(e.getMessage(), e);}
-            e.printStackTrace();
+            LOGGER.error("Failed to initialize the Velocity engine", e);
         }
     }
 

--- a/components/engine/engine-typescript/src/main/java/org/eclipse/dirigible/components/engine/typescript/TypeScriptService.java
+++ b/components/engine/engine-typescript/src/main/java/org/eclipse/dirigible/components/engine/typescript/TypeScriptService.java
@@ -13,6 +13,8 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.dirigible.repository.api.IRepository;
 import org.eclipse.dirigible.repository.api.IRepositoryStructure;
 import org.eclipse.dirigible.repository.api.RepositoryPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +36,8 @@ import java.util.stream.Collectors;
  */
 @Component
 public class TypeScriptService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TypeScriptService.class);
 
     /** The Constant TS_EXT. */
     private static final String TS_EXT = ".ts";
@@ -164,7 +168,9 @@ public class TypeScriptService {
             BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream()));
             String line;
             while ((line = in.readLine()) != null) {
-                System.out.println(line);
+                // esbuild's own diagnostics: the log, not stdout, so they are levelled, timestamped and
+                // visible in the Logs view like everything else the engine reports.
+                LOGGER.debug("[esbuild] {}", line);
             }
             int statusCode = process.waitFor();
             if (statusCode != 0) {

--- a/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/domain/WorkspaceSelectionTargetPair.java
+++ b/components/ide/ide-workspace/src/main/java/org/eclipse/dirigible/components/ide/workspace/domain/WorkspaceSelectionTargetPair.java
@@ -113,7 +113,6 @@ public class WorkspaceSelectionTargetPair {
                                                .getPath();
             String pathToCompare =
                     pathOfNode.substring(0, pathOfNode.length() >= skipPath.length() ? skipPath.length() : pathOfNode.length());
-            System.out.println(pathToCompare + ", " + pathOfNode);
             if (pathToCompare.equals(skipPath)) {
                 sourceSelection.set(i, sourceSelection.get(i)
                                                       .setResolution("skip"));

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/StaticObjects.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/StaticObjects.java
@@ -78,10 +78,11 @@ public final class StaticObjects {
         Object object = OBJECTS.get(key);
         if (object == null) {
             String message = "Static object by key: " + key + " is null";
+            // One report, in the log, WITH the stack that shows who asked for the missing object -
+            // the synthetic exception used to go to stderr, where nothing collects it.
             if (logger.isErrorEnabled()) {
-                logger.error(message);
+                logger.error(message, new IllegalStateException(message));
             }
-            new Exception(message).printStackTrace();
         }
         return object;
     }

--- a/modules/commons/commons-resources/src/main/java/org/eclipse/dirigible/commons/logging/ConsoleWebsocketHandler.java
+++ b/modules/commons/commons-resources/src/main/java/org/eclipse/dirigible/commons/logging/ConsoleWebsocketHandler.java
@@ -105,7 +105,11 @@ public class ConsoleWebsocketHandler extends TextWebSocketHandler {
                         session.sendMessage(new TextMessage(GsonHelper.toJson(record)));
                     }
                 } catch (IOException e) {
-                    System.err.println(e.getMessage());
+                    // NOT the logger, on purpose: this method is called BY the logging appender
+                    // (ConsoleLoggingAppender), so logging here would re-enter it and recurse. Standard
+                    // error is the one correct sink in this single place - with the cause, not just its
+                    // message.
+                    e.printStackTrace(System.err);
                 }
             }
         }


### PR DESCRIPTION
### Why

A print has no level, no timestamp, no logger name and no thread. It never reaches the Logs view or log aggregation, cannot be turned down in production, and pollutes the console stream the IDE terminal shows. Found while reviewing #6435, then swept the whole repo.

### The five real cases

| File | Was | Now |
|---|---|---|
| `EntityParser` | `System.err.println("Warning: Could not parse length value…")` — from a class with **no logger at all** | `LOGGER.warn("Could not parse the length value [{}] - ignoring it", length)` |
| `TypeScriptService` | every esbuild output line printed to stdout | `LOGGER.debug("[esbuild] {}", line)` |
| `WorkspaceSelectionTargetPair.skipByPath` | leftover debug print of two paths, every iteration | deleted |
| `VelocityGenerationEngine` | `e.printStackTrace()` on engine-init failure — with the proper logger call **sitting right above it, commented out** | `LOGGER.error("Failed to initialize the Velocity engine", e)` |
| `StaticObjects` | logged the error, then `new Exception(message).printStackTrace()` on top | one `logger.error(message, new IllegalStateException(message))`, so the stack showing who asked for the missing object lands where something collects it |

### The one that must keep printing

`ConsoleWebsocketHandler.distribute` is called **by** the logging appender (`ConsoleLoggingAppender`), so logging inside it re-enters the appender and recurses. `System.err` is correct in that single method — I left it, added a comment saying why, and made it print the cause instead of discarding everything but `getMessage()`. (Worth stating plainly: blind-fixing that one would have introduced a recursion bug.)

### Out of scope on purpose

`main()` CLIs (`EntityTransformer`, `TypeScriptApiDocGenerator`) and the startup banner, where stdout *is* the output; test-support modules and ITs.

### The rule, written down

`CLAUDE.md` "Conventions worth knowing" gains **"Never print to stdout or stderr - log"** next to the existing *"Always log the throwable"*, with the documented exception and the grep to run before committing. It also covers **generated code**: templates and scaffolded `custom/` stubs use the client SDK logger (`org.eclipse.dirigible.sdk.log.Logging`), because a generated class is read as house style by every application developer — that half is repeated in `engine-intent/CLAUDE.md`, where it leaked. (The template + stub fixes themselves ride in #6435, which introduced them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)