### PR TITLE
feat(core): platform readiness state keyed to artefact depletion

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/http/access/HttpSecurityURIConfigurator.java
@@ -45,6 +45,7 @@ public class HttpSecurityURIConfigurator {
             "/services/core/theme/**", //
             "/services/core/version/**", //
             "/services/core/healthcheck/**", //
+            "/services/core/readiness/**", //
             "/services/web/resources/**", //
             "/services/web/resources-locale/**", //
             "/services/web/platform-core/**", //

--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/readiness/PlatformReadiness.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/readiness/PlatformReadiness.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.readiness;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * The platform readiness state, keyed to artefact depletion (#6448): a synchronization pass that
+ * ends with no undepleted artefacts makes the instance READY - or READY_DEGRADED when artefacts
+ * parked terminally FAILED after exhausting their retries (a broken artefact must not pin the
+ * instance at initializing; it is a quality signal, not a traffic gate). The state re-arms to
+ * SYNCHRONIZING on every later pass (a publish), while {@link #isBootCompleted()} is a ONE-WAY
+ * latch: once the first pass has depleted, the instance accepts traffic forever - a publish never
+ * takes a running application offline.
+ *
+ * <p>
+ * A static singleton (like {@code HealthCheckStatus}) so the synchronizer, the endpoint and the
+ * shells reach it without wiring.
+ */
+public final class PlatformReadiness {
+
+    /** The lifecycle: INITIALIZING (boot) -> READY | READY_DEGRADED <-> SYNCHRONIZING. */
+    public enum State {
+        /** Booting - the first synchronization pass has not depleted yet. */
+        INITIALIZING,
+        /** A later pass is processing (a publish); the instance keeps serving. */
+        SYNCHRONIZING,
+        /** The last pass depleted with every artefact successful. */
+        READY,
+        /** The last pass depleted, but some artefacts parked FAILED after their retries. */
+        READY_DEGRADED
+    }
+
+    private static final PlatformReadiness INSTANCE = new PlatformReadiness();
+
+    private final AtomicReference<State> state = new AtomicReference<>(State.INITIALIZING);
+    private final AtomicBoolean bootCompleted = new AtomicBoolean(false);
+    private volatile int failedArtefacts = 0;
+    private volatile Instant since = Instant.now();
+
+    private PlatformReadiness() {}
+
+    public static PlatformReadiness getInstance() {
+        return INSTANCE;
+    }
+
+    /** A synchronization pass started: INITIALIZING stays; a post-boot pass is SYNCHRONIZING. */
+    public void passStarted() {
+        if (bootCompleted.get()) {
+            transition(State.SYNCHRONIZING);
+        }
+    }
+
+    /**
+     * A synchronization pass depleted its artefact queue.
+     *
+     * @param failed the artefacts that parked terminally FAILED in this pass (0 = clean READY)
+     */
+    public void passCompleted(int failed) {
+        failedArtefacts = Math.max(failed, 0);
+        bootCompleted.set(true);
+        transition(failedArtefacts == 0 ? State.READY : State.READY_DEGRADED);
+    }
+
+    public State getState() {
+        return state.get();
+    }
+
+    /** The artefacts terminally FAILED in the last depleted pass. */
+    public int getFailedArtefacts() {
+        return failedArtefacts;
+    }
+
+    /** When the current state was entered. */
+    public Instant getSince() {
+        return since;
+    }
+
+    /** The ONE-WAY boot latch: true once the first pass has depleted - traffic is accepted. */
+    public boolean isBootCompleted() {
+        return bootCompleted.get();
+    }
+
+    /** Test seam: reset to the boot state (the singleton outlives a test's application context). */
+    public void reset() {
+        state.set(State.INITIALIZING);
+        bootCompleted.set(false);
+        failedArtefacts = 0;
+        since = Instant.now();
+    }
+
+    private void transition(State next) {
+        if (state.getAndSet(next) != next) {
+            since = Instant.now();
+        }
+    }
+}

--- a/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/readiness/PlatformReadinessTest.java
+++ b/components/core/core-base/src/test/java/org/eclipse/dirigible/components/base/readiness/PlatformReadinessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.readiness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.dirigible.components.base.readiness.PlatformReadiness.State;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The readiness lifecycle (#6448): INITIALIZING until the first depleted pass; later passes re-arm
+ * to SYNCHRONIZING and settle READY / READY_DEGRADED; the boot latch is one-way.
+ */
+class PlatformReadinessTest {
+
+    private final PlatformReadiness readiness = PlatformReadiness.getInstance();
+
+    @BeforeEach
+    void reset() {
+        readiness.reset();
+    }
+
+    @Test
+    void bootStaysInitializingUntilTheFirstPassDepletes() {
+        assertEquals(State.INITIALIZING, readiness.getState());
+        readiness.passStarted();
+        assertEquals(State.INITIALIZING, readiness.getState(), "a pre-boot pass must not flip the state");
+        assertFalse(readiness.isBootCompleted());
+
+        readiness.passCompleted(0);
+        assertEquals(State.READY, readiness.getState());
+        assertTrue(readiness.isBootCompleted());
+    }
+
+    @Test
+    void aLaterPassReArmsButNeverRevokesTheBootLatch() {
+        readiness.passCompleted(0);
+
+        readiness.passStarted();
+        assertEquals(State.SYNCHRONIZING, readiness.getState(), "a post-boot pass re-arms the state");
+        assertTrue(readiness.isBootCompleted(), "the boot latch is one-way - a publish never takes the app offline");
+
+        readiness.passCompleted(3);
+        assertEquals(State.READY_DEGRADED, readiness.getState(), "terminally failed artefacts degrade, never block");
+        assertEquals(3, readiness.getFailedArtefacts());
+
+        readiness.passStarted();
+        readiness.passCompleted(0);
+        assertEquals(State.READY, readiness.getState(), "a clean pass clears the degradation");
+        assertEquals(0, readiness.getFailedArtefacts());
+    }
+}

--- a/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/endpoint/ReadinessEndpoint.java
+++ b/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/endpoint/ReadinessEndpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.healthcheck.endpoint;
+
+import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
+import org.eclipse.dirigible.components.base.readiness.PlatformReadiness;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The platform readiness (#6448): the state keyed to artefact depletion, consumable by probes,
+ * headless pipelines and the IDE status-bar indicator. Public like the healthcheck.
+ */
+@RestController
+@RequestMapping(BaseEndpoint.PREFIX_ENDPOINT_CORE + "readiness")
+public class ReadinessEndpoint {
+
+    /** The readiness payload. */
+    public record Readiness(String status, boolean acceptingTraffic, int failedArtefacts, String since) {
+    }
+
+    /**
+     * The current readiness state.
+     *
+     * @return the state, the one-way boot latch, the last pass's terminally failed artefact count, and
+     *         when the state was entered
+     */
+    @GetMapping
+    public ResponseEntity<Readiness> getReadiness() {
+        PlatformReadiness readiness = PlatformReadiness.getInstance();
+        return ResponseEntity.ok(new Readiness(readiness.getState()
+                                                        .name(),
+                readiness.isBootCompleted(), readiness.getFailedArtefacts(), readiness.getSince()
+                                                                                      .toString()));
+    }
+
+}

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -196,6 +196,8 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
         }
         logger.info("Executing synchronization...");
 
+        org.eclipse.dirigible.components.base.readiness.PlatformReadiness.getInstance()
+                                                                         .passStarted();
         processing.set(true);
         synchronizationWatcher.reset();
 
@@ -411,6 +413,10 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
             });
 
             logger.info("Processing synchronizers completed!");
+            // The queue is depleted - the instance is READY (#6448). Artefacts that parked FAILED
+            // after their retries degrade the state but never block it.
+            org.eclipse.dirigible.components.base.readiness.PlatformReadiness.getInstance()
+                                                                             .passCompleted(getErrors().size());
 
         } finally {
             if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Part of #6448 (the core; the IDE status-bar chip, the boot-only 503 gate and the ApplicationAvailability bridge follow).

- **`PlatformReadiness`** (core-base singleton): `INITIALIZING -> READY | READY_DEGRADED <-> SYNCHRONIZING`. Ready = the synchronization pass **depleted its artefact queue**; terminally FAILED artefacts (after their `DIRIGIBLE_SYNCHRONIZER_CROSS_RETRY_COUNT` retries) **degrade** the state with a count but never block it.
- **One-way boot latch**: the first depleted pass accepts traffic forever - later publishes re-arm only the state, never take a running app offline.
- **Wired** in `SynchronizationProcessor` (pass start/completion); **served** at `/services/core/readiness` (public, like healthcheck): `{status, acceptingTraffic, failedArtefacts, since}` - for probes, headless pipelines (retires log-grepping for 'Processing synchronizers completed!') and the coming IDE indicator.
- Verified: `PlatformReadinessTest` (boot latch, re-arm, degraded + clearing); formatter validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)