### PR TITLE
fix(numbering): per-row save in settings; base row of a partitioned series offers no counter (#6499)

### DIFF
--- a/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberEndpoint.java
+++ b/components/engine/engine-numbering/src/main/java/org/eclipse/dirigible/components/engine/numbering/DocumentNumberEndpoint.java
@@ -11,6 +11,8 @@ package org.eclipse.dirigible.components.engine.numbering;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.eclipse.dirigible.components.base.endpoint.BaseEndpoint;
 import org.springframework.http.HttpStatus;
@@ -50,12 +52,21 @@ public class DocumentNumberEndpoint extends BaseEndpoint {
     @GetMapping
     public ResponseEntity<List<SeriesView>> list() {
         try {
-            return ResponseEntity.ok(service.list()
-                                            .stream()
-                                            .map(row -> new SeriesView(row.series(), row.partition(), row.prefix(), row.size(),
-                                                    row.counter(), row.counter() + 1,
-                                                    DocumentNumberService.render(row.prefix(), row.size(), row.counter() + 1)))
-                                            .toList());
+            List<DocumentNumberStore.Series> rows = service.list();
+            // A series is PARTITIONED once any of its partition rows exists. The base ("") row of a
+            // partitioned series is only the shape template partitions inherit at birth - allocation
+            // never draws from it - so the settings page must not offer its counter for editing.
+            Set<String> partitionedSeries = rows.stream()
+                                                .filter(row -> !row.partition()
+                                                                   .isEmpty())
+                                                .map(DocumentNumberStore.Series::series)
+                                                .collect(Collectors.toSet());
+            return ResponseEntity.ok(rows.stream()
+                                         .map(row -> new SeriesView(row.series(), row.partition(), row.prefix(), row.size(), row.counter(),
+                                                 row.counter() + 1,
+                                                 DocumentNumberService.render(row.prefix(), row.size(), row.counter() + 1),
+                                                 partitionedSeries.contains(row.series())))
+                                         .toList());
         } catch (SQLException ex) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to list document-number series", ex);
         }
@@ -127,7 +138,10 @@ public class DocumentNumberEndpoint extends BaseEndpoint {
      * @param next the value the next document will get
      * @param example the next number as it will actually render - so an administrator sees the effect
      *        of a prefix or width change without issuing a document
+     * @param partitioned whether the series has partition rows - the base row of a partitioned series
+     *        is only the shape template new partitions inherit, so its counter is not editable
      */
-    record SeriesView(String series, String partition, String prefix, int size, long counter, long next, String example) {
+    record SeriesView(String series, String partition, String prefix, int size, long counter, long next, String example,
+            boolean partitioned) {
     }
 }

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/i18n/bg-BG/shell.json
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/i18n/bg-BG/shell.json
@@ -109,6 +109,8 @@
       "numberingSize": "Обща ширина",
       "numberingNext": "Следващ",
       "numberingExample": "Следващ номер:",
+      "numberingSaved": "Записано",
+      "numberingShapeTemplate": "Броячите живеят в редовете за отделните партиции по-долу; нова партиция се появява при първата си употреба, наследявайки тази форма.",
       "tenantConfigLabels": {
         "name": "Име",
         "subtitle": "Подзаглавие",

--- a/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/i18n/en-US/shell.json
+++ b/components/resources/application-core/src/main/resources/META-INF/dirigible/application-core/i18n/en-US/shell.json
@@ -109,6 +109,8 @@
       "numberingSize": "Total width",
       "numberingNext": "Next",
       "numberingExample": "Next number:",
+      "numberingSaved": "Saved",
+      "numberingShapeTemplate": "Counters live on the per-partition rows below; a new partition appears on its first use, inheriting this shape.",
       "tenantConfigLabels": {
         "name": "Name",
         "subtitle": "Subtitle",

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/js/appShell.js
@@ -158,6 +158,22 @@ document.addEventListener('alpine:init', () => {
     },
 
     /**
+     * The base ("") row of a PARTITIONED series is only the shape template new partitions inherit at
+     * birth - allocation always draws from a partition row - so its counter must not be offered for
+     * editing (editing it looks like seeding the next number and does nothing).
+     */
+    numberingIsShapeTemplate(row) {
+      return !row.partition && row.partitioned;
+    },
+
+    /** Whether the row's edits differ from what was loaded - drives the per-row Save. */
+    numberingDirty(row) {
+      return (row.prefix || '') !== row.orig.prefix
+        || parseInt(row.size, 10) !== row.orig.size
+        || (!this.numberingIsShapeTemplate(row) && parseInt(row.next, 10) !== row.orig.next);
+    },
+
+    /**
      * The next number as it will render with the row's CURRENT edits - prefix + sequence zero-padded
      * to the total width (mirrors the server's rendering, incl. never truncating an overflow).
      */
@@ -192,6 +208,9 @@ document.addEventListener('alpine:init', () => {
           prefix: c.prefix || '',
           size: c.size,
           next: c.next,
+          partitioned: !!c.partitioned,
+          saving: false,
+          saved: false,
           orig: { prefix: c.prefix || '', size: c.size, next: c.next }
         }));
       } catch (e) {
@@ -205,40 +224,49 @@ document.addEventListener('alpine:init', () => {
     },
 
     /**
-     * Persist each row's edits: a changed shape via PUT /shape, a changed next via PUT. Untouched
+     * Persist ONE row's edits: a changed shape via PUT /shape, a changed next via PUT. Untouched
      * values are not written - setNext rewinds the live counter, so writing an unchanged "next"
-     * would silently undo allocations made since the page loaded.
+     * would silently undo allocations made since the page loaded. Per-row on purpose: a real suite
+     * has dozens of series, and saving must sit next to what was edited, not below the whole list.
+     * Only the saved row's baseline is refreshed, so other rows' in-progress edits survive.
      */
-    async saveNumbering() {
+    async saveNumberingRow(row) {
       this.numberingError = null;
+      row.saving = true;
+      row.saved = false;
       try {
-        for (const row of this.numbering) {
-          const size = parseInt(row.size, 10);
-          const shapeChanged = (row.prefix || '') !== row.orig.prefix || size !== row.orig.size;
-          if (shapeChanged && isFinite(size)) {
-            const res = await fetch('/services/core/numbering/shape', {
-              method: 'PUT',
-              credentials: 'same-origin',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ series: row.series, partition: row.partition, prefix: row.prefix || '', size: size })
-            });
-            if (!res.ok) throw new Error('PUT shape ' + row.series + ' -> HTTP ' + res.status);
-          }
-          const next = parseInt(row.next, 10);
-          if (isFinite(next) && next >= 1 && next !== row.orig.next) {
-            const res = await fetch('/services/core/numbering', {
-              method: 'PUT',
-              credentials: 'same-origin',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ series: row.series, partition: row.partition, next: next })
-            });
-            if (!res.ok) throw new Error('PUT ' + row.series + ' -> HTTP ' + res.status);
-          }
+        const size = parseInt(row.size, 10);
+        const shapeChanged = (row.prefix || '') !== row.orig.prefix || size !== row.orig.size;
+        if (shapeChanged && isFinite(size)) {
+          const res = await fetch('/services/core/numbering/shape', {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ series: row.series, partition: row.partition, prefix: row.prefix || '', size: size })
+          });
+          if (!res.ok) throw new Error('PUT shape ' + row.series + ' -> HTTP ' + res.status);
+          row.orig.prefix = row.prefix || '';
+          row.orig.size = size;
         }
-        await this.loadNumbering();
+        const next = parseInt(row.next, 10);
+        if (!this.numberingIsShapeTemplate(row) && isFinite(next) && next >= 1 && next !== row.orig.next) {
+          const res = await fetch('/services/core/numbering', {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ series: row.series, partition: row.partition, next: next })
+          });
+          if (!res.ok) throw new Error('PUT ' + row.series + ' -> HTTP ' + res.status);
+          row.orig.next = next;
+        }
+        row.saved = true;
+        setTimeout(() => { row.saved = false; }, 2500);
       } catch (e) {
         console.error('document-numbering: failed to save', e);
         this.numberingError = 'save';
+      } finally {
+        row.saving = false;
+        this.refreshIcons();
       }
     },
 

--- a/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
+++ b/components/resources/resources-application/src/main/resources/META-INF/dirigible/application/views/_settings.html
@@ -177,10 +177,16 @@
         </template>
         <template x-if="!numberingLoading && numberingError !== 'forbidden' && numbering.length > 0">
           <div class="vbox gap-4">
+            <div class="hbox gap-2">
+              <button x-h-button data-variant="outline" data-size="sm" @click="loadNumbering()" x-text="T('application-core:shell.settings.reload', 'Reload')"></button>
+            </div>
             <template x-for="row in numbering" :key="row.series + '|' + row.partition">
               <div class="vbox gap-1">
                 <span class="text-sm font-medium" x-text="numberingLabel(row)"></span>
-                <div class="hbox gap-2">
+                <!-- Save sits ON the row (a real suite has dozens of series - one button below the
+                     whole list is off-screen); it lights up only when the row's edits differ from
+                     what was loaded, and only what changed is written. -->
+                <div class="hbox gap-2 items-end">
                   <div class="vbox gap-0" style="width: 10rem;">
                     <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingPrefix', 'Prefix')"></span>
                     <input x-h-input x-model="row.prefix" />
@@ -189,19 +195,32 @@
                     <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingSize', 'Total width')"></span>
                     <input x-h-input type="number" min="1" max="40" x-model="row.size" />
                   </div>
-                  <div class="vbox gap-0" style="width: 9rem;">
-                    <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingNext', 'Next')"></span>
-                    <input x-h-input type="number" min="1" x-model="row.next" />
-                  </div>
+                  <!-- The base row of a PARTITIONED series is only the shape template new partitions
+                       inherit - allocation always draws from a partition row - so it offers no Next. -->
+                  <template x-if="!numberingIsShapeTemplate(row)">
+                    <div class="vbox gap-0" style="width: 9rem;">
+                      <span x-h-text.muted class="text-xs" x-text="T('application-core:shell.settings.numberingNext', 'Next')"></span>
+                      <input x-h-input type="number" min="1" x-model="row.next" />
+                    </div>
+                  </template>
+                  <button x-h-button data-variant="emphasized" data-size="sm"
+                          :disabled="row.saving || !numberingDirty(row)"
+                          @click="saveNumberingRow(row)"
+                          x-text="T('application-core:shell.settings.save', 'Save')"></button>
+                  <template x-if="row.saved">
+                    <span class="text-sm" x-text="T('application-core:shell.settings.numberingSaved', 'Saved')"></span>
+                  </template>
                 </div>
-                <span x-h-text.muted class="text-sm"
-                      x-text="T('application-core:shell.settings.numberingExample', 'Next number:') + ' ' + numberingExample(row)"></span>
+                <template x-if="!numberingIsShapeTemplate(row)">
+                  <span x-h-text.muted class="text-sm"
+                        x-text="T('application-core:shell.settings.numberingExample', 'Next number:') + ' ' + numberingExample(row)"></span>
+                </template>
+                <template x-if="numberingIsShapeTemplate(row)">
+                  <span x-h-text.muted class="text-sm"
+                        x-text="T('application-core:shell.settings.numberingShapeTemplate', 'Counters live on the per-partition rows below; a new partition appears on its first use, inheriting this shape.')"></span>
+                </template>
               </div>
             </template>
-            <div class="hbox gap-2">
-              <button x-h-button data-variant="emphasized" @click="saveNumbering()" x-text="T('application-core:shell.settings.save', 'Save')"></button>
-              <button x-h-button data-variant="outline" @click="loadNumbering()" x-text="T('application-core:shell.settings.reload', 'Reload')"></button>
-            </div>
           </div>
         </template>
       </div>

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/NumberingSdkIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/NumberingSdkIT.java
@@ -10,11 +10,14 @@
 package org.eclipse.dirigible.integration.tests.api;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+
+import io.restassured.http.ContentType;
 
 import org.awaitility.Awaitility;
 import org.eclipse.dirigible.components.base.artefact.ArtefactLifecycle;
@@ -157,6 +160,51 @@ class NumberingSdkIT extends IntegrationTest {
             // range (two legal entities must not share a counter), in the shape inherited from the series.
             assertEquals(a1, b1, "each partition starts its own sequence: " + a1 + " vs " + b1);
             assertEquals(value(a1) + 1, value(a2), "another partition's allocation must not advance this one: " + a1 + " then " + a2);
+        }, ASSERTION_TIMEOUT_SECONDS);
+    }
+
+    @Test
+    void theSettingsSurfaceSeedsPartitionCountersAndTheBaseRowIsOnlyTheShapeTemplate() {
+        publishDeclarationAndController();
+
+        restAssuredExecutor.execute(() -> {
+            // Materialize a partition: its first allocation copies the base shape and starts its own
+            // counter (partition values are data - no artefact can pre-provision them).
+            allocate("/next/SEED");
+
+            // The management surface flags the series PARTITIONED - the base ("") row is only the
+            // shape template new partitions inherit, so the settings page offers no counter on it.
+            given().when()
+                   .get("/services/core/numbering")
+                   .then()
+                   .statusCode(200)
+                   .body("find { it.series == '" + SERIES + "' && it.partition == '' }.partitioned", equalTo(true))
+                   .body("find { it.series == '" + SERIES + "' && it.partition == 'SEED' }.partitioned", equalTo(true));
+
+            // Editing the BASE row's next must not affect partition allocations (the observed trap:
+            // an operator edits the base Next expecting to seed the next invoice number)...
+            given().contentType(ContentType.JSON)
+                   .body("{\"series\": \"" + SERIES + "\", \"partition\": \"\", \"next\": 500}")
+                   .when()
+                   .put("/services/core/numbering")
+                   .then()
+                   .statusCode(204);
+
+            // ...while a PARTITION row's next IS the seed: it round-trips and the next issued number
+            // renders exactly it.
+            given().contentType(ContentType.JSON)
+                   .body("{\"series\": \"" + SERIES + "\", \"partition\": \"SEED\", \"next\": 42}")
+                   .when()
+                   .put("/services/core/numbering")
+                   .then()
+                   .statusCode(204);
+            given().when()
+                   .get("/services/core/numbering")
+                   .then()
+                   .statusCode(200)
+                   .body("find { it.series == '" + SERIES + "' && it.partition == 'SEED' }.next", equalTo(42));
+
+            assertEquals("T-0042", allocate("/next/SEED"), "the partition row's Next is what the next document renders");
         }, ASSERTION_TIMEOUT_SECONDS);
     }
 


### PR DESCRIPTION
Closes #6499.

## What

- **Per-row Save.** The numbering settings page saved through one Save/Reload pair below the whole series list - off-screen with a real application's dozens of series. Save now sits on each row (`saveNumberingRow`), enabled only when the row differs from its loaded baseline; only the changed halves are written (shape via `PUT /shape`, counter via `PUT` - the endpoint's writes were already change-tracked so an unchanged Next never rewinds a live counter). Saving one row updates only that row's baseline, so in-progress edits on other rows survive; a transient "Saved" confirmation appears on the row. Reload moved to the top of the list.
- **Base-row trap closed.** For a partitioned series the base ("") row is only the shape template new partitions inherit on first allocation - allocation never draws from it - yet the page offered its Next for editing (observed live: base Next edited, the invoice still took the partition counter). `DocumentNumberEndpoint.SeriesView` gains a `partitioned` flag (true once any partition row of the series exists); the base row of a partitioned series renders **no Next input** and no "Next number" preview - its shape stays editable - plus one line of copy: "Counters live on the per-partition rows below; a new partition appears on its first use, inheriting this shape." (en + bg catalog entries added.)

## Test

`NumberingSdkIT.theSettingsSurfaceSeedsPartitionCountersAndTheBaseRowIsOnlyTheShapeTemplate` (green locally): materializes a partition, asserts the `partitioned` flag on both rows over `GET /services/core/numbering`, edits the BASE row's Next (must not affect partition allocations), edits the PARTITION row's Next to 42 and asserts the round-trip **and** that the next allocated document renders exactly `T-0042` - the outermost observable layer of the seeding contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)