### PR TITLE
chore(admin): the Administration entry sits between Partner and Workbench on Home

### DIFF
--- a/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/configs/shell.js
+++ b/components/resources/resources-admin/src/main/resources/META-INF/dirigible/admin/configs/shell.js
@@ -15,7 +15,9 @@ const shellData = {
     label: 'Administration',
     icon: 'shield',
     description: 'The administration surface: every entity as a plain table and form, one level above the database.',
-    order: 40
+    // Between the Partner portal (30) and the Workbench (40): the Administration shell is an
+    // operator surface, so it belongs with the runtime shells rather than after the development one.
+    order: 35
 };
 if (typeof exports !== 'undefined') {
     exports.getShell = () => shellData;

--- a/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
+++ b/components/resources/resources-home/src/main/resources/META-INF/dirigible/home/js/home.js
@@ -17,11 +17,13 @@
  */
 document.addEventListener('alpine:init', () => {
     // Fallbacks for shells that do not declare their own icon/description (older registrations).
-    const ICONS = { applicationShell: 'layout-grid', myShell: 'inbox', partnerShell: 'handshake', shellIde: 'code' };
+    const ICONS = { applicationShell: 'layout-grid', myShell: 'inbox', partnerShell: 'handshake', adminShell: 'shield',
+        shellIde: 'code' };
     const DESCRIPTIONS = {
         applicationShell: 'All business applications in one workspace.',
         myShell: 'Your tasks and your records - the personal workspace.',
         partnerShell: 'The portal for external partners.',
+        adminShell: 'Every record as a plain table and form - one level above the database.',
         shellIde: 'The development workbench for building on the platform.',
     };
 
@@ -40,10 +42,12 @@ document.addEventListener('alpine:init', () => {
      * technical first):
      *  - partnerShell: external partners are led straight to /services/web/partner/, so this is
      *    not their way in - it is here for the employees who need to see what a partner sees.
+     *  - adminShell: an operator tool. Everything it shows is reachable through the applications
+     *    themselves; it is the way in only when someone needs the plain, every-column view.
      *  - shellIde: a developer tool. Every developer is also an employee, so it must stay visible,
      *    but it should not compete with the two shells the rest of the company opens every morning.
      */
-    const SECONDARY = ['partnerShell', 'shellIde'];
+    const SECONDARY = ['partnerShell', 'adminShell', 'shellIde'];
 
     Alpine.data('home', () => ({
         branding: { name: '', subtitle: '', logo: '' },


### PR DESCRIPTION
The Administration shell landed on Home as a **third big tile**, competing with Applications and My Work. Two causes, one per commit.

**1. The card tied with the Workbench.** It carried `order: 40`, the Workbench's value. Now `35`.

**2. Home does not simply sort the registered shells.** It splits them into primary TILES (Applications, My Work — where the working day starts) and the quiet secondary ROWS below (Partner, Workbench), via a `SECONDARY` list in `home.js`. The Administration shell was in neither, so it rendered as a tile no matter what its order was.

It is an operator tool: everything it shows is reachable through the applications themselves, and it is the way in only when someone needs the plain, every-column view. So it joins the secondary rows between Partner and Workbench (least technical first), with the icon and description fallbacks the other shells carry.

Home after the change:

```
Applications      My Work                 <- primary tiles
--------------------------------------------------------
Partner           The portal for external partners.
Administration    The administration surface: every entity as a plain table and form...
Workbench         The development workbench for building on the platform.
```

Verified on a running instance: the two primary tiles are unchanged and the secondary rows read Partner, Administration, Workbench in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)