### PR TITLE
fix(application-shell): SETTING entity fills the settings pane (#6334)

### DIFF
--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
@@ -6,6 +6,13 @@
   while visible - an inline x-show=display:none block measures 0x0 and ignores data-size). No own
   x-data: it inherits the shell's `app` component (settingsItems / selectSetting / settingsUrl).
 -->
+<!-- vbox wrapper so the split fills #app (issue #6334): #app is a block container, so `flex-1` on a
+     bare split is inert and the split collapses to its content height - the 75% panel then stretched
+     only that far and the absolutely-positioned setting iframe rendered in a short box. Wrapping the
+     split in `vbox size-full` (a flex column at #app's full height) lets `flex-1` fill it, matching
+     every other view routed into #app (_dashboard/_inbox/_documents/_reports) and the per-project
+     settings view. -->
+<div class="vbox size-full">
 <div x-h-split class="bk-stretch flex-1" data-orientation="horizontal" data-variant="border">
   <div x-h-split-panel data-size="25%" data-min="200">
     <div class="vbox gap-2 p-3">
@@ -185,4 +192,5 @@
     <iframe x-show="settingsUrl" :src="settingsUrl" title="Settings"
             style="position:absolute; inset:0; width:100%; height:100%; border:0;"></iframe>
   </div>
+</div>
 </div>


### PR DESCRIPTION
Fixes #6334

## Problem
A SETTING entity opened from the `/services/web/application/` application shell (Settings in the sidebar footer → pick a setting) rendered in a short (~3-row) box with an internal scrollbar and empty space below, instead of filling the pane the way PRIMARY entities do.

## Root cause
In `application/views/_settings.html` the `x-h-split` was the **root** element rendered straight into `#app`. `#app` is a block container (`size-full overflow-auto flex-1`), so `flex-1` on the split is inert and the split collapsed to its **content** height (the short left-hand settings list). The 75% detail panel then stretched only that far, and the setting iframe — `position:absolute; inset:0` inside that panel — could only fill the short box. PRIMARY entities were unaffected because they open in the main hosted iframe, which is a direct `flex-1` child of the main flex column.

## Fix
Wrap the split in `<div class="vbox size-full">` — a flex column at `#app`'s full height — so `flex-1` fills it. This is the exact pattern every other view routed into `#app` already uses (`_dashboard.html`, the shared `_inbox`/`_documents`/`_reports`, and the per-project `settings.html.template`). One-element, HTML-only change; no behavior change for the built-in Region & Language / Tenant Configuration / Document Numbering panels.

## Verification
Bundled web resource (no hot reload), so verify against a rebuilt jar:
```
mvn -P quick-build install -pl components/resources/resources-application
mvn -P quick-build package -pl build/application
# restart, open /services/web/application/ → Settings → select a SETTING entity → fills the pane
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)