### PR TITLE
fix(preview): do not preview .settings/.glue - unknown extensions downloaded as f.txt

### DIFF
--- a/components/ui/view-preview/src/main/resources/META-INF/dirigible/view-preview/js/preview.js
+++ b/components/ui/view-preview/src/main/resources/META-INF/dirigible/view-preview/js/preview.js
@@ -214,6 +214,8 @@ previewView.controller('PreviewController', ($scope, $document, ButtonStates) =>
                 case 'form':
                 case 'report':
 				case 'intent':
+                case 'settings':
+                case 'glue':
                     return;
                 default:
                     url += '/web';


### PR DESCRIPTION
Opening a `.settings` or `.glue` file routed it through the Preview view's `default:` branch to `/services/web/...`, and the browser downloaded the JSON as `f.txt`. Both are generated model artefacts like `.extension` / `.table` / `.form` - they are now registered in the Preview's no-preview list.

Fixes #6462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)