### PR TITLE
fix(templates): the dead-Create family - user-entered document titles and defaulted required properties

### DIFF
--- a/build/application/src/main/resources/application.properties
+++ b/build/application/src/main/resources/application.properties
@@ -16,3 +16,8 @@ spring.session.timeout=8h
 server.servlet.session.timeout=8h
 server.servlet.session.cookie.max-age=8h
 spring.session.timeout=8h
+
+# Surface the reason of ResponseStatusException errors (e.g. generated REST validation messages)
+# in the JSON error body - without it a validation 400 reaches API callers and UIs as a bare
+# "Bad Request" with no actionable detail.
+server.error.include-message=always

--- a/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
+++ b/components/template/template-application-rest-java/src/main/resources/META-INF/dirigible/template-application-rest-java/api/EntityController.java.template
@@ -132,7 +132,8 @@ public class ${name}Controller {
 #if($hasReferenceValidations)
         validateReferences(entity);
 #end
-        return repository.save(entity);
+        ${name}Entity saved = repository.save(entity);
+        return repository.findOne(saved.#foreach($property in $properties)#if($property.dataPrimaryKey)${property.name}#end#end).orElse(saved);
     }
 #if($attachmentEntity)
 #if(!$attachmentReadOnly)
@@ -455,7 +456,7 @@ public class ${name}Controller {
 #end
 #end
 #foreach($property in $properties)
-#if($property.isRequiredProperty)
+#if($property.isRequiredProperty && !$property.dataDefaultValue)
         if (entity.${property.name} == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "The '${property.name}' property is required");
         }

--- a/components/template/template-application-rest-v2/src/main/resources/META-INF/dirigible/template-application-rest-v2/api/EntityController.ts.template
+++ b/components/template/template-application-rest-v2/src/main/resources/META-INF/dirigible/template-application-rest-v2/api/EntityController.ts.template
@@ -278,7 +278,7 @@ class ${name}Controller {
 
     private validateEntity(entity: any): void {
 #foreach ($property in $properties)
-#if($property.isRequiredProperty)
+#if($property.isRequiredProperty && !$property.dataDefaultValue)
         if (entity.${property.name} === null || entity.${property.name} === undefined) {
             throw new ValidationError(`The '${property.name}' property is required, provide a valid value`);
         }

--- a/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
+++ b/components/template/template-application-rest/src/main/resources/META-INF/dirigible/template-application-rest/api/entity.ts.template
@@ -232,7 +232,7 @@ class ${name}Service {
 
     private validateEntity(entity: any): void {
 #foreach ($property in $properties)
-#if($property.isRequiredProperty)
+#if($property.isRequiredProperty && !$property.dataDefaultValue)
         if (entity.${property.name} === null || entity.${property.name} === undefined) {
             throw new ValidationError(`The '${property.name}' property is required, provide a valid value`);
         }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -31,7 +31,7 @@
          the title bar, totals in the footer). -->
     <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
-#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{personalProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && $property.widgetType != "DOCUMENT_NUMBER" && $property.aggregate != "true")
+#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{personalProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
       <div x-h-field style="grid-column: span #if($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end">
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -31,7 +31,7 @@
          the title bar, totals in the footer). -->
     <div class="grid grid-cols-12 gap-4" style="max-width: 900px">
 #foreach($property in $properties)
-#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{partnerProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && $property.widgetType != "DOCUMENT_NUMBER" && $property.aggregate != "true")
+#if(!$property.dataAutoIncrement && !$property.sensitiveProperty && $property.name != "ProcessId" && (!$property.auditType || $property.auditType == "NONE") && $property.name != "Name" && $property.name != "$!{partnerProperty}" && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.aggregate != "true")
       <div x-h-field style="grid-column: span #if($property.widgetSize && $property.widgetSize != "")${property.widgetSize}#{else}6#end">
         <label x-h-label>
           <span x-text="T('$projectName:${tprefix}.t.${property.dataName}', '#if($property.widgetLabel)${property.widgetLabel}#else${property.name}#end')"></span>#if($property.isRequiredProperty == "true") <span class="text-destructive">*</span>#end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -440,7 +440,7 @@ document.addEventListener('alpine:init', () => {
     validationSchema() {
       return {
 #foreach($property in $properties)
-#if(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.aggregate != "true" && $property.isRequiredProperty == "true")
+#if(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.aggregate != "true" && $property.isRequiredProperty == "true" && !$property.dataDefaultValue)
         ${property.name}: [{ rule: 'required', message: 'This field is required.' }],
 #elseif(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.aggregate != "true" && $property.widgetType == "EMAIL")
         ${property.name}: [{ rule: 'email', message: 'Enter a valid email address.' }],
@@ -459,6 +459,10 @@ document.addEventListener('alpine:init', () => {
       if (this.isPreview) return;
       if (!this.validate()) {
         this.state = 'validation-error';
+        // Name the failing fields in the visible summary - an invalid field the layout does not
+        // render (or one scrolled out of view) is otherwise indistinguishable from a dead button.
+        const _failed = Object.keys(this.errors).filter(k => k !== '__summary' && this.errors[k]);
+        if (_failed.length) this.errors.__summary = 'Fields that need attention: ' + _failed.join(', ');
         this.scrollToSummary();
         return;
       }

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -72,7 +72,7 @@
 ## Read-only / system fields (ProcessId, audit, uuid, any field marked read-only) render in the
 ## read-only details block below the header form, not as editable inputs; they stay in the model for
 ## round-trip. Aggregate totals go in the totals footer; calculated fields stay inline (read-only).
-#if(!$property.dataAutoIncrement && $property.aggregate != "true" && $property.widgetType != "DOCUMENT_NUMBER" && $property.widgetType != "DOCUMENT_STATUS" && $property.isReadOnlyProperty != "true" && !($property.auditType && $property.auditType != "NONE"))
+#if(!$property.dataAutoIncrement && $property.aggregate != "true" && !($property.widgetType == "DOCUMENT_NUMBER" && $property.numberSeries) && $property.widgetType != "DOCUMENT_STATUS" && $property.isReadOnlyProperty != "true" && !($property.auditType && $property.auditType != "NONE"))
 #set($readonly = ($property.isCalculatedProperty == "true"))
 ## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
 #set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -462,7 +462,7 @@ document.addEventListener('alpine:init', () => {
     validationSchema() {
       return {
 #foreach($property in $properties)
-#if(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.isRequiredProperty == "true")
+#if(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.isRequiredProperty == "true" && !$property.dataDefaultValue)
         ${property.name}: [{ rule: 'required', message: 'This field is required.' }],
 #elseif(!$property.dataAutoIncrement && !$property.isCalculatedProperty && $property.widgetType == "EMAIL")
         ${property.name}: [{ rule: 'email', message: 'Enter a valid email address.' }],
@@ -481,6 +481,10 @@ document.addEventListener('alpine:init', () => {
       if (this.isPreview) return;
       if (!this.validate()) {
         this.state = 'validation-error';
+        // Name the failing fields in the visible summary - an invalid field the layout does not
+        // render (or one scrolled out of view) is otherwise indistinguishable from a dead button.
+        const _failed = Object.keys(this.errors).filter(k => k !== '__summary' && this.errors[k]);
+        if (_failed.length) this.errors.__summary = 'Fields that need attention: ' + _failed.join(', ');
         this.scrollToSummary();
         return;
       }

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -262,6 +262,27 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 relations:
                   - { name: Payslip, kind: manyToOne, to: Payslip, composition: true, required: true }
 
+              # The dead-Create family (found live 2026-07-29): a USER-ENTERED document title
+              # (function: DocumentTitle without a number series) must render as an editable input
+              # on the create page, and a required relation with init: (a DB-level default) must
+              # not be demanded by create validation on any layer - the database guarantees the
+              # value and the create echo must carry it.
+              - name: Voucher
+                function: Document
+                fields:
+                  - { name: id,        type: integer, primaryKey: true, generated: true }
+                  - { name: refNumber, type: string, required: true, length: 50, function: DocumentTitle }
+                  - { name: date,      type: date, required: true }
+                relations:
+                  - { name: Status, kind: manyToOne, to: EntryStatus, function: EntityStatus, init: 1, required: true }
+              - name: VoucherLine
+                function: DocumentItem
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: amount, type: decimal }
+                relations:
+                  - { name: Voucher, kind: manyToOne, to: Voucher, composition: true, required: true }
+
               # documentItemsLayout: chat - the document master's line-items child renders as a
               # conversation thread (x-h-chat bubbles + a composer) instead of the editable table;
               # the body maps to the messageBody field, author/timestamp to the child's audit columns.
@@ -1164,6 +1185,23 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         // repository OVERRIDES updateProperties to recompute it on that path too.
         assertTrue(claimRepository.contains("public int updateProperties(") && claimRepository.contains("computeName(entity)"),
                 "a label entity must recompute its display Name on the targeted updateProperties write path");
+
+        // The dead-Create family: a user-entered document title must be an editable input on the
+        // document page, and a required-with-init property must not be demanded by any validation
+        // layer (the DB default guarantees the value). Both halves shipped silently broken once:
+        // the title rendered only as the isEdit/isPreview header span, so client validation failed
+        // on a field the layout never rendered and the Create button looked dead.
+        String voucherView = contentOf("gen/emission/views/Voucher/Voucher-document.html");
+        assertTrue(voucherView.contains("x-model=\"form.RefNumber\""),
+                "a user-entered documentTitle (no number series) must render an editable input on the document page");
+        String voucherController = contentOf("gen/emission/api/voucher/VoucherController.java");
+        assertTrue(voucherController.contains("The 'RefNumber' property is required"),
+                "a plain required field keeps its REST create validation");
+        assertFalse(voucherController.contains("The 'Status' property is required"),
+                "required + init must not demand the payload value - the DB default guarantees it");
+        String voucherPage = contentOf("gen/emission/js/components/pages/Voucher/VoucherDocumentPage.js");
+        assertTrue(voucherPage.contains("RefNumber: [{ rule: 'required'"), "the client schema keeps required for the user-entered title");
+        assertFalse(voucherPage.contains("Status: [{ rule: 'required'"), "the client schema must not require a defaulted (init:) property");
     }
 
     /** Layer 2 (the outermost): the published app enforces the features over REST. */
@@ -1184,6 +1222,25 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                  .then()
                                                  .statusCode(200)
                                                  .body("[0].Name", equalTo("Брой")));
+
+        // The dead-Create family at the outermost layer: creating the document WITHOUT the
+        // defaulted status must succeed, and the echo must carry the DB-applied default (the
+        // persisted row, not the request payload the caller sent).
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"RefNumber\":\"INV-77\",\"Date\":\"2026-01-15\"}")
+                                                 .when()
+                                                 .post(API + "/voucher/VoucherController")
+                                                 .then()
+                                                 .statusCode(200)
+                                                 .body("Status", equalTo(1))
+                                                 .body("RefNumber", equalTo("INV-77")));
+        // Omitting the user-entered title stays a validation rejection.
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"Date\":\"2026-01-15\"}")
+                                                 .when()
+                                                 .post(API + "/voucher/VoucherController")
+                                                 .then()
+                                                 .statusCode(400));
 
         // leafOnly: Account 1 has a child, so referencing it must be rejected server-side.
         restAssuredExecutor.execute(() -> given().contentType("application/json")


### PR DESCRIPTION
## Problem

Field testing surfaced a family of generator/template defects that make a generated document's **Create button appear dead**, with no diagnosable reason on any layer:

1. **A user-entered document title gets no input.** A `function: DocumentTitle` field WITHOUT a `number:` series (e.g. the counterparty's own reference number, entered by the user) rendered only as the `isEdit || isPreview` header span. The create page had no input for it while the client validation schema required it - so `validate()` always failed on a field the layout never rendered, no POST was ever sent, and the page showed nothing actionable.
2. **`required` + `init:`/default contradiction.** A required property carrying a DB-level default was demanded by create validation on every layer (client schema, Java REST `validate()`, both legacy TS validators), although the database guarantees the value when the payload omits it. For an `EntityStatus` relation - which is never rendered as an input - this alone kills Create.
3. **The create echo hid DB defaults.** `create()` returned the request entity, so `init:`-applied values echoed as `null` while the persisted row had them.
4. **Silent-failure UX.** A client validation failure surfaced no field names (fatal when the invalid field is not rendered), and REST 4xx bodies dropped the `ResponseStatusException` reason, reaching callers as a bare "Bad Request".

## Fix

- `document-view.html.template`, `my-document-view.html.template`, `partner-document-view.html.template`: a non-stamped `DOCUMENT_NUMBER` property passes the input loop (renders via the text-input branch); a platform-stamped one (`numberSeries` present) stays display-only.
- `document-page.js.template`, `form-page.js.template`: skip the client `required` rule for properties with `dataDefaultValue`; on validation failure, name the failing fields in the visible summary.
- `EntityController.java.template` (+ the two legacy TS validators): skip the required-throw for defaulted properties; `create()` re-reads and returns the persisted row.
- `application.properties`: `server.error.include-message=always` so generated validation reasons reach REST callers.

## Verification (outermost layer)

`IntentEmissionCoverageIT` gains a `Voucher` fixture (user-entered title + required-with-init status) asserting both the emission tokens (title input present; required-throw absent for the defaulted property, present for the title; client schema rules per layer) and the runtime contract (create WITHOUT the defaulted status -> 200 with the default carried in the echo; create without the title -> 400). Local run: `Tests run: 1, Failures: 0, Errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)