### PR TITLE
feat(home): two primary destinations, Partner and Workbench as secondary

### DIFF
--- a/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/index.html
+++ b/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/index.html
@@ -38,10 +38,15 @@
       })();
     </script>
     <style>
-      /* The destination rows: editorial paragraphs with a link affordance, not dashboard cards. */
       .home-entry { text-decoration: none; color: inherit; }
+      /* The arrow is the "this is a link" affordance - it slides in on hover/keyboard focus. */
       .home-entry .home-entry-arrow { opacity: 0; transform: translateX(-4px); transition: opacity .15s ease, transform .15s ease; }
       .home-entry:hover .home-entry-arrow, .home-entry:focus-visible .home-entry-arrow { opacity: 1; transform: translateX(0); }
+      /* The primary destinations are framed tiles that lift towards the brand colour on hover. */
+      .home-tile { transition: border-color .15s ease, box-shadow .15s ease, transform .15s ease; }
+      .home-tile:hover, .home-tile:focus-visible { border-color: var(--primary); box-shadow: 0 6px 20px -8px rgb(0 0 0 / .18); transform: translateY(-2px); }
+      .home-tile:hover .home-tile-icon, .home-tile:focus-visible .home-tile-icon { background: var(--primary); color: var(--primary-foreground); }
+      .home-tile-icon { transition: background-color .15s ease, color .15s ease; }
     </style>
   </head>
 
@@ -70,21 +75,25 @@
 
     <!-- The welcome column. -->
     <div class="flex-1 overflow-auto" x-cloak>
-      <div class="mx-auto w-full px-6" style="max-width: 640px; padding-top: 9vh; padding-bottom: 4rem;">
+      <div class="mx-auto w-full px-6" style="max-width: 46rem; padding-top: 8vh; padding-bottom: 4rem;">
 
         <p class="text-sm text-muted-foreground" x-text="greeting()"></p>
-        <h1 class="text-3xl font-bold leading-tight" style="margin-top: .25rem;">
+        <h1 class="text-3xl font-bold leading-tight tracking-tight" style="margin-top: .25rem;">
           Welcome<span x-show="userName">, <span x-text="userName"></span></span>
         </h1>
         <p class="text-muted-foreground" style="margin-top: .75rem; max-width: 46ch;">
           Everything starts here. Pick where you want to work today.
         </p>
 
-        <!-- Destinations: one entry per shell registered on the `platform-shells` extension point. -->
-        <div class="vbox" style="margin-top: 2.5rem; gap: .25rem;">
-          <template x-for="s in shells" :key="s.id">
-            <a class="home-entry group hbox items-start gap-4 rounded-control p-4 hover:bg-accent" :href="s.path">
-              <span class="hbox items-center justify-center rounded-control bg-accent" style="width: 2.75rem; height: 2.75rem; flex: none;">
+        <!--
+          The primary destinations - the two places the company actually works. One tile per
+          non-secondary shell registered on the `platform-shells` extension point, so a stack that
+          ships more of them keeps working without a change here.
+        -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4" style="margin-top: 2.5rem;">
+          <template x-for="s in primaryShells" :key="s.id">
+            <a class="home-entry home-tile vbox gap-3 rounded-lg border border-border bg-card p-5" :href="s.path">
+              <span class="home-tile-icon hbox items-center justify-center rounded-md bg-muted size-11 flex-none">
                 <i role="img" x-h-lucide :data-lucide="s.icon || iconFor(s.id)" class="size-5"></i>
               </span>
               <span class="vbox min-w-0" style="gap: .15rem;">
@@ -96,10 +105,28 @@
               </span>
             </a>
           </template>
-          <p x-show="loaded && shells.length === 0" class="text-sm text-muted-foreground p-4">
-            Nothing is published here yet.
-          </p>
         </div>
+
+        <!-- The secondary destinations - present for whoever has them, but out of the main path. -->
+        <div x-show="secondaryShells.length" class="vbox border-t border-border"
+             style="margin-top: 2rem; padding-top: 1rem; gap: .25rem;">
+          <template x-for="s in secondaryShells" :key="s.id">
+            <a class="home-entry hbox items-center gap-3 rounded-md p-3 hover:bg-muted" :href="s.path">
+              <i role="img" x-h-lucide :data-lucide="s.icon || iconFor(s.id)" class="size-4 text-muted-foreground flex-none"></i>
+              <span class="text-sm font-medium flex-none" x-text="s.label"></span>
+              <!-- The description is the first thing to give up room on a narrow window. -->
+              <span class="text-sm text-muted-foreground truncate hidden sm:block"
+                    x-text="s.description || descriptionFor(s.id)"></span>
+              <span class="flex-1"></span>
+              <i role="img" x-h-lucide data-lucide="arrow-right" class="home-entry-arrow size-4 text-muted-foreground flex-none"></i>
+            </a>
+          </template>
+        </div>
+
+        <p x-show="loaded && shells.length === 0" class="text-sm text-muted-foreground"
+           style="margin-top: 2.5rem;">
+          Nothing is published here yet.
+        </p>
 
       </div>
     </div>

--- a/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
+++ b/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
@@ -25,6 +25,26 @@ document.addEventListener('alpine:init', () => {
         shellIde: 'The development workbench for building on the platform.',
     };
 
+    /*
+     * Registered shells that are deliberately not offered as a Home destination. They stay
+     * registered on `platform-shells` (the IDE's Window menu still lists them) and remain
+     * reachable by their own URL - Home simply is not the way in. Only the legacy
+     * AngularJS/BlimpKit dashboard, superseded by the Harmonia shells; its module stays, because
+     * the generated AngularJS apps still load its services.
+     */
+    const HIDDEN = ['dashboardShell'];
+
+    /*
+     * Shells that belong on Home but are not where the working day starts - rendered as quiet rows
+     * below the primary destinations, in registration order (Partner above Workbench, least
+     * technical first):
+     *  - partnerShell: external partners are led straight to /services/web/partner/, so this is
+     *    not their way in - it is here for the employees who need to see what a partner sees.
+     *  - shellIde: a developer tool. Every developer is also an employee, so it must stay visible,
+     *    but it should not compete with the two shells the rest of the company opens every morning.
+     */
+    const SECONDARY = ['partnerShell', 'shellIde'];
+
     Alpine.data('home', () => ({
         branding: { name: '', subtitle: '', logo: '' },
         userName: '',
@@ -63,12 +83,15 @@ document.addEventListener('alpine:init', () => {
                 if (!r.ok) return;
                 const list = await r.json();
                 this.shells = (Array.isArray(list) ? list : [])
-                    .filter((s) => s && s.path && s.label)
+                    .filter((s) => s && s.path && s.label && !HIDDEN.includes(s.id))
                     .sort((a, b) => (a.order ?? 100) - (b.order ?? 100));
             } catch (e) {
                 console.error('home: could not load the shells', e);
             }
         },
+
+        get primaryShells() { return this.shells.filter((s) => !SECONDARY.includes(s.id)); },
+        get secondaryShells() { return this.shells.filter((s) => SECONDARY.includes(s.id)); },
 
         greeting() {
             const h = new Date().getHours();


### PR DESCRIPTION
## What

The Home landing page (`resources-home`, the platform's default entry point) listed **every** shell registered on `platform-shells` as an equal destination — so the legacy BlimpKit Dashboard, the Partner portal and the developer Workbench all competed with the two shells the company actually opens every morning.

```
Before                          After
──────────────────────────      ─────────────────────────────────────────────
▤  Applications        →        ┌────────────────────┐  ┌────────────────────┐
▣  My Work             →        │ Applications    →  │  │ My Work         →  │
🤝 Partner             →        └────────────────────┘  └────────────────────┘
‹› Workbench           →        ─────────────────────────────────────────────
▦  Dashboard           →        🤝  Partner    The portal for external…    →
                                ‹›  Workbench  The development workbench…  →
```

- **Applications** and **My Work** are framed tiles in a responsive 2-up grid, lifting towards the brand colour on hover.
- **Partner** and **Workbench** are quiet single-line rows below a divider — least technical first, which falls out of their existing `order` values (30, 40) with no override. The Workbench stays visible because every developer or consultant is also an employee; it just no longer competes for the primary path.
- The legacy **Dashboard** is no longer offered as a destination.

## Scope: Home-page-side only

Nothing is de-registered from `platform-shells`:

- The IDE's **Window menu** is unchanged (`menus.js` aggregates the same extension point).
- Every shell stays reachable by its own URL. External partners still go straight to `/services/web/partner/` — the Home row is there for the employees who need to see what a partner sees.
- **`resources-dashboard` stays put.** It is not just the legacy shell: the AngularJS generated-app templates load `/services/web/dashboard/services/entity.js` and `process-tasks.js` from it.

Both lists are derived from the extension point, so a stack that ships more shells keeps working with no change here.

## Drive-by fix

The icon tiles and the row hover used `bg-accent` / `hover:bg-accent`. **Harmonia 2.6.0 has no `accent` colour token**, so both were silently rendering nothing — the tiles had no background and the rows had no hover state at all. Switched to `bg-muted` / `hover:bg-muted`.

## Verification

- Every utility class and CSS custom property in the new markup grepped against the served `harmonia.css` (`bg-card`, `border-border`, `bg-muted`, `sm:grid-cols-2`, `truncate`, `sm:block`, `--primary`, `--primary-foreground`, …).
- `node --check` on `home.js`; tag balance on `index.html`.
- Deployed into a running instance's registry and reviewed in the browser by the author.

No Java, no template, and no test touches this module, so the formatter / javadoc / unit-test gates are structurally unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)