### PR TITLE
feat(commons-process): configurable process execution timeout (#1491)

### DIFF
--- a/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/platform/Command.java
+++ b/components/api/api-modules-java/src/main/java/org/eclipse/dirigible/sdk/platform/Command.java
@@ -19,13 +19,11 @@ import org.eclipse.dirigible.components.api.platform.CommandFacade;
 /**
  * Spawns OS-level processes from the JVM, captures their merged stdout/stderr, and returns it as a
  * String. The first overload runs with the inherited environment; the second and third let you add
- * or remove specific variables; the third also accepts a {@link ProcessExecutionOptions} record for
- * advanced settings (working directory, timeout, capture-error-stream toggle).
+ * or remove specific variables; the third also accepts {@link ProcessExecutionOptions} for advanced
+ * settings (working directory and execution timeout).
  * <p>
- * Use with caution — the command string is passed to a shell on POSIX and to {@code cmd /c} on
- * Windows, so any user-supplied input must be sanitized or the call should use an
- * {@code ProcessExecutionOptions} variant that takes an argv array (see the commons-process package
- * for the full API).
+ * Use with caution — the command string is split into an executable and its arguments, so any
+ * user-supplied input must be sanitized by the caller.
  */
 public final class Command {
 

--- a/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
+++ b/components/api/api-modules-javascript/src/main/resources/META-INF/dirigible/modules/src/platform/command.ts
@@ -4,11 +4,12 @@
  * @name Command
  * @overview
  * 
- * The Command module provides a static utility class for executing system commands through the platform's CommandEngine. It allows developers to run shell commands with configurable options, including working directory and environment variable management. The module abstracts the complexities of process execution, providing a simple interface for integrating command execution into applications.
- * 
+ * The Command module provides a static utility class for executing system commands through the platform's CommandEngine. It allows developers to run shell commands with configurable options, including working directory, execution timeout and environment variable management. The module abstracts the complexities of process execution, providing a simple interface for integrating command execution into applications.
+ *
  * ### Key Features:
  * - **Command Execution**: The `execute` method allows for running system commands with specified options and environment variable configurations.
  * - **Structured Output**: The method returns a structured output containing the exit code, standard output, and error output of the executed command.
+ * - **Timeouts**: A `timeoutMillis` option destroys a command that outlives it, so a hung process cannot block the caller indefinitely.
  * 
  * ### Use Cases:
  * - **System Integration**: This module is ideal for applications that need to interact with the underlying operating system or execute external processes as part of their functionality.
@@ -22,6 +23,9 @@
  * console.log("Exit Code:", result.exitCode);
  * console.log("Standard Output:", result.standardOutput);
  * console.log("Error Output:", result.errorOutput);
+ *
+ * // Give up on a command that takes longer than five seconds
+ * Command.execute("./long-running.sh", { timeoutMillis: 5000 });
  * ```
  */
 
@@ -33,7 +37,13 @@ const ProcessExecutionOptions = Java.type("org.eclipse.dirigible.commons.process
  */
 interface CommandOptions {
 	/** The directory in which the command will be executed. */
-	workingDirectory: string
+	workingDirectory?: string
+	/**
+	 * The maximum time in milliseconds the command is allowed to run. A command still running when the
+	 * timeout elapses is destroyed and the execution throws instead of returning an exit code.
+	 * Omit to let the command run for as long as it needs.
+	 */
+	timeoutMillis?: number
 }
 
 /**
@@ -76,6 +86,10 @@ export class Command {
 
 		if (options?.workingDirectory) {
 			processExecutionOptions.setWorkingDirectory(options.workingDirectory);
+		}
+
+		if (options?.timeoutMillis) {
+			processExecutionOptions.setTimeoutMillis(options.timeoutMillis);
 		}
 
 		// The facade returns a JSON string, which we parse into the CommandOutput interface

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionException.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionException.java
@@ -22,4 +22,14 @@ public class ProcessExecutionException extends RuntimeException {
     public ProcessExecutionException(Throwable cause) {
         super(cause);
     }
+
+    /**
+     * Instantiates a new process execution exception.
+     *
+     * @param message the message
+     * @param cause the cause
+     */
+    public ProcessExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionFuture.java
@@ -9,14 +9,36 @@
  */
 package org.eclipse.dirigible.commons.process.execution;
 
+import jakarta.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import org.apache.commons.exec.ExecuteException;
 import org.apache.commons.exec.ExecuteResultHandler;
+import org.apache.commons.exec.ExecuteWatchdog;
 
 /**
  * The Class ProcessExecutionFuture.
  */
 public class ProcessExecutionFuture extends CompletableFuture<Integer> implements ExecuteResultHandler {
+
+    /** The watchdog enforcing the process timeout, or null when the process is not time-limited. */
+    private final ExecuteWatchdog watchdog;
+
+    /**
+     * Instantiates a new process execution future for a process that is not time-limited.
+     */
+    public ProcessExecutionFuture() {
+        this(null);
+    }
+
+    /**
+     * Instantiates a new process execution future.
+     *
+     * @param watchdog the watchdog enforcing the process timeout, or {@code null} when the process is
+     *        not time-limited
+     */
+    public ProcessExecutionFuture(@Nullable ExecuteWatchdog watchdog) {
+        this.watchdog = watchdog;
+    }
 
     /**
      * On process complete.
@@ -29,12 +51,18 @@ public class ProcessExecutionFuture extends CompletableFuture<Integer> implement
     }
 
     /**
-     * On process failed.
+     * On process failed. A process destroyed by the watchdog exceeded its configured timeout and never
+     * produced a meaningful exit code, so the failure is propagated instead of being reported as an
+     * ordinary non-zero exit.
      *
      * @param e the e
      */
     @Override
     public void onProcessFailed(ExecuteException e) {
-        complete(e.getExitValue());
+        if (watchdog != null && watchdog.killedProcess()) {
+            completeExceptionally(new ProcessExecutionException("The process was destroyed after exceeding its configured timeout", e));
+        } else {
+            complete(e.getExitValue());
+        }
     }
 }

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionOptions.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutionOptions.java
@@ -13,6 +13,7 @@ import jakarta.annotation.Nullable;
 
 public class ProcessExecutionOptions {
     private String workingDirectory;
+    private Long timeoutMillis;
 
     public void setWorkingDirectory(@Nullable String workingDirectory) {
         this.workingDirectory = workingDirectory;
@@ -21,5 +22,31 @@ public class ProcessExecutionOptions {
     @Nullable
     public String getWorkingDirectory() {
         return workingDirectory;
+    }
+
+    /**
+     * Sets the maximum time the process is allowed to run. A process that is still running when the
+     * timeout elapses is destroyed, and the execution fails with a {@link ProcessExecutionException}
+     * instead of returning an exit code.
+     *
+     * @param timeoutMillis the timeout in milliseconds, or {@code null} to let the process run for as
+     *        long as it needs
+     * @throws IllegalArgumentException if the timeout is not a positive number of milliseconds
+     */
+    public void setTimeoutMillis(@Nullable Long timeoutMillis) {
+        if (timeoutMillis != null && timeoutMillis <= 0) {
+            throw new IllegalArgumentException("Process timeout must be a positive number of milliseconds but was: " + timeoutMillis);
+        }
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    /**
+     * Gets the maximum time the process is allowed to run.
+     *
+     * @return the timeout in milliseconds, or {@code null} when the process is not time-limited
+     */
+    @Nullable
+    public Long getTimeoutMillis() {
+        return timeoutMillis;
     }
 }

--- a/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutor.java
+++ b/modules/commons/commons-process/src/main/java/org/eclipse/dirigible/commons/process/execution/ProcessExecutor.java
@@ -18,6 +18,7 @@ import org.eclipse.dirigible.commons.process.execution.output.ProcessResult;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -68,6 +69,13 @@ public abstract class ProcessExecutor<TOut> {
                 executor.setWorkingDirectory(workingDirectory);
             }
 
+            Long maybeTimeoutMillis = options.getTimeoutMillis();
+            if (maybeTimeoutMillis != null) {
+                executor.setWatchdog(ExecuteWatchdog.builder()
+                                                    .setTimeout(Duration.ofMillis(maybeTimeoutMillis))
+                                                    .get());
+            }
+
             return executeProcess(commandLine, executor, environmentVariables);
         } catch (Throwable t) {
             throw new ProcessExecutionException(t);
@@ -110,7 +118,7 @@ public abstract class ProcessExecutor<TOut> {
      */
     protected ProcessExecutionFuture execute(DefaultExecutor executor, CommandLine commandLine, Map<String, String> environmentVariables)
             throws IOException {
-        ProcessExecutionFuture processExecutionFuture = new ProcessExecutionFuture();
+        ProcessExecutionFuture processExecutionFuture = new ProcessExecutionFuture(executor.getWatchdog());
         executor.execute(commandLine, environmentVariables, processExecutionFuture);
         return processExecutionFuture;
     }

--- a/modules/commons/commons-process/src/test/java/org/eclipse/dirigible/commons/process/test/ProcessExecutionTimeoutTest.java
+++ b/modules/commons/commons-process/src/test/java/org/eclipse/dirigible/commons/process/test/ProcessExecutionTimeoutTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.commons.process.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.eclipse.dirigible.commons.process.execution.ProcessExecutionException;
+import org.eclipse.dirigible.commons.process.execution.ProcessExecutionOptions;
+import org.eclipse.dirigible.commons.process.execution.ProcessExecutor;
+import org.eclipse.dirigible.commons.process.execution.output.OutputsPair;
+import org.eclipse.dirigible.commons.process.execution.output.ProcessResult;
+import org.junit.Test;
+
+/**
+ * Tests the configurable process timeout of {@link ProcessExecutionOptions}.
+ */
+public class ProcessExecutionTimeoutTest {
+
+    /** How long the long-running command would run if it were left alone. */
+    private static final int LONG_COMMAND_SECONDS = 20;
+
+    /** The timeout the long-running command is expected to be destroyed after. */
+    private static final long TIMEOUT_MILLIS = 500;
+
+    private static final boolean WINDOWS = System.getProperty("os.name")
+                                                 .toLowerCase()
+                                                 .contains("win");
+
+    /**
+     * A process that outlives its timeout is destroyed, and the failure surfaces to the caller instead
+     * of being reported as an ordinary non-zero exit code.
+     */
+    @Test
+    public void testProcessExceedingTimeoutIsDestroyed() {
+        ProcessExecutionOptions options = new ProcessExecutionOptions();
+        options.setTimeoutMillis(TIMEOUT_MILLIS);
+
+        long start = System.nanoTime();
+        Future<ProcessResult<OutputsPair>> future = ProcessExecutor.create()
+                                                                   .executeProcess(longRunningCommand(), null, options);
+
+        ExecutionException exception = assertThrows(ExecutionException.class, future::get);
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue("Expected a ProcessExecutionException cause but got: " + exception.getCause(),
+                exception.getCause() instanceof ProcessExecutionException);
+        assertTrue("The process should have been destroyed long before it finished on its own, but it took " + elapsedMillis + "ms",
+                elapsedMillis < LONG_COMMAND_SECONDS * 1000L / 2);
+    }
+
+    /**
+     * A process that finishes within its timeout is unaffected by the watchdog.
+     */
+    @Test
+    public void testProcessWithinTimeoutSucceeds() throws ExecutionException, InterruptedException {
+        ProcessExecutionOptions options = new ProcessExecutionOptions();
+        options.setTimeoutMillis(60_000L);
+
+        ProcessResult<OutputsPair> result = ProcessExecutor.create()
+                                                           .executeProcess(quickCommand(), null, options)
+                                                           .get();
+
+        assertEquals(0, result.getExitCode());
+    }
+
+    /**
+     * Not configuring a timeout keeps the previous unbounded behaviour.
+     */
+    @Test
+    public void testProcessWithoutTimeoutSucceeds() throws ExecutionException, InterruptedException {
+        ProcessResult<OutputsPair> result = ProcessExecutor.create()
+                                                           .executeProcess(quickCommand(), null, new ProcessExecutionOptions())
+                                                           .get();
+
+        assertEquals(0, result.getExitCode());
+    }
+
+    /**
+     * A non-positive timeout is a caller mistake - it would destroy the process immediately - and is
+     * rejected where it is configured rather than at execution time.
+     */
+    @Test
+    public void testNonPositiveTimeoutIsRejected() {
+        ProcessExecutionOptions options = new ProcessExecutionOptions();
+
+        assertThrows(IllegalArgumentException.class, () -> options.setTimeoutMillis(0L));
+        assertThrows(IllegalArgumentException.class, () -> options.setTimeoutMillis(-1L));
+    }
+
+    /**
+     * A command that runs for {@value #LONG_COMMAND_SECONDS} seconds. Windows has no {@code sleep}
+     * executable, so a loopback ping of one packet per second stands in for it.
+     *
+     * @return the command line
+     */
+    private static String longRunningCommand() {
+        return WINDOWS ? "ping -n " + (LONG_COMMAND_SECONDS + 1) + " 127.0.0.1" : "sleep " + LONG_COMMAND_SECONDS;
+    }
+
+    /**
+     * A command that exits successfully straight away.
+     *
+     * @return the command line
+     */
+    private static String quickCommand() {
+        return WINDOWS ? "cmd /c echo ok" : "echo ok";
+    }
+}


### PR DESCRIPTION
Closes #1491.

## Why this issue was still open

#1491 asked for a process-executor API that is easy to configure. Two of its three items landed with #1487 back in 2022:

- [x] Easily configuring if the process error stream should be redirected to the out stream
- [x] Support async programming and don't block the caller thread
- [ ] **Easily configuring process timeouts** ← this PR

The author's own comment on the issue said as much ("Only partially, I have to add some functionality for timeouts and we'll close this"), which is why it was never auto-closed by #1487. Meanwhile the SDK `Command` javadoc already advertised a timeout that `ProcessExecutionOptions` never had.

## The change

| | |
|---|---|
| `ProcessExecutionOptions.timeoutMillis` | Nullable — `null` keeps the previous unbounded behaviour, so nothing changes for existing callers. A non-positive value throws `IllegalArgumentException` at configuration time (it would otherwise destroy the process immediately). |
| `ProcessExecutor` | Installs an `ExecuteWatchdog` for that duration via the non-deprecated `ExecuteWatchdog.builder()` (commons-exec 1.6.0). |
| `ProcessExecutionFuture` | Completes **exceptionally** when the watchdog destroyed the process. |
| `@aerokit/sdk/platform` `Command` | Accepts `timeoutMillis`; `workingDirectory` becomes optional so a caller can pass a timeout alone. |

Two design notes:

- **No signature churn.** The watchdog is read back off the executor with `executor.getWatchdog()` inside the existing `protected execute(...)`, so neither the abstract `executeProcess` contract nor `DefaultProcessExecutor` / `ErrorsRedirectProcessExecutor` change at all.
- **Timeout is an exception, not an exit code.** A destroyed process never produced a meaningful exit code, so completing with `e.getExitValue()` would be indistinguishable from a command that simply failed. `CommandFacade.execute` already declares `ExecutionException`, so this surfaces through the existing signatures with no API break.

```ts
import { Command } from "@aerokit/sdk/platform";

// give up on a command that takes longer than five seconds
Command.execute("./long-running.sh", { timeoutMillis: 5000 });
```

## Drive-by doc correction

The SDK `Command` javadoc claimed a capture-error-stream toggle and an `ProcessExecutionOptions` argv-array variant that **do not exist**, and said the command is "passed to a shell on POSIX and to `cmd /c` on Windows" when `ProcessExecutor` splits it via `Commandline.translateCommandline` and execs the binary directly — so the sanitisation advice was misleading. Rewritten to describe the two options that actually exist.

## Verification

- **4 new unit tests** in `commons-process`: destroy-on-timeout (a 20 s command killed at 500 ms, asserted via both the exception cause and elapsed time), completion inside a generous timeout, the no-timeout path (guards the null branch), and the non-positive rejection. OS-branched because unit tests run on the **ubuntu + windows** matrix and Windows has no `sleep` executable.
- `mvn -P unit-tests install` on `commons-process`, `api-platform`, `api-modules-java` — 6/6 green in commons-process, no regressions downstream.
- `mvn formatter:validate` clean (cache wiped first).
- `mvn -P release ... install` — javadoc builds with **zero** `error:`; remaining warnings are pre-existing "no comment" / default-constructor ones.
- TS rebuilt: `setTimeoutMillis` present in `dist/esm/platform/command.mjs` and `dist/cjs/platform/command.js`, `timeoutMillis?: number` in the generated `.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)