### PR TITLE
fix(engine-java): surface the rejection reason - Spring Boot 4 drops it from the error body

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
@@ -253,8 +253,11 @@ public class ControllerInvoker {
             body.put("message", e.getReason());
         }
         try {
-            response.getWriter()
-                    .write(objectMapper.writeValueAsString(body));
+            // Same channel as writeResponse: the output stream, written and flushed here rather than
+            // left to the container's commit.
+            objectMapper.writeValue(response.getOutputStream(), body);
+            response.getOutputStream()
+                    .flush();
         } catch (IOException writeFailure) {
             LOGGER.warn("Could not write the error body for status [{}]: {}", status, writeFailure.getMessage());
         }

--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/controller/ControllerInvoker.java
@@ -14,6 +14,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -67,8 +68,27 @@ public class ControllerInvoker {
         this.objectMapper = objectMapper;
     }
 
-    /** Resolve roles + bind params + invoke + serialise the result. */
+    /**
+     * Resolve roles + bind params + invoke + serialise the result.
+     *
+     * <p>
+     * Every {@link ResponseStatusException} raised on this path is rendered HERE, with its reason in
+     * the JSON body: Spring Boot 4 drops {@code getReason()} from the error body it builds, so
+     * {@code server.error.include-message=always} no longer surfaces it and a caller receives a bare
+     * {@code 400 Bad Request} for a perfectly actionable failure ("The 'Email' does not match the
+     * required pattern", "Entry needs at least one line"). Generated controllers carry their validation
+     * messages in exactly that reason, so dropping it makes the whole generated validation layer
+     * undiagnosable over REST.
+     */
     public void invoke(RouteMatch match, HttpServletRequest request, HttpServletResponse response) {
+        try {
+            invokeInternal(match, request, response);
+        } catch (ResponseStatusException e) {
+            writeError(response, e);
+        }
+    }
+
+    private void invokeInternal(RouteMatch match, HttpServletRequest request, HttpServletResponse response) {
         Route route = match.route();
         checkRoles(route.roles(), request);
 
@@ -210,6 +230,33 @@ public class ControllerInvoker {
                 return merged;
             default:
                 throw new BindingException("Unknown parameter binding kind: " + binding.kind());
+        }
+    }
+
+    /**
+     * Render a failed request as {@code {"status","error","message"}} with the exception's reason. A
+     * committed response is left alone (the controller already wrote something).
+     */
+    private void writeError(HttpServletResponse response, ResponseStatusException e) {
+        int status = e.getStatusCode()
+                      .value();
+        if (response.isCommitted()) {
+            return;
+        }
+        response.setStatus(status);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", status);
+        body.put("error", HttpStatus.valueOf(status)
+                                    .getReasonPhrase());
+        if (e.getReason() != null) {
+            body.put("message", e.getReason());
+        }
+        try {
+            response.getWriter()
+                    .write(objectMapper.writeValueAsString(body));
+        } catch (IOException writeFailure) {
+            LOGGER.warn("Could not write the error body for status [{}]: {}", status, writeFailure.getMessage());
         }
     }
 

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/ControllerInvokerBindingTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/ControllerInvokerBindingTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.dirigible.engine.java.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -159,9 +160,12 @@ class ControllerInvokerBindingTest {
                            .findFirst()
                            .orElseThrow();
 
-        ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> invoker.invoke(new RouteMatch(entry, route, Map.of("id", "abc")), mockRequest(null), new FakeResponse()));
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        FakeResponse response = new FakeResponse();
+        invoker.invoke(new RouteMatch(entry, route, Map.of("id", "abc")), mockRequest(null), response);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+        assertTrue(response.body()
+                           .contains("\"status\":400"),
+                response.body());
     }
 
     @Test
@@ -175,9 +179,12 @@ class ControllerInvokerBindingTest {
                            .findFirst()
                            .orElseThrow();
 
-        ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest("not json"), new FakeResponse()));
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+        FakeResponse response = new FakeResponse();
+        invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest("not json"), response);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+        assertTrue(response.body()
+                           .contains("\"status\":400"),
+                response.body());
     }
 
     @Test
@@ -191,9 +198,9 @@ class ControllerInvokerBindingTest {
                            .findFirst()
                            .orElseThrow();
 
-        ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest(null), new FakeResponse()));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getStatusCode());
+        FakeResponse response = new FakeResponse();
+        invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest(null), response);
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), response.getStatus());
     }
 
     @Test
@@ -207,12 +214,15 @@ class ControllerInvokerBindingTest {
                            .findFirst()
                            .orElseThrow();
 
-        ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest(null), new FakeResponse()));
+        FakeResponse response = new FakeResponse();
+        invoker.invoke(new RouteMatch(entry, route, Map.of()), mockRequest(null), response);
         // A domain validation (checks: gate, capacity guard, hand-written) is a user-fixable client
-        // error - the dispatcher maps ValidationException to 400 with the authored message, not a 500.
-        assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
-        assertEquals("debits must equal credits", e.getReason());
+        // error - the dispatcher maps ValidationException to 400 with the authored message, not a 500 -
+        // and the message must REACH THE CALLER in the body (Spring Boot 4 drops the exception reason).
+        assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
+        assertTrue(response.body()
+                           .contains("debits must equal credits"),
+                response.body());
     }
 
     // --- fixtures --------------------------------------------------------------------------------

--- a/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/ControllerInvokerRolesTest.java
+++ b/components/engine/engine-java/src/test/java/org/eclipse/dirigible/engine/java/controller/ControllerInvokerRolesTest.java
@@ -64,9 +64,9 @@ class ControllerInvokerRolesTest {
         when(req.getRemoteUser()).thenReturn("alice");
         // every isUserInRole call returns false by default.
 
-        ResponseStatusException e = assertThrows(ResponseStatusException.class,
-                () -> invoker.invoke(new RouteMatch(entry, route, Map.of()), req, new FakeResponse()));
-        assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
+        FakeResponse resp = new FakeResponse();
+        invoker.invoke(new RouteMatch(entry, route, Map.of()), req, resp);
+        assertEquals(HttpStatus.FORBIDDEN.value(), resp.status());
     }
 
     @Test


### PR DESCRIPTION
## Problem

Every generated controller carries its validation message as the `reason` of a `ResponseStatusException` — `"The value of 'Email' does not match the required pattern …"`, `"Entry needs at least one line"`, `"This X is referenced by other records and cannot be deleted"`.

**Spring Boot 4 no longer copies `getReason()` into the JSON error body.** `server.error.include-message=always` is therefore a no-op, and the `message` key is absent entirely from the response. A caller — API client or generated UI — gets a bare `400 Bad Request` for a perfectly actionable failure, which makes the whole generated validation layer undiagnosable over REST and leaves a UI able to say only "Could not save".

`ControllerInvoker` already documents this behavior for binding failures and works around it with a `LOGGER.warn` — but a server log is not reachable by the caller.

## Fix

`ControllerInvoker.invoke` renders a `ResponseStatusException` itself — `{status, error, message}`, with the reason — instead of rethrowing it into Spring's error machinery. A committed response is left untouched.

## Verified live

`POST` a supplier with a malformed e-mail against a running instance built from this branch:

```json
{"status":400,"error":"Bad Request","message":"The value of 'Email' does not match the required pattern '^[^@\\s]+@[^@\\s]+\\.[A-Za-z]{2,}$'"}
```

Before: `{"timestamp":…,"status":400,"error":"Bad Request","path":…}` — no `message` key at all.

Related: the client half (naming the failing fields in the UI summary) landed in #6457; this is the REST half of the same diagnosability gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)