### PR TITLE
test(intent): lock the .print scaffold's authored-wins semantics (#6497)

### DIFF
--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1286,6 +1287,31 @@ class IntentEngineIT extends IntegrationTest {
                                                  .statusCode(200));
         assertTrue(contentOf("custom/NotifyCustomer.java").contains("MY IMPLEMENTATION"),
                 "the developer's service-task handler must be preserved across regeneration");
+    }
+
+    @Test
+    void a_hand_edited_print_template_is_preserved_across_regeneration() {
+        writeIntent(INTENT_YAML);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        // A fresh project gets the scaffold: the minimal, model-derived starting point.
+        String printPath = "doc/Templates/Order/Print/en/standard.print";
+        String scaffold = contentOf(printPath);
+        assertTrue(scaffold.contains("<document") && scaffold.contains("<table source=\"items\">"),
+                "the first Generate must scaffold the standard print template, got: " + scaffold);
+
+        // The developer hand-improves it. A printed invoice is a formatted/audited artifact - the
+        // scaffold is a customization point (like the CMS seeding, which is create-if-absent), so a
+        // regeneration must leave the authored template BYTE-IDENTICAL, never re-emit over it.
+        String authored = "<document id=\"authored\"><page><section><field label=\"N\">{{document.Id}}</field></section></page></document>";
+        writeProjectFile(printPath, authored);
+        restAssuredExecutor.execute(() -> given().when()
+                                                 .post(GENERATE_URL)
+                                                 .then()
+                                                 .statusCode(200));
+        assertEquals(authored, contentOf(printPath), "an authored print template must survive regeneration byte-identical");
     }
 
     @Test


### PR DESCRIPTION
Closes #6497.

Investigation outcome: the platform generator **already** has the requested authored-wins semantics — `PrintIntentGenerator` writes `doc/Templates/<Entity>/Print/en/standard.print` via `writeModelFileIfAbsent` (generate-once, the developer-owned `.settings` pattern, in place since #6184), and the CMS seeding is create-if-absent. The clobbering observed in the field comes from downstream regeneration pipelines that classify `.print` as generated output and delete/rewrite it before invoking Generate — a consumer-side fix.

What this PR adds is the missing **test lock**: a new `IntentEngineIT` case that

1. generates a fresh project and asserts the scaffold is produced (`<document` + the items table),
2. hand-edits `standard.print`, regenerates, and asserts the authored content survives **byte-identical**.

A platform regression to emit-on-every-regen now fails CI instead of silently rewriting formatted/audited business documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)