### PR TITLE
chore(templates): name the form generator modules as the pair they are

### DIFF
--- a/components/template/template-form-builder-angularjs/pom.xml
+++ b/components/template/template-form-builder-angularjs/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 
-	<name>Components - Template - AngularJS Form Generator</name>
+	<name>Components - Template - Form Generator - AngularJS</name>
 	<artifactId>dirigible-components-template-form-builder-angularjs</artifactId>
     <packaging>jar</packaging>
 

--- a/components/template/template-form-builder-harmonia/pom.xml
+++ b/components/template/template-form-builder-harmonia/pom.xml
@@ -9,7 +9,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <name>Components - Template - Form Builder - Harmonia</name>
+    <name>Components - Template - Form Generator - Harmonia</name>
     <artifactId>dirigible-components-template-form-builder-harmonia</artifactId>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
`Components - Template - AngularJS Form Generator` appears to have no Harmonia counterpart in sorted module listings - but the counterpart exists and is fully wired (built, included in `group-templates`, registered on `platform-templates`; it is what the form artefact pipeline generates Harmonia forms with). It was just named `Components - Template - Form Builder - Harmonia`, so the pair read as unrelated modules.

Both are now `Components - Template - Form Generator - <stack>` and sort adjacent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)