### PR TITLE
feat(document): declarative row filtering - filter/match on table/for, match on if

### DIFF
--- a/modules/parsers/document/README.md
+++ b/modules/parsers/document/README.md
@@ -71,7 +71,7 @@ switch (node) {
 ## Attributes
 
 `id`, `width`, `height`, `flex`, `align`, `style`, `gap`, `padding`, `margin`, `label`,
-`source`, `src`, `repeatHeader`, `pageBreak` — all stored as plain strings.
+`source`, `src`, `filter`, `match`, `repeatHeader`, `pageBreak` — all stored as plain strings.
 
 - **Alignment** (`align`): `left`, `center`, `right`, `justify`.
 - **Widths/heights**: `100` (px), `100px`, `50%`, `*` (fraction weight 1), `2*`, `3*`;
@@ -158,6 +158,33 @@ Paths walk nested maps (`customer.name`); a `table`/`for` node's `source` list e
 row per element, and inside a row a bare path (`quantity`) resolves against the row first, then
 the enclosing document context; `if` keeps or drops its children by the truthiness of `source`.
 Unresolved placeholders render as **empty strings** — a printout never shows raw braces.
+
+**Row filtering** stays declarative — a value match, not an expression language: a `table`/`for`
+with `filter="kind"` keeps only the elements whose `kind` resolves truthy (in the row's scope),
+and adding `match="CONTRIBUTION | TAX"` narrows that to the listed `|`-separated literals. The
+same `match` on an `if` compares the resolved `source` against the listed values instead of
+testing truthiness. One fed collection can this way render into several purpose-grouped tables —
+a payslip's earnings vs deductions, a journal entry's debit vs credit side — without pre-splitting
+the data feed:
+
+```xml
+<row gap="12">
+    <stack>
+        <text style="subtitle">Earnings</text>
+        <table source="items" filter="kind" match="BASE | ENTRY">
+            <column width="3*">{{name}}</column>
+            <column width="*" align="right">{{amount}}</column>
+        </table>
+    </stack>
+    <stack>
+        <text style="subtitle">Deductions</text>
+        <table source="items" filter="kind" match="CONTRIBUTION | TAX">
+            <column width="3*">{{name}}</column>
+            <column width="*" align="right">{{amount}}</column>
+        </table>
+    </stack>
+</row>
+```
 **Floating-point values** (`Double`/`Float`/`BigDecimal`) print in the generated forms' money
 pattern `### ### ### ##0.00` (space-grouped thousands, two decimals, locale-independent);
 integral numbers print unformatted.

--- a/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
+++ b/modules/parsers/document/src/main/java/org/eclipse/dirigible/parsers/document/binding/DataBinder.java
@@ -35,6 +35,15 @@ import org.eclipse.dirigible.parsers.document.parser.TagRegistry;
  * the truthiness of its {@code source}.
  *
  * <p>
+ * Rows can be filtered declaratively — no expressions, staying a value match: a {@code table} or
+ * {@code for} node with {@code filter="Kind"} keeps only the elements whose {@code Kind} resolves
+ * truthy, and adding {@code match="CONTRIBUTION | TAX"} narrows that to the listed literal values
+ * ({@code |}-separated, trimmed). The same {@code match} attribute on an {@code if} node compares
+ * its resolved {@code source} against the listed values instead of testing truthiness. One fed
+ * collection can this way render into several purpose-grouped tables (a payslip's earnings vs
+ * deductions, a journal entry's debit vs credit side) without pre-splitting the data.
+ *
+ * <p>
  * The context is plain {@code Map<String, Object>} / {@code List<Object>} data (e.g. a JSON-decoded
  * entity). Paths walk nested maps ({@code customer.name}); inside a row scope a bare path
  * ({@code quantity}) resolves against the row first, then the enclosing document context. An
@@ -80,8 +89,10 @@ public final class DataBinder {
         for (Node child : node.children()) {
             switch (child) {
                 case IfNode ifNode -> {
-                    if (isTruthy(scope.resolve(ifNode.attributes()
-                                                     .get("source")))) {
+                    Object condition = scope.resolve(ifNode.attributes()
+                                                           .get("source"));
+                    if (matches(condition, ifNode.attributes()
+                                                 .get("match"))) {
                         bound.addAll(bindChildren(ifNode, scope));
                     }
                 }
@@ -110,6 +121,9 @@ public final class DataBinder {
         for (Object element : asList(scope.resolve(table.attributes()
                                                         .get("source")))) {
             Scope rowScope = new Scope(asMap(element), scope);
+            if (!keepRow(table, rowScope)) {
+                continue;
+            }
             List<Node> cells = new ArrayList<>();
             for (Node column : columns) {
                 cells.add(rebuild(column, rowScope, bindChildren(column, rowScope)));
@@ -123,8 +137,48 @@ public final class DataBinder {
         for (Object element : asList(scope.resolve(forNode.attributes()
                                                           .get("source")))) {
             Scope rowScope = new Scope(asMap(element), scope);
+            if (!keepRow(forNode, rowScope)) {
+                continue;
+            }
             target.addAll(bindChildren(forNode, rowScope));
         }
+    }
+
+    /**
+     * The row filter of a {@code table}/{@code for} node: no {@code filter} attribute keeps every row;
+     * {@code filter="<path>"} alone keeps the rows where the path resolves truthy (in the row's scope);
+     * {@code filter} plus {@code match="A | B"} keeps the rows whose resolved value equals one of the
+     * listed literals.
+     */
+    private static boolean keepRow(Node node, Scope rowScope) {
+        String filter = node.attributes()
+                            .get("filter");
+        if (filter == null || filter.isBlank()) {
+            return true;
+        }
+        return matches(rowScope.resolve(filter.trim()), node.attributes()
+                                                            .get("match"));
+    }
+
+    /**
+     * No {@code match} list means plain truthiness; otherwise the value's string form must equal one of
+     * the {@code |}-separated, trimmed literals — a null never matches.
+     */
+    private static boolean matches(Object value, String match) {
+        if (match == null || match.isBlank()) {
+            return isTruthy(value);
+        }
+        if (value == null) {
+            return false;
+        }
+        String candidate = String.valueOf(value);
+        for (String literal : match.split("\\|")) {
+            if (literal.trim()
+                       .equals(candidate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Node rebuild(Node node, Scope scope, List<Node> children) {

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/binding/DataBinderTest.java
@@ -161,6 +161,91 @@ public class DataBinderTest {
     }
 
     @Test
+    public void tableFilterAloneKeepsTruthyRows() {
+        Node root = parser.parse("""
+                <document>
+                    <table source="items" filter="billable">
+                        <column>{{name}}</column>
+                    </table>
+                </document>
+                """);
+        Node bound = binder.bind(root, Map.of("items",
+                List.of(Map.of("name", "Kept", "billable", true), Map.of("name", "Dropped", "billable", false), Map.of("name", "NoFlag"))));
+        TableNode table = (TableNode) bound.children()
+                                           .get(0);
+        // 1 column definition + only the truthy row
+        assertEquals(2, table.children()
+                             .size());
+        assertEquals("Kept", table.children()
+                                  .get(1)
+                                  .children()
+                                  .get(0)
+                                  .text());
+    }
+
+    @Test
+    public void tableFilterWithMatchKeepsTheListedValues() {
+        Node root = parser.parse("""
+                <document>
+                    <table source="items" filter="kind" match="CONTRIBUTION | TAX">
+                        <column>{{name}}</column>
+                    </table>
+                </document>
+                """);
+        Node bound = binder.bind(root,
+                Map.of("items", List.of(Map.of("kind", "BASE", "name", "Base salary"), Map.of("kind", "CONTRIBUTION", "name", "Pensions"),
+                        Map.of("kind", "TAX", "name", "Income tax"), Map.of("name", "Kindless"))));
+        TableNode table = (TableNode) bound.children()
+                                           .get(0);
+        // 1 column definition + the two matching rows, in source order
+        assertEquals(3, table.children()
+                             .size());
+        assertEquals("Pensions", table.children()
+                                      .get(1)
+                                      .children()
+                                      .get(0)
+                                      .text());
+        assertEquals("Income tax", table.children()
+                                        .get(2)
+                                        .children()
+                                        .get(0)
+                                        .text());
+    }
+
+    @Test
+    public void forFilterWithMatchExpandsOnlyMatchingElements() {
+        Node root = parser.parse("""
+                <document>
+                    <for source="lines" filter="side" match="DEBIT">
+                        <text>{{account}}</text>
+                    </for>
+                </document>
+                """);
+        Node bound = binder.bind(root,
+                Map.of("lines", List.of(Map.of("side", "DEBIT", "account", "601"), Map.of("side", "CREDIT", "account", "401"))));
+        assertEquals(1, bound.children()
+                             .size());
+        assertEquals("601", bound.children()
+                                 .get(0)
+                                 .text());
+    }
+
+    @Test
+    public void ifMatchComparesTheResolvedValueInsteadOfTruthiness() {
+        String template = "<document><if source=\"status\" match=\"POSTED | SENT\"><text>Final</text></if></document>";
+        Node matched = binder.bind(parser.parse(template), Map.of("status", "POSTED"));
+        assertEquals(1, matched.children()
+                               .size());
+        // a truthy-but-unlisted value does not match, and a missing value never matches
+        Node other = binder.bind(parser.parse(template), Map.of("status", "DRAFT"));
+        assertEquals(0, other.children()
+                             .size());
+        Node missing = binder.bind(parser.parse(template), Map.of());
+        assertEquals(0, missing.children()
+                               .size());
+    }
+
+    @Test
     public void nestedStructuresBindRecursively() {
         Node root = parser.parse("<document><section><row><stack><text>{{a.b}}</text></stack></row></section></document>");
         Node bound = binder.bind(root, Map.of("a", Map.of("b", "deep")));

--- a/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRendererTest.java
+++ b/modules/parsers/document/src/test/java/org/eclipse/dirigible/parsers/document/renderer/XslFoRendererTest.java
@@ -84,6 +84,29 @@ public class XslFoRendererTest {
     }
 
     @Test
+    public void filteredTablesRenderOnlyTheirMatchingRows() {
+        // one fed collection, two purpose-grouped tables (the payslip / journal two-column shape)
+        String fo = renderTemplate("""
+                <document>
+                    <table source="items" filter="kind" match="EARNING">
+                        <column label="Earnings">{{name}}</column>
+                    </table>
+                    <table source="items" filter="kind" match="DEDUCTION | TAX">
+                        <column label="Deductions">{{name}}</column>
+                    </table>
+                </document>
+                """, Map.of("items", List.of(Map.of("kind", "EARNING", "name", "Base pay"),
+                Map.of("kind", "DEDUCTION", "name", "Pension fund"), Map.of("kind", "TAX", "name", "Income tax"))));
+        assertTrue(fo.contains(">Base pay</fo:block>"));
+        assertTrue(fo.contains(">Pension fund</fo:block>"));
+        assertTrue(fo.contains(">Income tax</fo:block>"));
+        // the earnings table precedes the deductions table, and no row leaks across the filters
+        assertTrue(fo.indexOf("Base pay") < fo.indexOf("Pension fund"));
+        assertEquals(1, fo.split("Base pay", -1).length - 1);
+        assertEquals(1, fo.split("Pension fund", -1).length - 1);
+    }
+
+    @Test
     public void wideTableScalesTheFontDownSoContentFits() {
         // Three columns keep the body font size; every column beyond that drops it a point (floor 6),
         // so a nine-column financial table renders at 6pt instead of overflowing its narrow columns.


### PR DESCRIPTION
## What

Row filtering for the document print DSL, staying declarative (a value match, never an expression language):

- `<table source="items" filter="kind" match="CONTRIBUTION | TAX">` (and the same on `<for>`) keeps only the elements whose `filter` path, resolved in the row's scope, equals one of the `|`-separated literals; `filter` without `match` keeps truthy rows.
- `<if source="status" match="POSTED | SENT">` compares the resolved `source` against the listed values instead of testing truthiness. A null never matches.

## Why

One fed collection can now render into several purpose-grouped tables without pre-splitting the data feed - the two-column documents every payroll/accounting print needs:

- a payslip's earnings vs deductions columns
- a journal entry's debit vs credit side
- an invoice VAT summary per rate group

Until now `<if source>` was truthiness-only and `<table source>` rendered every element, so a grouped layout required feeding pre-split collections - which the generated print feeders do not produce.

## Verification

- `DataBinderTest`: filter alone (truthy rows), filter+match on `table` and `for`, `if match` comparison incl. the truthy-but-unlisted and missing-value cases.
- `XslFoRendererTest.filteredTablesRenderOnlyTheirMatchingRows`: end-to-end parse -> bind -> layout -> XSL-FO over ONE collection feeding two filtered tables, asserting each row renders exactly once and none leaks across the filters (the outermost inspectable layer - the PDF bytes come from FOP).
- Module suite: 99 tests, 0 failures. Release-profile javadoc clean.
- README: attribute vocabulary + a Data-binding section example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)