### PR TITLE
fix(harmonia): text and lookup fields span the full line-item dialog row (#6495)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -510,7 +510,9 @@
         <div x-show="draftError" x-h-alert data-variant="negative" role="alert"><div x-h-alert-description x-text="draftError"></div></div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <template x-for="col in editColumns" :key="col.name">
-            <div x-h-field>
+            <!-- Text and lookup fields span the whole dialog row (long names must be readable while
+                 typing); only the short paired widgets - numbers, checkboxes, date/time - share one. -->
+            <div x-h-field :style="['NUMBER','CHECKBOX','DATE','DATETIME-LOCAL'].includes(col.widget) ? '' : 'grid-column: 1 / -1'">
               <label x-h-label x-text="T(col.tkey, col.label)"></label>
               <template x-if="!col.readonly && col.widget === 'DROPDOWN'">
                 <div>


### PR DESCRIPTION
Closes #6495.

In the generated item create/edit dialog the field grid is `sm:grid-cols-2` and every field took one cell, so the product picker and the name input rendered at half width. Text inputs and relation (lookup) dropdowns now span the full dialog row via `grid-column: 1 / -1` (an inline style so it is correct in any column count, including the single-column mobile layout, and independent of which utilities the precompiled Harmonia CSS contains); the short paired widgets - numbers, checkboxes, date/time pickers - keep sharing a row.

No IT: presentation-only template change; the acceptance criterion is visual (Product and Name occupy the full dialog row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)