### PR TITLE
feat(core): platform readiness consumers - availability bridge, boot gate, IDE indicator (#6448)

### DIFF
--- a/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/readiness/PlatformReadiness.java
+++ b/components/core/core-base/src/main/java/org/eclipse/dirigible/components/base/readiness/PlatformReadiness.java
@@ -10,8 +10,13 @@
 package org.eclipse.dirigible.components.base.readiness;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The platform readiness state, keyed to artefact depletion (#6448): a synchronization pass that
@@ -28,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class PlatformReadiness {
 
-    /** The lifecycle: INITIALIZING (boot) -> READY | READY_DEGRADED <-> SYNCHRONIZING. */
+    /** The lifecycle: INITIALIZING (boot) &rarr; READY | READY_DEGRADED &harr; SYNCHRONIZING. */
     public enum State {
         /** Booting - the first synchronization pass has not depleted yet. */
         INITIALIZING,
@@ -42,9 +47,13 @@ public final class PlatformReadiness {
 
     private static final PlatformReadiness INSTANCE = new PlatformReadiness();
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlatformReadiness.class);
+
     private final AtomicReference<State> state = new AtomicReference<>(State.INITIALIZING);
     private final AtomicBoolean bootCompleted = new AtomicBoolean(false);
+    private final List<Consumer<State>> listeners = new CopyOnWriteArrayList<>();
     private volatile int failedArtefacts = 0;
+    private volatile int pendingArtefacts = 0;
     private volatile Instant since = Instant.now();
 
     private PlatformReadiness() {}
@@ -67,8 +76,24 @@ public final class PlatformReadiness {
      */
     public void passCompleted(int failed) {
         failedArtefacts = Math.max(failed, 0);
+        pendingArtefacts = 0;
         bootCompleted.set(true);
         transition(failedArtefacts == 0 ? State.READY : State.READY_DEGRADED);
+    }
+
+    /**
+     * Reports how many artefacts the running pass has still to deplete, so the readiness endpoint and
+     * the IDE indicator can show progress rather than an opaque spinner.
+     *
+     * @param pending the undepleted artefact count
+     */
+    public void passProgress(int pending) {
+        pendingArtefacts = Math.max(pending, 0);
+    }
+
+    /** The artefacts the running pass has still to deplete (0 when no pass is running). */
+    public int getPendingArtefacts() {
+        return pendingArtefacts;
     }
 
     public State getState() {
@@ -90,17 +115,40 @@ public final class PlatformReadiness {
         return bootCompleted.get();
     }
 
+    /**
+     * Registers a listener notified after every state change. Listeners run on the synchronizer's
+     * thread, so a slow or throwing one must not disturb the pass - a failure is logged and swallowed.
+     *
+     * @param listener the listener
+     */
+    public void addStateListener(Consumer<State> listener) {
+        listeners.add(listener);
+    }
+
     /** Test seam: reset to the boot state (the singleton outlives a test's application context). */
     public void reset() {
         state.set(State.INITIALIZING);
         bootCompleted.set(false);
         failedArtefacts = 0;
+        pendingArtefacts = 0;
         since = Instant.now();
+        listeners.clear();
     }
 
     private void transition(State next) {
         if (state.getAndSet(next) != next) {
             since = Instant.now();
+            notifyListeners(next);
+        }
+    }
+
+    private void notifyListeners(State next) {
+        for (Consumer<State> listener : listeners) {
+            try {
+                listener.accept(next);
+            } catch (RuntimeException ex) {
+                LOGGER.error("Platform readiness listener [{}] failed for state [{}]", listener, next, ex);
+            }
         }
     }
 }

--- a/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/endpoint/ReadinessEndpoint.java
+++ b/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/endpoint/ReadinessEndpoint.java
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReadinessEndpoint {
 
     /** The readiness payload. */
-    public record Readiness(String status, boolean acceptingTraffic, int failedArtefacts, String since) {
+    public record Readiness(String status, boolean acceptingTraffic, int pendingArtefacts, int failedArtefacts, String since) {
     }
 
     /**
@@ -39,8 +39,8 @@ public class ReadinessEndpoint {
         PlatformReadiness readiness = PlatformReadiness.getInstance();
         return ResponseEntity.ok(new Readiness(readiness.getState()
                                                         .name(),
-                readiness.isBootCompleted(), readiness.getFailedArtefacts(), readiness.getSince()
-                                                                                      .toString()));
+                readiness.isBootCompleted(), readiness.getPendingArtefacts(), readiness.getFailedArtefacts(), readiness.getSince()
+                                                                                                                       .toString()));
     }
 
 }

--- a/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/filter/HealthCheckFilter.java
+++ b/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/filter/HealthCheckFilter.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.components.base.healthcheck.filter;
 
 import java.io.IOException;
+import java.util.List;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -20,14 +21,46 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.eclipse.dirigible.components.base.healthcheck.status.HealthCheckStatus;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.readiness.PlatformReadiness;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 
 /**
- * The HTTP Context Filter.
+ * The boot-only traffic gate (#6448): while the first synchronization pass has not depleted its
+ * artefact queue, application-facing requests are refused, because they would otherwise hit
+ * half-initialized state (missing artefacts, unregistered controllers, unimported CSVIM data).
+ *
+ * <p>
+ * Keyed to {@link PlatformReadiness#isBootCompleted()} - a ONE-WAY latch, so a later publish never
+ * takes a running application offline, however long its pass runs. A browser is sent to the
+ * auto-refreshing busy page it has always been sent to; every other client now gets a
+ * {@code 503 Service Unavailable} with {@code Retry-After}, which is what an API client, a CI
+ * pipeline or a probe can actually act on.
+ *
+ * <p>
+ * {@link #EXCLUDED_PREFIXES} is the set of paths that must keep working while the platform boots -
+ * the IDE (so a developer can watch the instance come up), authentication, the health and readiness
+ * endpoints, the actuator, and static resources.
  */
 @Component
 public class HealthCheckFilter implements Filter {
+
+    /**
+     * Paths served during boot. Matched against the servlet path with the {@code /services} and
+     * {@code /public} prefixes stripped (see {@link #getRequestPath(HttpServletRequest)}), so an IDE
+     * module at {@code /services/web/shell-ide/...} is matched as {@code /web/shell-ide/...}.
+     */
+    private static final List<String> EXCLUDED_PREFIXES = List.of( //
+            // Static and shared resources.
+            "/web/resources", "/js/resources", "/webjars", "/web/theme/", "/js/theme/", //
+            // The platform's own status surfaces and the busy page itself.
+            "/core/healthcheck", "/core/readiness", "/index-busy.html", "/ops", "/actuator", "/error", //
+            // Authentication - a user must be able to reach the IDE while the instance boots.
+            "/login", "/logout", "/oauth2", "/saml2", //
+            // The IDE shell and the modules it loads.
+            "/web/shell-ide", "/web/platform-core", "/js/platform-core", "/web/ide-", "/web/editor-", "/web/view-", "/web/perspective-",
+            "/web/menu-", "/web/service-", "/ide/", "/websockets/ide");
 
     /**
      * Inits the.
@@ -53,73 +86,57 @@ public class HealthCheckFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
-        String path = getRequestPath(httpRequest);
-        boolean isResources = isResourcesRequest(path);
-        boolean isHealthCheck = isHealtCheckRequest(path);
-        boolean isOps = isOpsRequest(path);
-        boolean isWebJars = isWebJarsRequest(path);
-        boolean isTheme = isThemeRequest(path);
-        if (!isResources && !isHealthCheck && !isOps && !isWebJars && !isTheme) {
-            HealthCheckStatus healthStatus = HealthCheckStatus.getInstance();
-            if (healthStatus.getStatus()
-                            .equals(HealthCheckStatus.Status.Ready)) {
-                chain.doFilter(request, response);
-                return;
-            }
+        if (PlatformReadiness.getInstance()
+                             .isBootCompleted()
+                || isExcluded(getRequestPath(httpRequest))) {
+            chain.doFilter(request, response);
+            return;
+        }
+        refuse(httpRequest, httpResponse);
+    }
+
+    /**
+     * Refuses the request: the auto-refreshing busy page for a browser, a retryable 503 for every other
+     * client.
+     *
+     * @param httpRequest the request
+     * @param httpResponse the response
+     * @throws IOException Signals that an I/O exception has occurred.
+     */
+    private void refuse(HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws IOException {
+        if (acceptsHtml(httpRequest)) {
             httpResponse.sendRedirect("/index-busy.html");
             return;
         }
-        chain.doFilter(request, response);
+        httpResponse.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        httpResponse.setHeader(HttpHeaders.RETRY_AFTER, Integer.toString(DirigibleConfig.READINESS_GATE_RETRY_AFTER_SECONDS.getIntValue()));
     }
 
     /**
-     * Checks if is resources request.
+     * Whether the caller wants a page rather than data. A browser navigation sends
+     * {@code Accept: text/html,...}; an API client, a probe or a {@code fetch()} does not.
      *
-     * @param path the path
-     * @return true, if is resources request
+     * @param httpRequest the request
+     * @return true when the caller accepts HTML
      */
-    private boolean isResourcesRequest(String path) {
-        return path.startsWith("/web/resources") || path.startsWith("/js/resources");
+    private boolean acceptsHtml(HttpServletRequest httpRequest) {
+        String accept = httpRequest.getHeader(HttpHeaders.ACCEPT);
+        return accept != null && accept.contains("text/html");
     }
 
     /**
-     * Checks if is healt check request.
+     * Checks whether the path must be served while the platform boots.
      *
      * @param path the path
-     * @return true, if is healt check request
+     * @return true, if the path is excluded from the gate
      */
-    private boolean isHealtCheckRequest(String path) {
-        return path.startsWith("/core/healthcheck") || path.startsWith("/index-busy.html");
-    }
-
-    /**
-     * Checks if is ops request.
-     *
-     * @param path the path
-     * @return true, if is ops request
-     */
-    private boolean isOpsRequest(String path) {
-        return path.startsWith("/ops");
-    }
-
-    /**
-     * Checks if is web jars request.
-     *
-     * @param path the path
-     * @return true, if is web jars request
-     */
-    private boolean isWebJarsRequest(String path) {
-        return path.startsWith("/webjars");
-    }
-
-    /**
-     * Checks if is theme request.
-     *
-     * @param path the path
-     * @return true, if is theme request
-     */
-    private boolean isThemeRequest(String path) {
-        return path.startsWith("/web/theme/") || path.startsWith("/js/theme/");
+    private boolean isExcluded(String path) {
+        for (String prefix : EXCLUDED_PREFIXES) {
+            if (path.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -136,14 +153,6 @@ public class HealthCheckFilter implements Filter {
                        .replace("/public", "");
         }
         return path;
-    }
-
-    /**
-     * Destroy.
-     */
-    @Override
-    public void destroy() {
-        // Not used
     }
 
 }

--- a/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/readiness/ReadinessAvailabilityBridge.java
+++ b/components/core/core-healthcheck/src/main/java/org/eclipse/dirigible/components/base/healthcheck/readiness/ReadinessAvailabilityBridge.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.healthcheck.readiness;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.dirigible.commons.config.DirigibleConfig;
+import org.eclipse.dirigible.components.base.readiness.PlatformReadiness;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bridges the platform readiness (#6448) onto Spring's {@code ApplicationAvailability}, so
+ * {@code /actuator/health/readiness} - and therefore any orchestrator's readiness probe - refuses
+ * traffic until the first synchronization pass has depleted its artefact queue. Off by default: it
+ * changes what an orchestrator does with the instance, so it is an operator's decision
+ * ({@code DIRIGIBLE_READINESS_AVAILABILITY_BRIDGE_ENABLED}).
+ *
+ * <p>
+ * Spring Boot publishes {@code ACCEPTING_TRAFFIC} itself on {@link ApplicationReadyEvent}, so the
+ * refusal has to be published after that event to win; the platform then flips to
+ * {@code ACCEPTING_TRAFFIC} when the boot latch closes. Later passes (a publish) are deliberately
+ * NOT bridged - a publish must never take a running application out of the load balancer.
+ */
+@Component
+class ReadinessAvailabilityBridge {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReadinessAvailabilityBridge.class);
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    /** The acceptance is published once - later passes must not re-announce it on every transition. */
+    private final AtomicBoolean trafficAccepted = new AtomicBoolean(false);
+
+    ReadinessAvailabilityBridge(ApplicationEventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    void refuseTrafficUntilArtefactsDeplete() {
+        if (!DirigibleConfig.READINESS_AVAILABILITY_BRIDGE_ENABLED.getBooleanValue()) {
+            return;
+        }
+        PlatformReadiness readiness = PlatformReadiness.getInstance();
+        if (readiness.isBootCompleted()) {
+            // The first pass already depleted while the context was starting - nothing to hold back.
+            return;
+        }
+        readiness.addStateListener(state -> {
+            if (PlatformReadiness.getInstance()
+                                 .isBootCompleted()) {
+                acceptTraffic();
+            }
+        });
+        LOGGER.info("Refusing traffic until the first synchronization pass depletes its artefacts");
+        AvailabilityChangeEvent.publish(eventPublisher, this, ReadinessState.REFUSING_TRAFFIC);
+    }
+
+    private void acceptTraffic() {
+        if (!trafficAccepted.compareAndSet(false, true)) {
+            return;
+        }
+        LOGGER.info("The first synchronization pass depleted - accepting traffic");
+        AvailabilityChangeEvent.publish(eventPublisher, this, ReadinessState.ACCEPTING_TRAFFIC);
+    }
+}

--- a/components/core/core-healthcheck/src/test/java/org/eclipse/dirigible/components/base/healthcheck/filter/HealthCheckFilterTest.java
+++ b/components/core/core-healthcheck/src/test/java/org/eclipse/dirigible/components/base/healthcheck/filter/HealthCheckFilterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.base.healthcheck.filter;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.dirigible.components.base.readiness.PlatformReadiness;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+/**
+ * The boot-only traffic gate (#6448).
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class HealthCheckFilterTest {
+
+    private static final String APP_PATH = "/services/web/myapp/index.html";
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    private final HealthCheckFilter filter = new HealthCheckFilter();
+
+    @BeforeEach
+    void resetReadiness() {
+        PlatformReadiness.getInstance()
+                         .reset();
+    }
+
+    @AfterEach
+    void releaseTheGate() {
+        // The singleton outlives the test - leave it open so unrelated tests are unaffected.
+        PlatformReadiness.getInstance()
+                         .passCompleted(0);
+    }
+
+    @Test
+    void aBootedInstancePassesEverythingThrough() throws Exception {
+        PlatformReadiness.getInstance()
+                         .passCompleted(0);
+        givenServletPath(APP_PATH);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void anApiClientIsRefusedWithARetryableUnavailableDuringBoot() throws Exception {
+        givenServletPath(APP_PATH);
+        when(request.getHeader("Accept")).thenReturn("application/json");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, never()).doFilter(request, response);
+        verify(response).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        verify(response).setHeader("Retry-After", "5");
+    }
+
+    @Test
+    void aBrowserIsSentToTheBusyPageDuringBoot() throws Exception {
+        givenServletPath(APP_PATH);
+        when(request.getHeader("Accept")).thenReturn("text/html,application/xhtml+xml");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain, never()).doFilter(request, response);
+        verify(response).sendRedirect("/index-busy.html");
+        verify(response, never()).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * The IDE, authentication, the actuator and the platform's own status surfaces have to answer while
+     * the instance boots - that is how an operator finds out what it is waiting for.
+     */
+    @Test
+    void thePathsNeededToDiagnoseBootAreNeverGated() throws Exception {
+        for (String path : new String[] {"/services/web/shell-ide/index.html", "/services/core/readiness",
+                "/services/core/healthcheck/status", "/actuator/health/readiness", "/login", "/webjars/alpinejs/dist/cdn.min.js",
+                "/services/web/platform-core/ui/styles/fonts.css", "/index-busy.html"}) {
+            FilterChain freshChain = org.mockito.Mockito.mock(FilterChain.class);
+            HttpServletRequest freshRequest = org.mockito.Mockito.mock(HttpServletRequest.class);
+            when(freshRequest.getPathInfo()).thenReturn(null);
+            when(freshRequest.getServletPath()).thenReturn(path);
+
+            filter.doFilter(freshRequest, response, freshChain);
+
+            verify(freshChain, org.mockito.Mockito.description(path + " must be served during boot")).doFilter(freshRequest, response);
+        }
+        verify(response, never()).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        verify(response, never()).sendRedirect(anyString());
+    }
+
+    private void givenServletPath(String path) {
+        when(request.getPathInfo()).thenReturn(null);
+        when(request.getServletPath()).thenReturn(path);
+    }
+}

--- a/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
+++ b/components/core/core-initializers/src/main/java/org/eclipse/dirigible/components/initializers/synchronizer/SynchronizationProcessor.java
@@ -339,6 +339,9 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
 
                             logger.info("Retry [{}] - cross-processing of [{}] undepleated artefacts: [{}]", (retryCount + 1),
                                     undepleted.size(), undepleted);
+                            // Progress for the readiness endpoint and the IDE indicator (#6448).
+                            org.eclipse.dirigible.components.base.readiness.PlatformReadiness.getInstance()
+                                                                                             .passProgress(undepleted.size());
                             Set<TopologyWrapper<? extends Artefact>> cross = new HashSet<>();
                             Set<TopologyWrapper<? extends Artefact>> results = depleter.deplete(undepleted, ArtefactPhase.PREPARE);
                             cross.addAll(results);
@@ -413,10 +416,6 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
             });
 
             logger.info("Processing synchronizers completed!");
-            // The queue is depleted - the instance is READY (#6448). Artefacts that parked FAILED
-            // after their retries degrade the state but never block it.
-            org.eclipse.dirigible.components.base.readiness.PlatformReadiness.getInstance()
-                                                                             .passCompleted(getErrors().size());
 
         } finally {
             if (logger.isDebugEnabled()) {
@@ -444,6 +443,12 @@ public class SynchronizationProcessor implements SynchronizationWalkerCallback, 
 
             initialized.set(true);
             processing.set(false);
+            // The queue is depleted - the instance is READY (#6448). Artefacts that parked FAILED
+            // after their retries degrade the state but never block it. Deliberately in the finally:
+            // the boot gate is keyed to this latch, so a pass that THREW must not pin the instance at
+            // INITIALIZING forever - one broken pass blocks traffic no more than one broken artefact.
+            org.eclipse.dirigible.components.base.readiness.PlatformReadiness.getInstance()
+                                                                             .passCompleted(getErrors().size());
         }
     }
 

--- a/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
+++ b/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/platform/shell.js
@@ -699,11 +699,49 @@ if (window !== top) {
             </bk-notification>
         </div>`,
     }))
-    .directive("statusBar", () => ({
+    .directive("statusBar", ["$http", "$interval", ($http, $interval) => ({
       restrict: "E",
       replace: true,
       link: (scope) => {
         const statusBarHub = new StatusBarHub();
+        // The platform readiness indicator (#6448): the honest answer to "did the synchronization
+        // finish?", which until now meant grepping the log for "Processing synchronizers completed!".
+        // Polled fast while a pass is running, slowly once booted (just to catch a publish).
+        const READINESS_URL = "/services/core/readiness";
+        const POLL_BOOTING = 3000;
+        const POLL_IDLE = 30000;
+        let readinessPoll = null;
+        scope.readiness = null;
+        scope.readinessText = () => {
+          const r = scope.readiness;
+          if (!r) return "";
+          if (r.status === "INITIALIZING" || r.status === "SYNCHRONIZING") {
+            return r.pendingArtefacts > 0 ? `Synchronizing... (${r.pendingArtefacts} pending)` : "Synchronizing...";
+          }
+          return r.status === "READY_DEGRADED" ? `Ready - ${r.failedArtefacts} failed` : "Ready";
+        };
+        scope.readinessBusy = () => {
+          const s = scope.readiness && scope.readiness.status;
+          return s === "INITIALIZING" || s === "SYNCHRONIZING";
+        };
+        scope.readinessDegraded = () => scope.readiness && scope.readiness.status === "READY_DEGRADED";
+        const pollReadiness = () => {
+          $http.get(READINESS_URL).then(
+            (response) => {
+              const wasBusy = scope.readinessBusy();
+              scope.readiness = response.data;
+              // Re-arm the interval when the pace should change (a pass started or finished).
+              if (wasBusy !== scope.readinessBusy()) scheduleReadiness();
+            },
+            () => (scope.readiness = null),
+          );
+        };
+        const scheduleReadiness = () => {
+          if (readinessPoll) $interval.cancel(readinessPoll);
+          readinessPoll = $interval(pollReadiness, scope.readinessBusy() ? POLL_BOOTING : POLL_IDLE);
+        };
+        pollReadiness();
+        scheduleReadiness();
         scope.busy = "";
         scope.message = "";
         scope.label = "";
@@ -727,6 +765,7 @@ if (window !== top) {
           statusBarHub.removeMessageListener(messageListener);
           statusBarHub.removeMessageListener(errorListener);
           statusBarHub.removeMessageListener(labelListener);
+          if (readinessPoll) $interval.cancel(readinessPoll);
         });
       },
       template: `<div class="statusbar bk-border--top">
@@ -742,5 +781,11 @@ if (window !== top) {
                 <i class="statusbar--icon statusbar--link sap-icon--delete" ng-click="clearError()"></i>
             </div>
             <div class="statusbar-label" ng-if="label"><span class="statusbar--text">{{ label }}</span></div>
+            <div class="statusbar-readiness" ng-if="readiness" ng-class="{ 'statusbar-readiness--degraded': readinessDegraded() }" title="{{ readinessText() }}">
+                <bk-loader ng-if="readinessBusy()" contrast="true"></bk-loader>
+                <i ng-if="!readinessBusy() && !readinessDegraded()" class="statusbar--icon sap-icon--sys-enter-2"></i>
+                <i ng-if="readinessDegraded()" class="statusbar--icon sap-icon--alert"></i>
+                <span class="statusbar--text">{{ readinessText() }}</span>
+            </div>
         </div>`,
-    }));
+    })]);

--- a/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/styles/shell.css
+++ b/components/resources/platform-core/src/main/resources/META-INF/dirigible/platform-core/ui/styles/shell.css
@@ -252,3 +252,27 @@ body:not(.bk-backdrop--active)>.main-header>.fd-shellbar {
     word-wrap: break-word;
     white-space: wrap;
 }
+/* The platform readiness indicator (#6448): pinned to the trailing edge of the status bar - a
+   spinner while a synchronization pass runs, then a quiet "Ready", or a warning tint when
+   artefacts parked terminally FAILED. */
+.statusbar-readiness {
+    min-width: fit-content;
+    max-width: fit-content;
+    justify-content: end;
+    margin-inline-start: auto;
+    padding-inline: 0.5rem;
+    gap: 0.5rem;
+}
+
+.statusbar-readiness>* {
+    box-sizing: border-box;
+}
+
+.statusbar-readiness--degraded {
+    color: var(--warning-foreground);
+    background-color: var(--warning);
+}
+
+.statusbar-readiness--degraded .statusbar--icon {
+    color: var(--warning-foreground);
+}

--- a/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
+++ b/modules/commons/commons-config/src/main/java/org/eclipse/dirigible/commons/config/DirigibleConfig.java
@@ -62,6 +62,12 @@ public enum DirigibleConfig {
 
     SYNCHRONIZER_CROSS_RETRY_INTERVAL_MILLIS("DIRIGIBLE_SYNCHRONIZER_CROSS_RETRY_INTERVAL_MILLIS", "10000"), //
 
+    /** Bridge the platform readiness onto Spring's ApplicationAvailability (#6448). */
+    READINESS_AVAILABILITY_BRIDGE_ENABLED("DIRIGIBLE_READINESS_AVAILABILITY_BRIDGE_ENABLED", Boolean.FALSE.toString()), //
+
+    /** Seconds an API client is asked to wait when the boot gate refuses a request (#6448). */
+    READINESS_GATE_RETRY_AFTER_SECONDS("DIRIGIBLE_READINESS_GATE_RETRY_AFTER_SECONDS", "5"), //
+
     HOME_URL("DIRIGIBLE_HOME_URL", "services/web/home/"), //
 
     APPLICATION_LANGUAGES("DIRIGIBLE_APPLICATION_LANGUAGES", "en,bg"), //


### PR DESCRIPTION
Completes #6448. #6449 landed the core (`PlatformReadiness` + `/services/core/readiness`) and reserved the three consumers; this is them.

## 1. The boot gate evolves `HealthCheckFilter` — it does not add a second gate

**This is the design decision worth reviewing.** `HealthCheckFilter` already blocked app traffic during boot and redirected to `/index-busy.html`, driven by `HealthCheckStatus` (whose `status` field is already a one-way latch set by `SynchronizationProcessor`). A new filter would have meant **two overlapping gates with two notions of "ready"** on the same requests, with the redirect usually winning first. So the existing filter was re-keyed instead:

| | before | after |
|---|---|---|
| gate signal | `HealthCheckStatus` | `PlatformReadiness.isBootCompleted()` |
| browser | redirect `/index-busy.html` | unchanged |
| API client / probe | *also* redirected | **503 + `Retry-After`** |
| excluded | resources, webjars, theme, ops, healthcheck | + readiness, actuator, error, login/logout/oauth2/saml2, the IDE shell and its modules |

`HealthCheckStatus` keeps driving `/core/healthcheck`; only the gate moved off it.

## 2. `passCompleted` moved into the synchronizer's `finally` — please look at this one

It sat inside the `try`, so **a pass that threw never closed the latch**. That was harmless while only the endpoint read it. With the gate keyed to it, a thrown pass would have left the instance serving 503 *forever* — and the old `HealthCheckStatus` had a `TimeLimited` force-open fallback that `PlatformReadiness` does not. One broken pass must block traffic no more than one broken artefact does. (`errors` is cleared in `prepare()`, not in this `finally`, so `getErrors()` is still valid there.)

## 3. ApplicationAvailability bridge

`DIRIGIBLE_READINESS_AVAILABILITY_BRIDGE_ENABLED`, **off by default** — it changes what an orchestrator does with the instance, so it is an operator's decision. `REFUSING_TRAFFIC` until the first depletion, then `ACCEPTING_TRAFFIC`, published once. Spring Boot announces `ACCEPTING_TRAFFIC` itself on `ApplicationReadyEvent`, so the refusal is published *after* that event to win. Later passes are deliberately not bridged — a publish must not pull a running app out of the load balancer.

## 4. IDE status-bar indicator

A chip on the trailing edge of the status bar: spinner `Synchronizing... (N pending)` while a pass runs → `Ready` → warning-tinted `Ready - N failed`. Polls every 3 s while a pass runs and every 30 s once booted, re-arming when the pace should change, cancelled on `$destroy`. Retires "grep the log for `Processing synchronizers completed!`".

## 5. `pending` is now real

The issue specified `(status, pending, failed)` but the endpoint had no pending count. The synchronizer's retry loop already knows `undepleted.size()`, so `passProgress` reports it and the endpoint exposes `pendingArtefacts`.

## Drive-by: a latent release-breaking javadoc error from #6449

`READY_DEGRADED <-> SYNCHRONIZING` — the bare `<` is malformed HTML under doclint, so `mvn -P release` fails on `PlatformReadiness`. The release profile is not run on push, so this would have surfaced only at release time (the same trap that broke the 2026-07-10 release). Escaped to `&rarr;`/`&harr;`.

## Deviations from the issue, deliberate

- **No loopback internal-bypass rule.** It would disable the gate for every same-host caller — including the ITs meant to prove it — and it is not a security boundary. The explicit exclusion list is what actually encodes "must work during boot".
- **The indicator does not link to a Synchronization view** — no such view exists in the repo.
- **A 4-case filter unit test rather than an IT.** Exercising the gate end-to-end needs requests to land inside the boot window, which is inherently racy in a test that boots the app first. The unit test covers booted-passthrough, API 503+Retry-After, browser redirect, and that all eight diagnose-boot paths stay open.

## Verification

`formatter:validate` clean · `-P unit-tests` green on all four Java modules (incl. the 4 new filter cases) · `mvn -P release` javadoc **0 errors** · `shell.js` `node --check`ed.

One note: `core-initializers` first failed with `expected CREATE but was UPDATE` — stale file-backed H2 from my own repeated runs, not this change; green on a clean target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)