### PR TITLE
[Security] Disabling or deleting a user at the IdP does not terminate their active session (Cognito/Keycloak)

### DIFF
--- a/components/security/security-cognito/pom.xml
+++ b/components/security/security-cognito/pom.xml
@@ -36,6 +36,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.dirigible</groupId>
+            <artifactId>dirigible-components-security-oauth2</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>

--- a/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
+++ b/components/security/security-cognito/src/main/java/org/eclipse/dirigible/components/security/cognito/CognitoSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigur
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
 import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
+import org.eclipse.dirigible.components.security.oauth2.OAuth2SessionRevalidationFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,11 +32,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 
 /**
  * The Class OAuth2SecurityConfiguration.
@@ -66,11 +69,13 @@ public class CognitoSecurityConfiguration {
      */
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator,
-            ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter, CognitoLogoutSuccessHandler cognitoLogoutSuccessHandler)
-            throws Exception {
+            ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter, CognitoLogoutSuccessHandler cognitoLogoutSuccessHandler,
+            OAuth2AuthorizedClientService authorizedClientService) throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
+            .addFilterBefore(new OAuth2SessionRevalidationFilter(authorizedClientService, userAuthoritiesMapper()),
+                    AuthorizationFilter.class)
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.disable()))
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(oauth2 -> {

--- a/components/security/security-keycloak/pom.xml
+++ b/components/security/security-keycloak/pom.xml
@@ -30,6 +30,10 @@
 			<artifactId>dirigible-components-engine-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.dirigible</groupId>
+			<artifactId>dirigible-components-security-oauth2</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>

--- a/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
+++ b/components/security/security-keycloak/src/main/java/org/eclipse/dirigible/components/security/keycloak/KeycloakSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.eclipse.dirigible.components.base.http.access.HttpSecurityURIConfigur
 import org.eclipse.dirigible.components.base.http.roles.Roles;
 import org.eclipse.dirigible.components.base.util.AuthoritiesUtil;
 import org.eclipse.dirigible.components.security.oauth.ScopeRoleJwtAuthoritiesConverter;
+import org.eclipse.dirigible.components.security.oauth2.OAuth2SessionRevalidationFilter;
 import org.eclipse.dirigible.components.tenants.tenant.TenantContextInitFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,12 +35,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 
 /**
  * The Class KeycloakSecurityConfiguration.
@@ -74,11 +77,14 @@ public class KeycloakSecurityConfiguration {
     @Bean
     SecurityFilterChain configure(HttpSecurity http, TenantContextInitFilter tenantContextInitFilter,
             HttpSecurityURIConfigurator httpSecurityURIConfigurator, ScopeRoleJwtAuthoritiesConverter scopeRoleJwtAuthoritiesConverter,
-            KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler) throws Exception {
+            KeycloakLogoutSuccessHandler keycloakLogoutSuccessHandler, OAuth2AuthorizedClientService authorizedClientService)
+            throws Exception {
         http.authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
             .addFilterBefore(tenantContextInitFilter, OAuth2LoginAuthenticationFilter.class)
+            .addFilterBefore(new OAuth2SessionRevalidationFilter(authorizedClientService, userAuthoritiesMapper()),
+                    AuthorizationFilter.class)
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.sameOrigin()))
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(Customizer.withDefaults())

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SecurityConfiguration.java
@@ -17,9 +17,11 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 
 /**
  * The Class OAuth2SecurityConfiguration.
@@ -43,11 +45,13 @@ public class OAuth2SecurityConfiguration {
      * @throws Exception the exception
      */
     @Bean
-    SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http, HttpSecurityURIConfigurator httpSecurityURIConfigurator,
+            OAuth2AuthorizedClientService authorizedClientService) throws Exception {
         http//
             .authorizeHttpRequests(authz -> authz.requestMatchers("/oauth2/**", "/login/**")
                                                  .permitAll())
             .csrf(csrf -> csrf.disable())
+            .addFilterBefore(new OAuth2SessionRevalidationFilter(authorizedClientService), AuthorizationFilter.class)
             .headers(headers -> headers.frameOptions(frameOpts -> frameOpts.disable()))
             .oauth2Client(Customizer.withDefaults())
             .oauth2Login(Customizer.withDefaults())

--- a/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SessionRevalidationFilter.java
+++ b/components/security/security-oauth2/src/main/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SessionRevalidationFilter.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientRefreshTokenTokenResponseClient;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.WebUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Re-validates {@code oauth2Login} browser sessions against the identity provider so that access
+ * revoked at the IdP (user disabled, deleted or globally signed out) actually terminates the
+ * session within a bounded window instead of surviving until logout.
+ *
+ * <p>
+ * After the initial authorization-code exchange the session never consults the IdP again, so the
+ * IdP's only reliable revocation signal is its refusal to honor the stored refresh token. Once the
+ * session's access token expires, this filter refreshes it: a refusal invalidates the HTTP session
+ * and forces re-authentication, while a successful refresh also rebuilds the principal from the
+ * fresh ID token so role/group changes at the IdP are picked up without a logout. The stale window
+ * is therefore bounded by the access-token lifetime, which stays configurable at the IdP.
+ *
+ * <p>
+ * Sessions whose authorized client carries no refresh token (e.g. GitHub OAuth apps with
+ * non-expiring tokens) cannot be re-validated and are passed through unchanged.
+ */
+public class OAuth2SessionRevalidationFilter extends OncePerRequestFilter {
+
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(OAuth2SessionRevalidationFilter.class);
+
+    /**
+     * Refresh slightly before the actual expiration, mirroring Spring's authorized client providers.
+     */
+    private static final Duration CLOCK_SKEW = Duration.ofSeconds(60);
+
+    private final OAuth2AuthorizedClientService authorizedClientService;
+    private final GrantedAuthoritiesMapper userAuthoritiesMapper;
+    private final OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenResponseClient;
+    private final OidcUserService oidcUserService;
+    private final JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory;
+    private final SecurityContextRepository securityContextRepository;
+
+    /**
+     * Instantiates the filter for a chain without a custom user authorities mapper.
+     *
+     * @param authorizedClientService the store holding the tokens obtained at login
+     */
+    public OAuth2SessionRevalidationFilter(OAuth2AuthorizedClientService authorizedClientService) {
+        this(authorizedClientService, null);
+    }
+
+    /**
+     * Instantiates the filter.
+     *
+     * @param authorizedClientService the store holding the tokens obtained at login
+     * @param userAuthoritiesMapper the mapper deriving Dirigible role authorities from the IdP user, or
+     *        {@code null} to keep the authorities the user service resolves
+     */
+    public OAuth2SessionRevalidationFilter(OAuth2AuthorizedClientService authorizedClientService,
+            GrantedAuthoritiesMapper userAuthoritiesMapper) {
+        this(authorizedClientService, userAuthoritiesMapper, new RestClientRefreshTokenTokenResponseClient(), new OidcUserService(),
+                new OidcIdTokenDecoderFactory(), new HttpSessionSecurityContextRepository());
+    }
+
+    OAuth2SessionRevalidationFilter(OAuth2AuthorizedClientService authorizedClientService, GrantedAuthoritiesMapper userAuthoritiesMapper,
+            OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenResponseClient, OidcUserService oidcUserService,
+            JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory, SecurityContextRepository securityContextRepository) {
+        this.authorizedClientService = authorizedClientService;
+        this.userAuthoritiesMapper = userAuthoritiesMapper;
+        this.refreshTokenResponseClient = refreshTokenResponseClient;
+        this.oidcUserService = oidcUserService;
+        this.idTokenDecoderFactory = idTokenDecoderFactory;
+        this.securityContextRepository = securityContextRepository;
+    }
+
+    /**
+     * Re-validates the current session-based OAuth2 authentication before the request is authorized.
+     * When the session is terminated the chain continues unauthenticated, so the standard entry point
+     * redirects to login.
+     *
+     * @param request the request
+     * @param response the response
+     * @param chain the chain
+     * @throws ServletException the servlet exception
+     * @throws IOException the IO exception
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        Authentication authentication = SecurityContextHolder.getContext()
+                                                             .getAuthentication();
+        if (authentication instanceof OAuth2AuthenticationToken oauth2Authentication) {
+            revalidate(oauth2Authentication, request, response);
+        }
+        chain.doFilter(request, response);
+    }
+
+    private void revalidate(OAuth2AuthenticationToken authentication, HttpServletRequest request, HttpServletResponse response) {
+        String registrationId = authentication.getAuthorizedClientRegistrationId();
+        String principalName = authentication.getName();
+        OAuth2AuthorizedClient authorizedClient = authorizedClientService.loadAuthorizedClient(registrationId, principalName);
+        if (authorizedClient == null) {
+            LOGGER.info("No authorized client for user [{}] and registration [{}] - terminating the session", principalName,
+                    registrationId);
+            terminateSession(request);
+            return;
+        }
+        if (!isExpired(authorizedClient.getAccessToken())) {
+            return;
+        }
+        if (authorizedClient.getRefreshToken() == null) {
+            LOGGER.debug("No refresh token for user [{}] and registration [{}] - the session cannot be re-validated", principalName,
+                    registrationId);
+            return;
+        }
+        synchronized (WebUtils.getSessionMutex(request.getSession())) {
+            // a concurrent request on the same session may have completed the re-validation already
+            authorizedClient = authorizedClientService.loadAuthorizedClient(registrationId, principalName);
+            if (authorizedClient == null) {
+                terminateSession(request);
+                return;
+            }
+            if (isExpired(authorizedClient.getAccessToken()) && authorizedClient.getRefreshToken() != null) {
+                refresh(authentication, authorizedClient, request, response);
+            }
+        }
+    }
+
+    private void refresh(OAuth2AuthenticationToken authentication, OAuth2AuthorizedClient authorizedClient, HttpServletRequest request,
+            HttpServletResponse response) {
+        ClientRegistration clientRegistration = authorizedClient.getClientRegistration();
+        String principalName = authentication.getName();
+        OAuth2AccessTokenResponse tokenResponse;
+        try {
+            tokenResponse = refreshTokenResponseClient.getTokenResponse(new OAuth2RefreshTokenGrantRequest(clientRegistration,
+                    authorizedClient.getAccessToken(), authorizedClient.getRefreshToken()));
+        } catch (OAuth2AuthorizationException ex) {
+            LOGGER.info("The identity provider [{}] refused to refresh the tokens of user [{}] with error [{}] - terminating the session",
+                    clientRegistration.getRegistrationId(), principalName, ex.getError()
+                                                                             .getErrorCode(),
+                    ex);
+            authorizedClientService.removeAuthorizedClient(clientRegistration.getRegistrationId(), principalName);
+            terminateSession(request);
+            return;
+        }
+        OAuth2RefreshToken refreshToken =
+                tokenResponse.getRefreshToken() != null ? tokenResponse.getRefreshToken() : authorizedClient.getRefreshToken();
+        OAuth2AuthorizedClient refreshedClient =
+                new OAuth2AuthorizedClient(clientRegistration, principalName, tokenResponse.getAccessToken(), refreshToken);
+        authorizedClientService.saveAuthorizedClient(refreshedClient, authentication);
+        refreshAuthentication(authentication, clientRegistration, tokenResponse, request, response);
+        LOGGER.debug("Re-validated the session of user [{}] against registration [{}]", principalName,
+                clientRegistration.getRegistrationId());
+    }
+
+    /**
+     * Rebuilds the session principal from the ID token issued with the refresh so authority changes at
+     * the IdP (e.g. group membership) take effect without a logout. The IdP has just accepted the
+     * refresh, so on a rebuild problem the session stays valid with the authorities from login time.
+     */
+    private void refreshAuthentication(OAuth2AuthenticationToken authentication, ClientRegistration clientRegistration,
+            OAuth2AccessTokenResponse tokenResponse, HttpServletRequest request, HttpServletResponse response) {
+        Object idTokenValue = tokenResponse.getAdditionalParameters()
+                                           .get(OidcParameterNames.ID_TOKEN);
+        if (idTokenValue == null || !(authentication.getPrincipal() instanceof OidcUser)) {
+            return;
+        }
+        OAuth2AuthenticationToken refreshedAuthentication;
+        try {
+            Jwt jwt = idTokenDecoderFactory.createDecoder(clientRegistration)
+                                           .decode(idTokenValue.toString());
+            OidcIdToken idToken = new OidcIdToken(jwt.getTokenValue(), jwt.getIssuedAt(), jwt.getExpiresAt(), jwt.getClaims());
+            OidcUser oidcUser = oidcUserService.loadUser(new OidcUserRequest(clientRegistration, tokenResponse.getAccessToken(), idToken,
+                    tokenResponse.getAdditionalParameters()));
+            Collection<? extends GrantedAuthority> authorities =
+                    userAuthoritiesMapper != null ? userAuthoritiesMapper.mapAuthorities(oidcUser.getAuthorities())
+                            : oidcUser.getAuthorities();
+            refreshedAuthentication =
+                    new OAuth2AuthenticationToken(oidcUser, authorities, authentication.getAuthorizedClientRegistrationId());
+            refreshedAuthentication.setDetails(authentication.getDetails());
+        } catch (JwtException | OAuth2AuthenticationException ex) {
+            LOGGER.warn("Failed to rebuild the principal of user [{}] from the refreshed ID token - keeping the login-time authorities",
+                    authentication.getName(), ex);
+            return;
+        }
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(refreshedAuthentication);
+        SecurityContextHolder.setContext(securityContext);
+        securityContextRepository.saveContext(securityContext, request, response);
+    }
+
+    private static boolean isExpired(OAuth2AccessToken accessToken) {
+        Instant expiresAt = accessToken.getExpiresAt();
+        return expiresAt == null || Instant.now()
+                                           .isAfter(expiresAt.minus(CLOCK_SKEW));
+    }
+
+    private static void terminateSession(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SessionRevalidationFilterTest.java
+++ b/components/security/security-oauth2/src/test/java/org/eclipse/dirigible/components/security/oauth2/OAuth2SessionRevalidationFilterTest.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2RefreshTokenGrantRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.web.context.SecurityContextRepository;
+
+/**
+ * Unit tests for {@link OAuth2SessionRevalidationFilter} - the re-validation of oauth2Login
+ * sessions against the identity provider via the stored refresh token.
+ */
+@ExtendWith(MockitoExtension.class)
+class OAuth2SessionRevalidationFilterTest {
+
+    private static final String REGISTRATION_ID = "test";
+    private static final String PRINCIPAL_NAME = "test-user";
+
+    @Mock
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @Mock
+    private GrantedAuthoritiesMapper userAuthoritiesMapper;
+
+    @Mock
+    private OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenResponseClient;
+
+    @Mock
+    private OidcUserService oidcUserService;
+
+    @Mock
+    private JwtDecoderFactory<ClientRegistration> idTokenDecoderFactory;
+
+    @Mock
+    private SecurityContextRepository securityContextRepository;
+
+    @Mock
+    private JwtDecoder jwtDecoder;
+
+    private OAuth2SessionRevalidationFilter filter;
+    private ClientRegistration clientRegistration;
+    private OAuth2AuthenticationToken authentication;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockHttpSession session;
+    private MockFilterChain chain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new OAuth2SessionRevalidationFilter(authorizedClientService, userAuthoritiesMapper, refreshTokenResponseClient,
+                oidcUserService, idTokenDecoderFactory, securityContextRepository);
+        clientRegistration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+                                               .clientId("test-client")
+                                               .clientSecret("test-secret")
+                                               .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                                               .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                                               .authorizationUri("https://idp.example.org/oauth2/authorize")
+                                               .tokenUri("https://idp.example.org/oauth2/token")
+                                               .userNameAttributeName("sub")
+                                               .build();
+        authentication = new OAuth2AuthenticationToken(oidcUser("old-id-token"), List.of(new SimpleGrantedAuthority("ROLE_LOGIN_TIME")),
+                REGISTRATION_ID);
+        setAuthentication(authentication);
+        session = new MockHttpSession();
+        request = new MockHttpServletRequest();
+        request.setSession(session);
+        response = new MockHttpServletResponse();
+        chain = new MockFilterChain();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void passesThroughNonOAuth2Authentication() throws Exception {
+        Authentication basicAuthentication = new UsernamePasswordAuthenticationToken("admin", "admin", List.of());
+        setAuthentication(basicAuthentication);
+
+        filter.doFilter(request, response, chain);
+
+        verifyNoInteractions(authorizedClientService, refreshTokenResponseClient);
+        assertChainContinuedWith(basicAuthentication);
+        assertFalse(session.isInvalid());
+    }
+
+    @Test
+    void passesThroughWhenAccessTokenIsFresh() throws Exception {
+        stubAuthorizedClient(freshAccessToken(), refreshToken());
+
+        filter.doFilter(request, response, chain);
+
+        verifyNoInteractions(refreshTokenResponseClient);
+        assertChainContinuedWith(authentication);
+        assertFalse(session.isInvalid());
+    }
+
+    @Test
+    void passesThroughWhenExpiredButNoRefreshTokenAvailable() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), null);
+
+        filter.doFilter(request, response, chain);
+
+        verifyNoInteractions(refreshTokenResponseClient);
+        assertChainContinuedWith(authentication);
+        assertFalse(session.isInvalid());
+    }
+
+    @Test
+    void terminatesSessionWhenAuthorizedClientIsMissing() throws Exception {
+        when(authorizedClientService.loadAuthorizedClient(REGISTRATION_ID, PRINCIPAL_NAME)).thenReturn(null);
+
+        filter.doFilter(request, response, chain);
+
+        assertTrue(session.isInvalid());
+        assertNull(SecurityContextHolder.getContext()
+                                        .getAuthentication());
+        assertChainContinued();
+    }
+
+    @Test
+    void terminatesSessionWhenIdPRefusesRefresh() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), refreshToken());
+        when(refreshTokenResponseClient.getTokenResponse(any(OAuth2RefreshTokenGrantRequest.class))).thenThrow(
+                new OAuth2AuthorizationException(new OAuth2Error("invalid_grant")));
+
+        filter.doFilter(request, response, chain);
+
+        assertTrue(session.isInvalid());
+        assertNull(SecurityContextHolder.getContext()
+                                        .getAuthentication());
+        verify(authorizedClientService).removeAuthorizedClient(REGISTRATION_ID, PRINCIPAL_NAME);
+        verify(authorizedClientService, never()).saveAuthorizedClient(any(), any());
+        assertChainContinued();
+    }
+
+    @Test
+    void savesRefreshedTokensAndKeepsSessionOnSuccessfulRefresh() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), refreshToken());
+        when(refreshTokenResponseClient.getTokenResponse(any(OAuth2RefreshTokenGrantRequest.class))).thenReturn(
+                tokenResponse("new-refresh-token", null));
+
+        filter.doFilter(request, response, chain);
+
+        OAuth2AuthorizedClient savedClient = captureSavedClient();
+        assertEquals("new-access-token", savedClient.getAccessToken()
+                                                    .getTokenValue());
+        assertEquals("new-refresh-token", savedClient.getRefreshToken()
+                                                     .getTokenValue());
+        assertFalse(session.isInvalid());
+        assertChainContinuedWith(authentication);
+    }
+
+    @Test
+    void retainsPreviousRefreshTokenWhenResponseOmitsIt() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), refreshToken());
+        when(refreshTokenResponseClient.getTokenResponse(any(OAuth2RefreshTokenGrantRequest.class))).thenReturn(tokenResponse(null, null));
+
+        filter.doFilter(request, response, chain);
+
+        OAuth2AuthorizedClient savedClient = captureSavedClient();
+        assertEquals("old-refresh-token", savedClient.getRefreshToken()
+                                                     .getTokenValue());
+        assertFalse(session.isInvalid());
+        assertChainContinuedWith(authentication);
+    }
+
+    @Test
+    void rebuildsPrincipalAndAuthoritiesFromRefreshedIdToken() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), refreshToken());
+        when(refreshTokenResponseClient.getTokenResponse(any(OAuth2RefreshTokenGrantRequest.class))).thenReturn(
+                tokenResponse("new-refresh-token", "new-id-token"));
+        when(idTokenDecoderFactory.createDecoder(clientRegistration)).thenReturn(jwtDecoder);
+        when(jwtDecoder.decode("new-id-token")).thenReturn(jwt("new-id-token"));
+        OidcUser refreshedUser = oidcUser("new-id-token");
+        when(oidcUserService.loadUser(any(OidcUserRequest.class))).thenReturn(refreshedUser);
+        List<GrantedAuthority> refreshedAuthorities = List.of(new SimpleGrantedAuthority("ROLE_REFRESHED"));
+        doReturn(refreshedAuthorities).when(userAuthoritiesMapper)
+                                      .mapAuthorities(any());
+
+        filter.doFilter(request, response, chain);
+
+        Authentication currentAuthentication = SecurityContextHolder.getContext()
+                                                                    .getAuthentication();
+        assertNotSame(authentication, currentAuthentication);
+        assertSame(refreshedUser, currentAuthentication.getPrincipal());
+        assertEquals(List.of(new SimpleGrantedAuthority("ROLE_REFRESHED")), List.copyOf(currentAuthentication.getAuthorities()));
+        verify(securityContextRepository).saveContext(any(SecurityContext.class), any(), any());
+        assertFalse(session.isInvalid());
+        assertChainContinued();
+    }
+
+    @Test
+    void keepsLoginTimeAuthoritiesWhenRefreshedIdTokenCannotBeProcessed() throws Exception {
+        stubAuthorizedClient(expiredAccessToken(), refreshToken());
+        when(refreshTokenResponseClient.getTokenResponse(any(OAuth2RefreshTokenGrantRequest.class))).thenReturn(
+                tokenResponse("new-refresh-token", "new-id-token"));
+        when(idTokenDecoderFactory.createDecoder(clientRegistration)).thenReturn(jwtDecoder);
+        when(jwtDecoder.decode("new-id-token")).thenThrow(new JwtException("invalid token"));
+
+        filter.doFilter(request, response, chain);
+
+        assertFalse(session.isInvalid());
+        assertChainContinuedWith(authentication);
+        assertEquals("new-access-token", captureSavedClient().getAccessToken()
+                                                             .getTokenValue());
+    }
+
+    private void stubAuthorizedClient(OAuth2AccessToken accessToken, OAuth2RefreshToken refreshToken) {
+        OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(clientRegistration, PRINCIPAL_NAME, accessToken, refreshToken);
+        when(authorizedClientService.loadAuthorizedClient(REGISTRATION_ID, PRINCIPAL_NAME)).thenReturn(authorizedClient);
+    }
+
+    private OAuth2AuthorizedClient captureSavedClient() {
+        ArgumentCaptor<OAuth2AuthorizedClient> captor = ArgumentCaptor.forClass(OAuth2AuthorizedClient.class);
+        verify(authorizedClientService).saveAuthorizedClient(captor.capture(), any(Authentication.class));
+        return captor.getValue();
+    }
+
+    private void assertChainContinued() {
+        assertSame(request, chain.getRequest());
+    }
+
+    private void assertChainContinuedWith(Authentication expectedAuthentication) {
+        assertChainContinued();
+        assertSame(expectedAuthentication, SecurityContextHolder.getContext()
+                                                                .getAuthentication());
+    }
+
+    private static void setAuthentication(Authentication authentication) {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    private static OidcUser oidcUser(String idTokenValue) {
+        OidcIdToken idToken = new OidcIdToken(idTokenValue, Instant.now(), Instant.now()
+                                                                                  .plusSeconds(300),
+                Map.of("sub", PRINCIPAL_NAME));
+        return new DefaultOidcUser(List.of(new SimpleGrantedAuthority("ROLE_USER")), idToken);
+    }
+
+    private static OAuth2AccessToken expiredAccessToken() {
+        return new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "expired-access-token", Instant.now()
+                                                                                                        .minusSeconds(3600),
+                Instant.now()
+                       .minusSeconds(60));
+    }
+
+    private static OAuth2AccessToken freshAccessToken() {
+        return new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "fresh-access-token", Instant.now(), Instant.now()
+                                                                                                                     .plusSeconds(3600));
+    }
+
+    private static OAuth2RefreshToken refreshToken() {
+        return new OAuth2RefreshToken("old-refresh-token", Instant.now());
+    }
+
+    private static OAuth2AccessTokenResponse tokenResponse(String refreshTokenValue, String idTokenValue) {
+        OAuth2AccessTokenResponse.Builder builder = OAuth2AccessTokenResponse.withToken("new-access-token")
+                                                                             .tokenType(OAuth2AccessToken.TokenType.BEARER)
+                                                                             .expiresIn(300);
+        if (refreshTokenValue != null) {
+            builder.refreshToken(refreshTokenValue);
+        }
+        if (idTokenValue != null) {
+            builder.additionalParameters(Map.of(OidcParameterNames.ID_TOKEN, idTokenValue));
+        }
+        return builder.build();
+    }
+
+    private static Jwt jwt(String tokenValue) {
+        return Jwt.withTokenValue(tokenValue)
+                  .header("alg", "RS256")
+                  .subject(PRINCIPAL_NAME)
+                  .issuedAt(Instant.now())
+                  .expiresAt(Instant.now()
+                                    .plusSeconds(300))
+                  .claim("cognito:groups", List.of("Developer"))
+                  .build();
+    }
+}


### PR DESCRIPTION
Session-based OAuth2 logins (Cognito, Keycloak, GitHub) are now re-validated against the identity provider once the session's access token expires: the stored refresh token is exchanged for fresh tokens, and a refusal terminates the session and forces re-authentication. Role/group changes at the IdP are picked up on re-validation without a logout.

Closes #6480

🤖 Generated with [Claude Code](https://claude.com/claude-code)