### PR TITLE
fix(harmonia): items-table text cells wrap; table scrolls inside its own container (#6493)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -232,6 +232,9 @@
       </div>
       <div x-show="itemsError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="itemsError"></div></div>
 
+      <!-- The container gives an over-wide table its OWN horizontal scrollbar (w-full overflow-x-auto),
+           so it can never grow past the page column and render under the status stepper. -->
+      <div x-h-table-container>
       <table x-h-table data-borders="rows" class="w-full">
         <thead x-h-table-header>
           <tr x-h-table-row>
@@ -243,7 +246,11 @@
           <template x-for="(row, idx) in items" :key="row[itemsDef.primaryKey] != null ? row[itemsDef.primaryKey] : idx">
             <tr x-h-table-row data-hoverable="true">
               <template x-for="col in editColumns" :key="col.name">
-                <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellDisplay(col, row)"></td>
+                <!-- x-h-table-cell bakes whitespace-nowrap; a sentence-long item name is NORMAL
+                     invoice data, so text cells override it and wrap within their column. -->
+                <td x-h-table-cell :class="col.number ? 'text-right' : ''"
+                    :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
+                    x-text="cellDisplay(col, row)"></td>
               </template>
               <td x-h-table-cell data-row-actions x-show="!isPreview" @click.stop>
                 <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions">
@@ -262,6 +269,7 @@
           </tr>
         </tbody>
       </table>
+      </div>
     </div>
 #end
 
@@ -366,7 +374,9 @@
                 <template x-for="row in rows" :key="row[def.primaryKey]">
                   <tr x-h-table-row data-hoverable="true">
                     <template x-for="col in def.columns" :key="col.name">
-                      <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
+                      <td x-h-table-cell :class="col.number ? 'text-right' : ''"
+                          :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
+                          x-text="cellValue(col, row)"></td>
                     </template>
                     <td x-h-table-cell data-row-actions x-show="!isPreview">
                       <button x-h-button data-variant="transparent" data-size="sm" aria-label="Delete" @click="askDelete(row)"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -294,7 +294,9 @@
                   <template x-for="row in rows" :key="row[def.primaryKey]">
                     <tr x-h-table-row data-hoverable="true">
                       <template x-for="col in def.columns" :key="col.name">
-                        <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
+                        <td x-h-table-cell :class="col.number ? 'text-right' : ''"
+                            :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
+                            x-text="cellValue(col, row)"></td>
                       </template>
                       <td x-h-table-cell data-row-actions x-show="!isPreview">
                         <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" x-h-lucide data-lucide="ellipsis"></i></button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -230,7 +230,9 @@
                     <template x-for="row in rows" :key="row[def.primaryKey]">
                       <tr x-h-table-row data-hoverable="true">
                         <template x-for="col in def.columns" :key="col.name">
-                          <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="cellValue(col, row)"></td>
+                          <td x-h-table-cell :class="col.number ? 'text-right' : ''"
+                              :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
+                              x-text="cellValue(col, row)"></td>
                         </template>
                         <!-- Read-only browse pane: children are added/edited/deleted from the record's
                              Edit form (where these same panels are editable), NOT here. Only the


### PR DESCRIPTION
Closes #6493.

Two paper cuts on the generated document page, both presentation-only:

- **Text cells wrap.** `x-h-table-cell` bakes `whitespace-nowrap`; the generated line-items table (and the shared detail-panel tables on the document/manage/master pages) now override it on non-numeric cells with `white-space: normal; overflow-wrap: anywhere`, so a sentence-long item name wraps within its column. Numeric cells keep the nowrap + right alignment.
- **The table scrolls inside itself.** The line-items table is wrapped in a bare `x-h-table-container` (Harmonia's `relative w-full overflow-x-auto`), so an over-wide table gets its own horizontal scrollbar instead of growing past the page column and rendering under the status-stepper widget.

Inline styles rather than utility classes on purpose: the override must beat the directive-injected `whitespace-nowrap` regardless of which utilities the precompiled Harmonia CSS happens to contain.

No IT: this is a presentation-only template change with no behavior, routes, or data shapes touched (the acceptance criterion is visual - a 120-char item name wraps within its column and nothing renders under the stepper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)