### PR TITLE
fix(intent): a see-only personal surface offers no write affordance (#6425)

### DIFF
--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -297,10 +297,11 @@ server-side on writes, foreign records 404. A field marked `sensitive: true` (no
 identity field, or the owner FK) is stripped from personal responses and ignored on personal
 writes - use it for billing rates and amounts the person must not see. Add `personalReadOnly: true`
 alongside `personal: true` to make the personal surface **see-only**: the generated `MyController`
-serves the scoped reads but its create/update/delete return **405**, and the my pages drop
-New/Edit/Delete - for records the owner may view but never author (a leave-balance account, a
-payslip); the regular (power) controller still writes them normally. The regular controller is
-unaffected. Sensitivity propagates to derived fields automatically: a rollup target (`op: sum` /
+serves the scoped reads but its create/update/delete return **403**, and the my pages render no
+write affordance at all - no New on the list, no Save/Delete on the form or the document, and no
+Add on a child panel or on the document's items - for records the owner may view but never author
+(a leave-balance account, a payslip); the regular (power) controller still writes them normally.
+The regular controller is unaffected. Sensitivity propagates to derived fields automatically: a rollup target (`op: sum` /
 `latest`) whose `of:` child field is sensitive, and an `aggregate: true` master field fed by a
 same-named sensitive item field, are treated as sensitive whenever their entity has a personal
 surface (own `personal:` relation, or scope inherited through a composition parent chain) - the

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityMyController.java.template
@@ -94,7 +94,7 @@ public class ${name}MyController {
 
 #if($personalReadOnly)
     // See-only personal surface (intent personalReadOnly): the owner may read their own records but
-    // never author them - the write endpoints exist only to refuse with 405 (the power controller
+    // never author them - the write endpoints exist only to refuse with 403 (the power controller
     // remains the sole write path). Fixes the self-grant risk on owner-owned reference records.
     @Post
     @Documentation("Not allowed - this ${name} is read-only on the personal surface")

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -105,6 +105,7 @@
         </template>
         <div x-show="items.length === 0" x-h-text.muted class="p-2" x-text="T('$projectName:${tprefix}.messages.noData', 'No messages yet.')"></div>
       </div>
+#if(!$personalReadOnly)
       <div class="vbox gap-2">
 #if($chatInternalProperty)
         <label class="hbox items-center gap-2 text-sm">
@@ -117,6 +118,7 @@
           <button type="button" x-h-button data-variant="primary" @click="sendMessage(chatDraft)" :disabled="chatSending || !chatDraft.trim()" :aria-label="T('$projectName:${tprefix}.defaults.send', 'Send')"><i role="img" x-h-lucide data-lucide="send"></i></button>
         </div>
       </div>
+#end
     </div>
 #else
     <!-- Line items (only once the document exists). Add/edit via a dialog; delete inline. -->
@@ -124,10 +126,12 @@
       <div x-h-toolbar data-variant="transparent" data-size="sm">
         <span x-h-toolbar-title class="shrink-0" x-text="itemsDef ? T(itemsDef.tkey, '${documentItemsLabel}') : '${documentItemsLabel}'"></span>
         <div x-h-toolbar-spacer></div>
+#if(!$personalReadOnly)
         <button x-h-button data-variant="primary" data-size="sm" @click="openItem(null)">
           <i role="img" x-h-lucide data-lucide="plus"></i>
           <span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span>
         </button>
+#end
       </div>
       <div x-show="itemsError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemsError"></div></div>
       <div x-h-table-container.scroll>
@@ -137,7 +141,9 @@
               <template x-for="col in itemColumns()" :key="col.name">
                 <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label)"></th>
               </template>
+#if(!$personalReadOnly)
               <th x-h-table-head scope="col"></th>
+#end
             </tr>
           </thead>
           <tbody x-h-table-body>
@@ -146,13 +152,15 @@
                 <template x-for="col in itemColumns()" :key="col.name">
                   <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="displayItem(row, col)"></td>
                 </template>
+#if(!$personalReadOnly)
                 <td x-h-table-cell class="text-right">
                   <button x-h-button data-variant="transparent" data-size="icon-sm" aria-label="Delete" @click.stop="deleteItem(row)"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>
                 </td>
+#end
               </tr>
             </template>
             <tr x-show="items.length === 0">
-              <td x-h-table-cell :colspan="itemColumns().length + 1" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
+              <td x-h-table-cell :colspan="itemColumns().length#if(!$personalReadOnly) + 1#end" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
             </tr>
           </tbody>
         </table>
@@ -204,10 +212,12 @@
             <div x-h-card-header class="hbox items-center">
               <span x-h-card-title x-text="child.label"></span>
               <div class="grow"></div>
+#if(!$personalReadOnly)
               <button x-h-button data-variant="primary" data-size="sm" @click="addChild(child)">
                 <i role="img" x-h-lucide data-lucide="plus"></i>
                 <span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span>
               </button>
+#end
             </div>
             <div x-h-card-content>
               <div x-show="child.state === 'loading'"><div x-h-spinner></div></div>
@@ -247,6 +257,11 @@
 #end
 
     <div class="hbox gap-2" style="max-width: 900px">
+#if($personalReadOnly)
+      <div class="grow"></div>
+      <button x-h-button data-variant="transparent" @click="goBack()"
+              x-text="T('$projectName:${tprefix}.defaults.back', 'Back')"></button>
+#else
       <button x-h-button data-variant="negative" x-show="mode === 'edit'" @click="deleteOpen = true"
               x-text="T('$projectName:${tprefix}.defaults.delete', 'Delete')"></button>
       <div class="grow"></div>
@@ -256,6 +271,7 @@
         <span x-show="saving" x-h-spinner></span>
         <span x-text="T('$projectName:${tprefix}.defaults.save', 'Save')"></span>
       </button>
+#end
     </div>
   </div>
 
@@ -297,7 +313,9 @@
       </div>
       <div x-h-dialog-footer>
         <button x-h-button data-variant="transparent" @click="itemDialog = false" x-text="T('$projectName:${tprefix}.defaults.cancel', 'Cancel')"></button>
+#if(!$personalReadOnly)
         <button x-h-button data-variant="primary" @click="saveItem()" x-text="T('$projectName:${tprefix}.defaults.save', 'Save')"></button>
+#end
       </div>
     </div>
   </div>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -110,10 +110,12 @@
             <div x-h-card-header class="hbox items-center">
               <span x-h-card-title x-text="child.label"></span>
               <div class="grow"></div>
+#if(!$personalReadOnly)
               <button x-h-button data-variant="primary" data-size="sm" @click="addChild(child)">
                 <i role="img" x-h-lucide data-lucide="plus"></i>
                 <span x-text="T('$projectName:${tprefix}.defaults.add', 'Add')"></span>
               </button>
+#end
             </div>
             <div x-h-card-content>
               <div x-show="child.state === 'loading'"><div x-h-spinner></div></div>

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/parameterUtils.js
@@ -223,7 +223,7 @@ export function process(model, parameters) {
                         e.personalIdentityEntityClass = `gen.${javaGen}.data.${javaPerspective}.${p.relationshipEntityName}Entity`;
                         e.personalIdentityRepositoryClass = `gen.${javaGen}.data.${javaPerspective}.${p.relationshipEntityName}Repository`;
                         // See-only personal surface (intent personalReadOnly): the my controller's
-                        // writes 405 and the my pages drop New/Edit/Delete.
+                        // writes 403 and the my pages render no write affordance.
                         e.personalReadOnly = !!p.relationshipPersonalReadOnly;
                     }
                     // partner (intent `partner: true`): the external-partner mirror of the personal

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -202,7 +202,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: Claim, kind: manyToOne, to: Claim, composition: true }
 
               # personalReadOnly: a see-only personal surface - the owner reads their own Balance
-              # rows but the my controller's writes 405 (a record the back office grants, the
+              # rows but the my controller's writes 403 (a record the back office grants, the
               # person must never author - the self-grant guard).
               - name: Balance
                 fields:
@@ -210,6 +210,34 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: days, type: decimal }
                 relations:
                   - { name: Person, kind: manyToOne, to: Person, required: true, personal: true, personalReadOnly: true }
+
+              # A composition child of the see-only personal root: the child inherits the read-only
+              # scope, so the parent's my FORM renders its panel for reading but must offer no Add -
+              # an affordance whose every use the child's own my controller refuses.
+              - name: BalanceEntry
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: Balance, kind: manyToOne, to: Balance, composition: true, required: true }
+
+              # The see-only personal surface in its DOCUMENT shape (a payslip the employee may read
+              # and never author): the same personalReadOnly flag must strip the item Add/Delete, the
+              # item dialog's Save and the Save/Delete footer from the my-document view too.
+              - name: Payslip
+                function: Document
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string, length: 20, function: DocumentTitle }
+                relations:
+                  - { name: Person, kind: manyToOne, to: Person, required: true, personal: true, personalReadOnly: true }
+              - name: PayslipLine
+                function: DocumentItem
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: Payslip, kind: manyToOne, to: Payslip, composition: true, required: true }
 
               # documentItemsLayout: chat - the document master's line-items child renders as a
               # conversation thread (x-h-chat bubbles + a composer) instead of the editable table;
@@ -753,7 +781,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(lineMy.contains("entity.Cost = null"),
                 "a sensitive field on a scope-inheriting child must be scrubbed from its personal controller");
 
-        // personalReadOnly: the scoped controller still serves reads but its write methods 405 -
+        // personalReadOnly: the scoped controller still serves reads but its write methods 403 -
         // no repository.save on the personal surface (the power controller keeps writing).
         String balanceMy = contentOf("gen/emission/api/balance/BalanceMyController.java");
         assertTrue(balanceMy.contains("read-only on your personal surface"),
@@ -763,6 +791,32 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 "personalReadOnly must NOT emit a persisting create/update on the personal controller");
         String balanceMyView = contentOf("gen/emission/views/my/Balance-list.html");
         assertTrue(!balanceMyView.contains("newEntity()"), "personalReadOnly my list must not render the New button");
+        // ... and no write affordance survives on the my FORM either. The child panel's Add was the
+        // last one left: the child controller refuses every use of it (403), so it was an affordance
+        // that always failed on exactly the surface whose point is read-without-author.
+        String balanceMyForm = contentOf("gen/emission/views/my/Balance-form.html");
+        // The positive anchor first: the READ half must still be there, or the assertions below would
+        // pass on an empty/missing file instead of on a rendered see-only form.
+        assertTrue(balanceMyForm.contains("x-for=\"child in children\"") && balanceMyForm.contains("goBack()"),
+                "personalReadOnly my form must still render the child panel and the Back button");
+        assertTrue(!balanceMyForm.contains("addChild(child)"), "personalReadOnly my form must not render the child Add button");
+        assertTrue(!balanceMyForm.contains("save()") && !balanceMyForm.contains("deleteOpen = true"),
+                "personalReadOnly my form must not render Save or Delete");
+        // The guard is conditional, not blanket: a WRITABLE personal form keeps its child Add.
+        String claimMyForm = contentOf("gen/emission/views/my/Claim-form.html");
+        assertTrue(claimMyForm.contains("addChild(child)"), "a writable personal form must still render the child Add button");
+        // Same flag, DOCUMENT shape: items add/delete, the item dialog's Save and the Save/Delete
+        // footer all go; Back stays. The read surface (the items table itself) is untouched.
+        String payslipMyDoc = contentOf("gen/emission/views/my/Payslip-document.html");
+        assertTrue(!payslipMyDoc.contains("openItem(null)") && !payslipMyDoc.contains("deleteItem(row)"),
+                "personalReadOnly my document must not render the item Add or the per-row Delete");
+        assertTrue(!payslipMyDoc.contains("saveItem()"), "personalReadOnly my document must not render the item dialog's Save");
+        assertTrue(!payslipMyDoc.contains("save()") && !payslipMyDoc.contains("deleteOpen = true"),
+                "personalReadOnly my document must not render the Save or Delete footer buttons");
+        assertTrue(payslipMyDoc.contains("openItem(row)"), "personalReadOnly my document must still open an item for reading");
+        // Positive control on the document shape too - the writable personal chat keeps its composer.
+        String ticketMyDoc = contentOf("gen/emission/views/my/Ticket-document.html");
+        assertTrue(ticketMyDoc.contains("sendMessage(chatDraft)"), "a writable personal document must still render the chat composer");
 
         // assignee: personal - the BPMN assigns the task to the start-time-resolved owner and the
         // trigger listener seeds that variable from the identity mapping.
@@ -1319,7 +1373,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 30);
 
         // personalReadOnly: the scoped read serves 200 (the owner sees their own rows), but a write
-        // to the personal surface is refused 405 - the see-only guarantee at the outermost layer.
+        // to the personal surface is refused 403 - the see-only guarantee at the outermost layer.
         restAssuredExecutor.execute(() -> given().when()
                                                  .get(API + "/balance/BalanceMyController")
                                                  .then()


### PR DESCRIPTION
Closes #6425.

`personalReadOnly: true` made the personal surface see-only in most places — the generated `<Entity>MyController` refuses create/update/delete with 403 and the my list has no New — but the my **form** still drew an Add button on every composition-child panel. The child controller refuses each use of it, so it was safe and useless at once: an affordance that always fails, on exactly the surfaces whose point is that the owner may look and not author.

Fixing it exposed the larger half. The sibling **my-document** view honoured the flag *nowhere*: on a see-only personal document the item Add, the per-row Delete, the item dialog's Save, the chat composer and the whole Save/Delete footer all rendered. Guarding only the reported button would have left the worse hole in place, so both my surfaces now derive every write affordance from the same flag.

The read half is deliberately untouched — child panels, the items table, and an item opened for reading all stay, with **Back** where Save/Delete/Cancel were (the pattern the my form already used).

## Changes

- `ui/my/my-form-view.html.template` — guard the child-panel Add (the reported defect).
- `ui/my/my-document-view.html.template` — the same guard, plus the item Add, the per-row Delete (and its now-empty header cell and the empty-state `colspan`), the item dialog's Save, the chat composer, and a Back-only footer.
- `IntentEmissionCoverageIT` — the see-only `Balance` gains a composition child, so its my form actually renders a child panel (the bug was invisible before: the entity had no children); the issue's own example arrives as a see-only personal **document** (`Payslip`/`PayslipLine`).
- `intent-assistant-guide.md` — the `personalReadOnly` paragraph now states the full contract.

## Test notes

Both directions, so this cannot rot into a blanket suppression: a **writable** personal form must still render its child Add and a writable personal chat its composer. The see-only form is anchored on its read half first (child panel + Back), so the absence-assertions cannot pass on a file that failed to render.

## Drive-by

The guide, `parameterUtils.js`, the `EntityMyController` template comment and two IT comments all said the refusal is **405**, while the code has always thrown `HttpStatus.FORBIDDEN` — the IT asserts 403 three lines below its own comment saying 405. Corrected to 403.

## Verification

`IntentEmissionCoverageIT` green locally (generate → publish → emission + runtime assertions, 86 s), formatter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)