### PR TITLE
fix(print): scaffold emits only keys the feeder puts; back-references label by their number (#6503)

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentEntities.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/IntentEntities.java
@@ -82,6 +82,38 @@ public final class IntentEntities {
     }
 
     /** The entity's primary-key field, or null when none is declared. */
+    /**
+     * The property a to-one target's records are LABELED by, resolving broader than the authored
+     * {@code name} field so a document back-reference labels as its number: (1) an authored
+     * {@code name} field; (2) the stored {@code Name} a {@code label:} expression generates; (3) the
+     * {@code function: DocumentTitle} field - a document's human identity (its number). Empty when
+     * nothing resolves - the caller then omits the {@code __label} put / the scaffold field rather than
+     * reference a value that cannot exist.
+     *
+     * @param target the relation's target entity, may be {@code null}
+     * @return the PascalCase label property, or {@code ""}
+     */
+    public static String labelFieldOf(EntityIntent target) {
+        if (target == null) {
+            return "";
+        }
+        for (FieldIntent field : target.getFields()) {
+            if (field.getName() != null && "name".equalsIgnoreCase(field.getName())) {
+                return IntentNaming.pascalCase(field.getName());
+            }
+        }
+        if (target.getLabel() != null && !target.getLabel()
+                                                .isBlank()) {
+            return "Name"; // the stored, repository-recomputed label property the expression generates
+        }
+        for (FieldIntent field : target.getFields()) {
+            if (field.isDocumentTitle() && field.getName() != null) {
+                return IntentNaming.pascalCase(field.getName());
+            }
+        }
+        return "";
+    }
+
     public static FieldIntent primaryKeyOf(EntityIntent entity) {
         if (entity == null) {
             return null;

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupport.java
@@ -110,10 +110,71 @@ final class PrintFeederSupport {
             addNode(relation, "root", "document", 1, model, byName, compositionParents, context, nodes, usedVars, visited);
         }
         feeder.put("nodes", nodes);
+        feeder.put("itemNodes", buildItemNodes(items, master, model, byName, compositionParents, context, usedVars));
         // Drives the one reflective copy helper the template emits - only when a cross-model node needs it.
-        feeder.put("hasCrossModel", nodes.stream()
-                                         .anyMatch(node -> Boolean.TRUE.equals(node.get("crossModel"))));
+        feeder.put("hasCrossModel", hasCrossModel(feeder));
         return feeder;
+    }
+
+    /**
+     * One node per to-one relation of the LINE-ITEMS entity (its composition back-reference to the
+     * master excluded - that is the document itself), so an items-table column can render the
+     * relation's label ({@code {{Unit}}} - "1 month") or descend into its fields
+     * ({@code {{Unit.Name}}}), exactly as the header relations resolve. Depth 1: an item relation feeds
+     * its target's own record, not the target's further graph.
+     */
+    private static List<Map<String, Object>> buildItemNodes(EntityIntent items, EntityIntent master, IntentModel model,
+            Map<String, EntityIntent> byName, Map<String, String> compositionParents, IntentGenerationContext context,
+            Set<String> usedVars) {
+        List<Map<String, Object>> itemNodes = new ArrayList<>();
+        for (RelationIntent relation : items.getRelations()) {
+            if (!isToOne(relation) || relation.getName() == null || relation.getTo() == null) {
+                continue;
+            }
+            if (relation.isComposition() && master.getName()
+                                                  .equals(relation.getTo())) {
+                continue; // the back-reference to the document - the header, not an item lookup
+            }
+            boolean crossModel = relation.getModel() != null && !relation.getModel()
+                                                                         .isBlank();
+            // Prefixed so an item relation named like a header one (Customer on both) cannot collide.
+            String entityVar = uniqueVar("item" + IntentNaming.pascalCase(relation.getName()), usedVars);
+            Map<String, Object> node = new LinkedHashMap<>();
+            node.put("entityVar", entityVar);
+            node.put("mapVar", entityVar + "Map");
+            node.put("fkProperty", IntentNaming.pascalCase(relation.getName()));
+            node.put("keyInParent", IntentNaming.pascalCase(relation.getName()));
+            node.put("entity", relation.getTo());
+            node.put("crossModel", crossModel);
+            if (crossModel) {
+                UsesIntent uses = findUses(model, relation.getModel());
+                CrossModelSupport.TargetInfo target = uses == null ? null : CrossModelSupport.resolve(context, uses, relation.getTo());
+                node.put("model", relation.getModel());
+                node.put("perspective", target != null ? target.perspectiveName() : relation.getTo());
+                node.put("labelField", target != null ? target.labelField() : "Name");
+                // No `scalars`: the template copies the owner's fields reflectively (see the class note).
+                node.put("scalars", List.of());
+            } else {
+                EntityIntent target = byName.get(relation.getTo());
+                node.put("model", "");
+                node.put("perspective", target != null && target.isSetting() ? "Settings"
+                        : IntentEntities.resolvePerspective(relation.getTo(), compositionParents));
+                node.put("labelField", nameField(target));
+                node.put("scalars", scalarDescriptors(target));
+            }
+            itemNodes.add(node);
+        }
+        return itemNodes;
+    }
+
+    /** Whether any header or item node is cross-model - drives the one reflective copy helper. */
+    @SuppressWarnings("unchecked")
+    private static boolean hasCrossModel(Map<String, Object> feeder) {
+        boolean header = ((List<Map<String, Object>>) feeder.get("nodes")).stream()
+                                                                          .anyMatch(node -> Boolean.TRUE.equals(node.get("crossModel")));
+        boolean item = ((List<Map<String, Object>>) feeder.get("itemNodes")).stream()
+                                                                            .anyMatch(node -> Boolean.TRUE.equals(node.get("crossModel")));
+        return header || item;
     }
 
     /**

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupport.java
@@ -271,19 +271,15 @@ final class PrintFeederSupport {
     }
 
     /**
-     * The same-model to-one target's label property: its {@code name} field (PascalCased), or empty
-     * when the target has none — the template then omits the {@code __label} put rather than emit an
-     * accessor for a field that does not exist (which would fail {@code javac}).
+     * The same-model to-one target's label property, resolved by the shared
+     * {@link IntentEntities#labelFieldOf(EntityIntent)} - an authored {@code name} field, the stored
+     * {@code Name} a {@code label:} generates, or the {@code DocumentTitle} field (so a document
+     * back-reference labels as its number). Empty when nothing resolves - the template then omits the
+     * {@code __label} put rather than emit an accessor for a field that does not exist (which would
+     * fail {@code javac}).
      */
     private static String nameField(EntityIntent target) {
-        if (target != null) {
-            for (FieldIntent field : target.getFields()) {
-                if (field.getName() != null && "name".equalsIgnoreCase(field.getName())) {
-                    return IntentNaming.pascalCase(field.getName());
-                }
-            }
-        }
-        return "";
+        return IntentEntities.labelFieldOf(target);
     }
 
     private static UsesIntent findUses(IntentModel model, String alias) {

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.dirigible.components.intent.generator.IntentEntities;
 import org.eclipse.dirigible.components.intent.generator.IntentGenerationContext;
 import org.eclipse.dirigible.components.intent.generator.IntentNaming;
 import org.eclipse.dirigible.components.intent.generator.IntentTargetGenerator;
@@ -74,7 +75,7 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
             String fileName = "doc/Templates/" + master.getKey()
                                                        .getName()
                     + "/Print/en/standard.print";
-            context.writeModelFileIfAbsent(fileName, buildTemplate(master.getKey(), master.getValue()));
+            context.writeModelFileIfAbsent(fileName, buildTemplate(master.getKey(), master.getValue(), IntentEntities.byName(model)));
             LOGGER.debug("Generated standard print template [{}]", fileName);
         }
     }
@@ -148,13 +149,18 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
-     * Builds the standard template for one document master.
+     * Builds the standard template for one document master. Every placeholder the scaffold emits is a
+     * key the generated print feeder actually puts (the scaffold/feeder contract): the primary key is
+     * never referenced (the feeder deliberately excludes it), and a same-model relation appears only
+     * when its target resolves a label - a dead {@code {{...}}} renders as an empty value that a
+     * template author then hunts through the whole pipeline.
      *
      * @param master the header entity
      * @param items the line-items entity
+     * @param byName all entities by name (to resolve a relation target's label)
      * @return the {@code .print} template source
      */
-    static String buildTemplate(EntityIntent master, EntityIntent items) {
+    public static String buildTemplate(EntityIntent master, EntityIntent items, Map<String, EntityIntent> byName) {
         String label = IntentNaming.humanize(master.getName());
         StringBuilder template = new StringBuilder(4096);
         template.append("<!-- Standard print template for ")
@@ -194,7 +200,17 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
             appendField(template, "            ", field.getName());
         }
         for (RelationIntent relation : master.getRelations()) {
-            if (isToOne(relation)) {
+            if (!isToOne(relation) || relation.getName() == null) {
+                continue;
+            }
+            // The feeder labels a same-model relation only when its target resolves a label property
+            // (name / label: / DocumentTitle); without one, a bare {{document.<Relation>}} would render
+            // an empty value - so the scaffold omits the field instead of emitting a dead placeholder.
+            // A cross-model target is labeled by the owner-model convention and always emitted.
+            boolean crossModel = relation.getModel() != null && !relation.getModel()
+                                                                         .isBlank();
+            if (crossModel || !IntentEntities.labelFieldOf(byName.get(relation.getTo()))
+                                             .isEmpty()) {
                 appendField(template, "            ", relation.getName());
             }
         }
@@ -241,12 +257,17 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
             template.append("        </section>\n\n");
         }
 
+        // Footer: the label plus the document number when one exists. NEVER the primary key - the
+        // feeder deliberately excludes it, so {{document.Id}} would be a dead placeholder.
         template.append("        <footer>\n");
         template.append("            <text align=\"center\">")
-                .append(escape(label))
-                .append(" {{document.")
-                .append(number != null ? IntentNaming.pascalCase(number.getName()) : "Id")
-                .append("}}</text>\n");
+                .append(escape(label));
+        if (number != null) {
+            template.append(" {{document.")
+                    .append(IntentNaming.pascalCase(number.getName()))
+                    .append("}}");
+        }
+        template.append("</text>\n");
         template.append("        </footer>\n\n");
         template.append("    </page>\n");
         template.append("</document>\n");

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupportTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PrintFeederSupportTest.java
@@ -46,6 +46,8 @@ class PrintFeederSupportTest {
                   - { name: quantity, type: decimal, required: true }
                 relations:
                   - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+                  - { name: Unit, kind: manyToOne, to: Unit }
+                  - { name: Product, kind: manyToOne, to: Product, model: customers }
               - name: SalesInvoiceStatus
                 kind: setting
                 fields:
@@ -58,6 +60,11 @@ class PrintFeederSupportTest {
                 relations:
                   - { name: Country, kind: manyToOne, to: Country }
               - name: Country
+                fields:
+                  - { name: id, type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Unit
+                kind: setting
                 fields:
                   - { name: id, type: integer, primaryKey: true, generated: true }
                   - { name: name, type: string }
@@ -161,6 +168,41 @@ class PrintFeederSupportTest {
         assertFalse(regionScalars.isEmpty(), "a same-model node still names its fields - it is regenerated with them");
 
         assertEquals(Boolean.TRUE, feeder.get("hasCrossModel"), "the reflective copy helper is emitted for this feeder");
+    }
+
+    /**
+     * An items-table column must be able to render a line's to-one relation ({@code {{Unit}}} - "1
+     * month") exactly as the header relations resolve: one node per item to-one, the composition
+     * back-reference to the document excluded, same-model fields named / cross-model copied
+     * reflectively, and the variables prefixed so a header relation of the same name cannot collide.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void itemToOneRelationsAreFedWithLabelAndFields() {
+        Map<String, Object> feeder = feeder();
+        List<Map<String, Object>> itemNodes = (List<Map<String, Object>>) feeder.get("itemNodes");
+        Map<String, Map<String, Object>> byKey = new java.util.LinkedHashMap<>();
+        for (Map<String, Object> node : itemNodes) {
+            byKey.put((String) node.get("keyInParent"), node);
+        }
+
+        assertFalse(byKey.containsKey("SalesInvoice"), "the composition back-reference is the header, not an item lookup");
+
+        Map<String, Object> unit = byKey.get("Unit");
+        assertNotNull(unit, "a same-model item relation is fed");
+        assertEquals(Boolean.FALSE, unit.get("crossModel"));
+        assertEquals("Settings", unit.get("perspective"), "a setting target loads from the shared Settings perspective");
+        assertEquals("Name", unit.get("labelField"));
+        assertEquals("itemUnit", unit.get("entityVar"), "item variables are prefixed so header names cannot collide");
+        List<Map<String, Object>> unitScalars = (List<Map<String, Object>>) unit.get("scalars");
+        assertFalse(unitScalars.isEmpty(), "a same-model item node names its fields - {{Unit.Name}} descends");
+
+        Map<String, Object> product = byKey.get("Product");
+        assertNotNull(product, "a cross-model item relation is fed");
+        assertEquals(Boolean.TRUE, product.get("crossModel"));
+        assertEquals("customers", product.get("model"));
+        assertTrue(((List<Map<String, Object>>) product.get("scalars")).isEmpty(),
+                "a cross-model item node dereferences no named field of the owner (dirigible #6422)");
     }
 
     /** A document whose whole relation graph is local needs no reflective copy helper. */

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PrintScaffoldFeederContractTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/PrintScaffoldFeederContractTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2010-2026 Eclipse Dirigible contributors
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-FileCopyrightText: Eclipse Dirigible contributors SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.dirigible.components.intent.generator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.dirigible.components.intent.generator.print.PrintIntentGenerator;
+import org.eclipse.dirigible.components.intent.model.EntityIntent;
+import org.eclipse.dirigible.components.intent.model.IntentModel;
+import org.eclipse.dirigible.components.intent.parser.IntentParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The scaffold/feeder CONTRACT: every {@code {{...}}} placeholder the generated
+ * {@code standard.print} scaffold emits must be a key the generated print feeder actually puts. The
+ * two generators derive from the same model but used to disagree - the scaffold referenced the
+ * primary key (which the feeder deliberately excludes) and bare relation maps that carried no
+ * {@code __label} - and a dead placeholder renders as an empty value the template author then hunts
+ * through the whole pipeline. The fixture exercises the shapes that broke: a {@code number:}-style
+ * DocumentTitle, an EntityStatus relation, a document back-reference (a target with no {@code name}
+ * field, labeled by its number), and a relation to an entity with no resolvable label at all.
+ */
+class PrintScaffoldFeederContractTest {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{\\{([^}]+)}}");
+
+    private static final String INTENT = """
+            name: shipping
+            entities:
+              # a document master with a DocumentTitle number and NO name field - the back-reference
+              # target below: it must be labeled by its number, not dropped.
+              - name: GoodsIssue
+                function: Document
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string, function: DocumentTitle }
+                  - { name: note,   type: string }
+                relations:
+                  - { name: Status, kind: manyToOne, to: ShippingStatus, function: EntityStatus, init: 1 }
+              - name: GoodsIssueItem
+                function: DocumentItem
+                fields:
+                  - { name: id,       type: integer, primaryKey: true, generated: true }
+                  - { name: quantity, type: decimal }
+                relations:
+                  - { name: GoodsIssue, kind: manyToOne, to: GoodsIssue, composition: true, required: true }
+
+              # the invoice: number + status + a back-reference to the GoodsIssue + a relation whose
+              # target resolves NO label (no name, no label:, no DocumentTitle).
+              - name: SalesInvoice
+                function: Document
+                fields:
+                  - { name: id,     type: integer, primaryKey: true, generated: true }
+                  - { name: number, type: string, function: DocumentTitle }
+                  - { name: date,   type: date }
+                  - { name: total,  type: decimal, aggregate: true }
+                relations:
+                  - { name: Status,     kind: manyToOne, to: ShippingStatus, function: EntityStatus, init: 1 }
+                  - { name: GoodsIssue, kind: manyToOne, to: GoodsIssue }
+                  - { name: Bare,       kind: manyToOne, to: Bare }
+              - name: SalesInvoiceItem
+                function: DocumentItem
+                fields:
+                  - { name: id,       type: integer, primaryKey: true, generated: true }
+                  - { name: name,     type: string }
+                  - { name: quantity, type: decimal }
+                relations:
+                  - { name: SalesInvoice, kind: manyToOne, to: SalesInvoice, composition: true, required: true }
+                  - { name: Unit, kind: manyToOne, to: Unit }
+
+              - name: ShippingStatus
+                kind: setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              - name: Unit
+                kind: setting
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: name, type: string }
+              # no name, no label:, no DocumentTitle - nothing can label a reference to it
+              - name: Bare
+                fields:
+                  - { name: id,   type: integer, primaryKey: true, generated: true }
+                  - { name: code, type: integer }
+            """;
+
+    private final IntentModel model = IntentParser.parse(INTENT);
+    private final Map<String, EntityIntent> byName = IntentEntities.byName(model);
+
+    private Map<String, Map<String, Object>> feedersByEntity() {
+        IntentGenerationContext context = new IntentGenerationContext(model, "/proj", "proj", "workspace", "app", null);
+        Map<String, Map<String, Object>> feeders = new LinkedHashMap<>();
+        for (Map<String, Object> feeder : PrintFeederSupport.buildPrintFeeders(model, byName, IntentEntities.compositionParents(model),
+                context)) {
+            feeders.put((String) feeder.get("entity"), feeder);
+        }
+        return feeders;
+    }
+
+    @Test
+    void aDocumentBackReferenceIsLabeledByItsNumberNotDropped() {
+        EntityIntent invoice = byName.get("SalesInvoice");
+        String scaffold = PrintIntentGenerator.buildTemplate(invoice, byName.get("SalesInvoiceItem"), byName);
+        assertTrue(scaffold.contains("{{document.GoodsIssue}}"),
+                "a back-reference to another document must stay on the scaffold - it is labeled by its number");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> nodes = (List<Map<String, Object>>) feedersByEntity().get("SalesInvoice")
+                                                                                       .get("nodes");
+        Map<String, Object> goodsIssue = nodes.stream()
+                                              .filter(node -> "GoodsIssue".equals(node.get("keyInParent")))
+                                              .findFirst()
+                                              .orElseThrow();
+        assertTrue("Number".equals(goodsIssue.get("labelField")),
+                "the feeder labels the back-reference by the target's DocumentTitle field, got: " + goodsIssue.get("labelField"));
+    }
+
+    @Test
+    void aRelationWithNoResolvableLabelIsOmittedFromTheScaffold() {
+        EntityIntent invoice = byName.get("SalesInvoice");
+        String scaffold = PrintIntentGenerator.buildTemplate(invoice, byName.get("SalesInvoiceItem"), byName);
+        assertFalse(scaffold.contains("{{document.Bare}}"),
+                "a relation whose target resolves no label would render an empty value - the scaffold must omit it");
+    }
+
+    @Test
+    void theFooterNeverReferencesThePrimaryKey() {
+        // GoodsIssue HAS a number, so its footer uses it; strip the number to force the fallback.
+        EntityIntent goodsIssue = byName.get("GoodsIssue");
+        goodsIssue.getFields()
+                  .removeIf(field -> "number".equals(field.getName()));
+        String scaffold = PrintIntentGenerator.buildTemplate(goodsIssue, byName.get("GoodsIssueItem"), byName);
+        assertFalse(scaffold.contains("{{document.Id}}"),
+                "the feeder deliberately excludes the primary key - the scaffold must never reference it");
+    }
+
+    /** The sweep: every placeholder the scaffold emits resolves against the feeder's contract. */
+    @Test
+    @SuppressWarnings("unchecked")
+    void everyScaffoldPlaceholderIsAKeyTheFeederPuts() {
+        for (Map.Entry<String, Map<String, Object>> entry : feedersByEntity().entrySet()) {
+            EntityIntent master = byName.get(entry.getKey());
+            Map<String, Object> feeder = entry.getValue();
+            String scaffold = PrintIntentGenerator.buildTemplate(master, byName.get((String) feeder.get("itemsEntity")), byName);
+
+            Set<String> documentKeys = new LinkedHashSet<>();
+            ((List<Map<String, Object>>) feeder.get("rootScalars")).forEach(scalar -> documentKeys.add((String) scalar.get("name")));
+            ((List<Map<String, Object>>) feeder.get("nodes")).forEach(node -> documentKeys.add((String) node.get("keyInParent")));
+            Set<String> itemKeys = new LinkedHashSet<>();
+            ((List<Map<String, Object>>) feeder.get("itemScalars")).forEach(scalar -> itemKeys.add((String) scalar.get("name")));
+            ((List<Map<String, Object>>) feeder.get("itemNodes")).forEach(node -> itemKeys.add((String) node.get("keyInParent")));
+
+            Matcher matcher = PLACEHOLDER.matcher(scaffold);
+            while (matcher.find()) {
+                String path = matcher.group(1)
+                                     .trim();
+                String[] segments = path.split("\\.");
+                if ("document".equals(segments[0])) {
+                    assertTrue(documentKeys.contains(segments[1]), "scaffold placeholder {{" + path + "}} of [" + master.getName()
+                            + "] is not fed - the feeder puts only " + documentKeys);
+                } else {
+                    assertTrue(itemKeys.contains(segments[0]), "scaffold items placeholder {{" + path + "}} of [" + master.getName()
+                            + "] is not fed - the feeder puts only " + itemKeys);
+                }
+            }
+        }
+    }
+}

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 
+import org.eclipse.dirigible.components.intent.generator.IntentEntities;
 import org.eclipse.dirigible.components.intent.model.EntityIntent;
 import org.eclipse.dirigible.components.intent.model.IntentModel;
 import org.eclipse.dirigible.components.intent.parser.IntentParser;
@@ -75,7 +76,7 @@ class PrintIntentGeneratorTest {
         EntityIntent master = masters.keySet()
                                      .iterator()
                                      .next();
-        String template = PrintIntentGenerator.buildTemplate(master, masters.get(master));
+        String template = PrintIntentGenerator.buildTemplate(master, masters.get(master), IntentEntities.byName(model));
 
         // must parse cleanly with the document-template DSL parser
         DocumentNode document = new DocumentParser().parseDocument(template);
@@ -104,8 +105,8 @@ class PrintIntentGeneratorTest {
         EntityIntent master = masters.keySet()
                                      .iterator()
                                      .next();
-        String first = PrintIntentGenerator.buildTemplate(master, masters.get(master));
-        String second = PrintIntentGenerator.buildTemplate(master, masters.get(master));
+        String first = PrintIntentGenerator.buildTemplate(master, masters.get(master), IntentEntities.byName(model));
+        String second = PrintIntentGenerator.buildTemplate(master, masters.get(master), IntentEntities.byName(model));
         assertEquals(first, second);
     }
 }

--- a/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/PrintFeeder.java.template
+++ b/components/template/template-application-events-java/src/main/resources/META-INF/dirigible/template-application-events-java/events/PrintFeeder.java.template
@@ -87,6 +87,10 @@ public class ${className}PrintFeeder {
 #end
 
         List<Object> items = new ArrayList<>();
+#foreach($n in $itemNodes)
+        // ${n.entity} lookups (via the items' ${n.fkProperty}): one load per DISTINCT key, not per row.
+        Map<Object, gen.${n.genFolder}.data.${n.javaPerspective}.${n.entity}Entity> ${n.entityVar}Cache = new LinkedHashMap<>();
+#end
         for (gen.${javaGenFolderName}.data.${itemsJavaPerspective}.${itemsEntity}Entity item : new gen.${javaGenFolderName}.data.${itemsJavaPerspective}.${itemsEntity}Repository().findAll(Criteria.create().eq("${itemsFkProperty}", id))) {
             Map<String, Object> im = new LinkedHashMap<>();
 #foreach($s in $itemScalars)
@@ -95,6 +99,44 @@ public class ${className}PrintFeeder {
 #else
             im.put("${s.name}", item.${s.name});
 #end
+#end
+#foreach($n in $itemNodes)
+
+            // ${n.entity} (via ${n.fkProperty}) - so an items column renders {{${n.keyInParent}}} (the
+            // label) or descends into {{${n.keyInParent}.<Field>}}, exactly as the header relations do.
+            gen.${n.genFolder}.data.${n.javaPerspective}.${n.entity}Entity ${n.entityVar} = null;
+            if (item.${n.fkProperty} != null) {
+                ${n.entityVar} = ${n.entityVar}Cache.get(item.${n.fkProperty});
+                if (${n.entityVar} == null) {
+                    ${n.entityVar} = new gen.${n.genFolder}.data.${n.javaPerspective}.${n.entity}Repository().findById(item.${n.fkProperty});
+                    if (${n.entityVar} != null) {
+                        ${n.entityVar}Cache.put(item.${n.fkProperty}, ${n.entityVar});
+                    }
+                }
+            }
+            Map<String, Object> ${n.mapVar} = new LinkedHashMap<>();
+            if (${n.entityVar} != null) {
+#if($n.crossModel)
+                // ${n.model} owns this record, so its fields are copied as they are TODAY rather than
+                // named here (dirigible #6422).
+                copyRecordFields(${n.entityVar}, ${n.mapVar});
+#if($n.labelField != "")
+                ${n.mapVar}.put("__label", ${n.mapVar}.get("${n.labelField}"));
+#end
+#else
+#if($n.labelField != "")
+                ${n.mapVar}.put("__label", ${n.entityVar}.${n.labelField});
+#end
+#foreach($s in $n.scalars)
+#if($s.date)
+                ${n.mapVar}.put("${s.name}", ${n.entityVar}.${s.name} == null ? null : ${n.entityVar}.${s.name}.toString());
+#else
+                ${n.mapVar}.put("${s.name}", ${n.entityVar}.${s.name});
+#end
+#end
+#end
+            }
+            im.put("${n.keyInParent}", ${n.mapVar});
 #end
             items.add(im);
         }

--- a/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
+++ b/components/ui/service-generate/src/main/resources/META-INF/dirigible/service-generate/template/generateUtils.js
@@ -1425,6 +1425,24 @@ export function generateFiles(model, parameters, templateSources) {
                                 // committed gen/ survives the owner retiring a field. hasCrossModel emits
                                 // that one helper only where it is needed.
                                 hasCrossModel: feeder.hasCrossModel === true,
+                                // Line-item to-one lookups: the same shape as the header nodes, resolved
+                                // per row (label + fields), so an items-table column can render the
+                                // relation ({{Unit}} / {{Unit.Name}}).
+                                itemNodes: (feeder.itemNodes || []).map(function (n) {
+                                    return {
+                                        entityVar: n.entityVar,
+                                        mapVar: n.mapVar,
+                                        fkProperty: n.fkProperty,
+                                        keyInParent: n.keyInParent,
+                                        entity: n.entity,
+                                        crossModel: n.crossModel === true,
+                                        model: n.model,
+                                        genFolder: n.crossModel ? sanitizeJavaIdentifier(n.model) : parameters.javaGenFolderName,
+                                        javaPerspective: sanitizeJavaIdentifier(n.perspective),
+                                        labelField: n.labelField,
+                                        scalars: n.scalars
+                                    };
+                                }),
                                 nodes: (feeder.nodes || []).map(function (n) {
                                     return {
                                         entityVar: n.entityVar,

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -414,6 +414,9 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: amount, type: decimal }
                 relations:
                   - { name: Bill, kind: manyToOne, to: Bill, composition: true, required: true }
+                  # an item-level to-one: the print feeder must feed it per row so an items-table
+                  # column can render {{Unit}} (the label, translated) or {{Unit.Name}}
+                  - { name: Unit, kind: manyToOne, to: Unit }
 
               # keyed cross-entity aggregate: a signed ledger summed per (Person, Unit) into a
               # materialised total row keyed by the same two FKs. Ledger.amount is SENSITIVE and
@@ -1173,6 +1176,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(sendBill.contains("attachLanguageSource.Locale"), "the language must be read off the person's locale");
         assertTrue(sendBill.contains("org.eclipse.dirigible.sdk.print.Print.defaultLanguage()"),
                 "a null/blank locale must fall back to the application language set at send time");
+
+        // The feeder resolves the LINE-ITEM to-one relations per row - an items-table column renders
+        // {{Unit}} (the target's label, through the repository so the translation overlay applies) or
+        // descends into {{Unit.Name}} - with one load per DISTINCT key, not one per row.
+        String billFeeder = contentOf("gen/events/emission/BillPrintFeeder.java");
+        assertTrue(billFeeder.contains("itemUnitCache"), "item relation lookups are cached per distinct key: " + billFeeder);
+        assertTrue(billFeeder.contains("new gen.emission.data.settings.UnitRepository().findById(item.Unit)"),
+                "the item's Unit is loaded through its generated repository");
+        assertTrue(billFeeder.contains("itemUnitMap.put(\"__label\", itemUnit.Name)"),
+                "the item relation map carries the __label the binder renders for a bare {{Unit}}");
+        assertTrue(billFeeder.contains("im.put(\"Unit\", itemUnitMap)"), "the map is hung under the relation's own key on the row");
         assertTrue(sendBill.contains("catch (Exception"), "a transition's mail must be fail-soft - the status flip has already committed");
 
         // (2) On a PROCESS STEP - a JavaDelegate whose work IS the message: it re-loads the trigger


### PR DESCRIPTION
Closes #6503. **Stacked on #6502** (line-item relation feeding) - the diff includes it until #6502 merges; review the last commit only.

## What

The `.print` scaffold generator and the print-feeder generator derive from the same model but disagreed about one contract, producing dead placeholders on freshly scaffolded templates:

- **Footer `{{document.Id}}`** on a master without a DocumentTitle field - the feeder deliberately excludes the primary key. The footer now shows the number when one exists and nothing otherwise.
- **Bare back-reference maps with no `__label`** (`{{document.GoodsIssue}}`) - the feeder labeled a relation target only by a literal `name` field, and a document's identity is its number.

Both sides now converge on one shared label resolution (`IntentEntities.labelFieldOf`): authored `name` field → the stored `Name` a `label:` expression generates → the `function: DocumentTitle` field. A document back-reference therefore **prints its number** ("GI0000042") - exactly what a follow-up document wants - instead of rendering empty; and the scaffold omits a same-model relation only when its target resolves no label at all (a cross-model target keeps the owner-model convention).

## Test

`PrintScaffoldFeederContractTest` (4 new cases, 13/13 print tests green): a back-reference is labeled by its number on both sides; a label-less relation is omitted from the scaffold; the footer never references the PK; and the sweep - every `{{...}}` placeholder the scaffold emits resolves against the feeder's contract (root scalars + header nodes, item scalars + item nodes) over a fixture with number/status/back-refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)