### PR TITLE
docs(intent): the assistant guide documents the notify fan-out (forEach)

### DIFF
--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -1157,6 +1157,31 @@ due date.
       language: bg                       # optional print-template language (default en)
 ```
 
+**One message per related row: `forEach`.** Some sends are naturally per-row rather than per-record -
+a payroll run mails every payslip to its own employee, an order confirmation goes to each contact. Name
+the related entity with `forEach:` and the block sends ONE message per row of it; from then on every
+path resolves against the **ROW**: the recipient, the `{placeholders}`, and `attach: print` (the row's
+own document).
+
+```yaml
+    notify:
+      forEach: Payslip                     # the rows: Payslips whose FK points at this record
+      to: Employee.email                   # the ROW's employee
+      subject: "Payslip {PayrollRun.month}"    # one hop from the ROW (its run)
+      body: "Dear {Employee.name}, net pay {net}."   # {net} is the ROW's own field
+      attach: print                        # the ROW's rendered document
+```
+
+The row entity must have **exactly one** to-one relation back to the record: none means the rows are
+unrelated, several make the intended set ambiguous, and both are validation errors rather than a
+quietly wrong list of recipients.
+
+**A fan-out is fail-soft per row, at every call site** - including a process step, which otherwise
+fails. A row with no address is skipped, a failed send is logged, and the step completes with a summary
+count. That is deliberate: failing the task would have the engine retry the WHOLE fan-out and mail
+everyone who already received their message a second time, and a partial send cannot be made
+idempotent.
+
 Where the block can sit - the three places an intent acts, plus the standalone `notifications` entry:
 
 | Call site | Reads | Sends when |
@@ -1412,6 +1437,7 @@ payment's unallocated balance; entity writes go only through the generated repos
 | lifecycle event | `onCreate`, `onUpdate`, `onDelete` |
 | notification `channel` | `email` |
 | notify `attach` | `print` (the record's own rendered document; the entity must be a document) |
+| notify `forEach` | a declared entity with exactly ONE to-one relation back to the record (one message per row; every path resolves against the row) |
 | notify block sites | `notifications[]`, `schedules[].notify`, `transitions[].notify`, `serviceTask` `args.notify` |
 | schedule `where` `op` | `eq`, `ne`, `gt`, `ge`, `lt`, `le`, `like` |
 | integration `method` | `GET`, `POST`, `PUT`, `PATCH`, `DELETE` |


### PR DESCRIPTION
The notify fan-out shipped with #6435 — `NotificationIntent.forEach`, `NotifySupport.fanOut`, the `forEach*` glue keys, `Send.java.template`'s per-row loop and thirteen `GlueSendDocumentTest` cases are all on master — but the authoring guide never got its section.

On master, `intent-assistant-guide.md` has **no mention** of it: no "fan-out", no "one message per related row", and the keyword table lists `notify attach` while omitting `notify forEach`. The only `forEach` the guide describes is the unrelated `generates`/`children` collection (`forEach: { entity: … }` / `forEach: { days: … }`).

That matters more than a normal doc gap: this guide is the resource fed to the Intent Editor's AI assistant, so the assistant cannot author a keyword the engine already accepts — and would plausibly reach for the `generates`-style map shape, which a notify block does not take.

The text was written when the feature was built and never left a working tree.

## What it documents

- the shape — `forEach: <Entity>`, after which **every** path resolves against the **row**: the recipient, the `{placeholders}`, and `attach: print` (the row's own document);
- the exactly-one-to-one-back-relation rule, and that zero and ambiguous are both validation errors;
- why a fan-out is **fail-soft per row** rather than failing the step: a retry would re-mail everyone already served, so a partial send cannot be made idempotent;
- one keyword-table row.

## Verified against master, not trusted

Every claim was checked before writing it down:

| Claim | Where it holds |
|---|---|
| `forEach: <Entity>` is a plain string | `NotificationIntent.forEach` |
| zero / ambiguous back-reference are validation errors | `IntentParser.validateNotifyBlock` — unknown entity, and `backReferencesTo(...) != 1` |
| skip no-recipient, log a failure, complete with a summary | `Send.java.template` — `sent` / `skipped` / `failed` counters + summary log |
| `attach: print` renders the **row's** document | `validateNotifyBlock` re-points `aboutEntity` at the row entity |

Docs only — no code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)