### PR TITLE
fix(java): log a successful compile batch at INFO - a recovered batch must be visible

### DIFF
--- a/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceCompiler.java
+++ b/components/engine/engine-java/src/main/java/org/eclipse/dirigible/engine/java/runtime/JavaSourceCompiler.java
@@ -141,7 +141,11 @@ public class JavaSourceCompiler {
             Map<String, String> failures = buckets.failures();
 
             if (failures.isEmpty()) {
-                LOGGER.debug("Compiled batch: [{}] units, [{}] class file(s), no failures", units.size(), bytecode.size());
+                // INFO, not DEBUG: the batch runs only when the source set changed, and after a
+                // mid-publish failure this line is the ONLY visible evidence that the next cycle
+                // recovered - at DEBUG the stale failure ERROR stays the log's last word and a
+                // green system diagnoses as dead.
+                LOGGER.info("Compiled batch: [{}] units, [{}] class file(s), no failures", units.size(), bytecode.size());
             } else {
                 LOGGER.error("Compiled batch: [{}] units, [{}] class file(s); [{}] unit(s) failed to compile: {}", units.size(),
                         bytecode.size(), failures.size(), failures.keySet());


### PR DESCRIPTION
## Problem

The client-Java batch compiler logs a FAILED batch at ERROR, but a successful batch at DEBUG. During a large Publish All, an early batch legitimately fails (consumers compile before their dependency project reaches the registry) and the NEXT cycle recovers automatically - the new artefacts mark the synchronizer dirty and the rebuild succeeds.

At default log level, however, that recovery is invisible: the stale failure ERROR stays the log's last compile line. Observed live: a fully converged instance (all controllers registered, zero errors) was diagnosed as "all beans down" from the log - twice, by different readers, on the same afternoon.

## Fix

Log the no-failures batch result at INFO. The batch only runs when the source set changed (the synchronizer's dirty flag), so this is once per rebuild, not log noise.

## Notes

- Not enforcement-bearing (log level only) - no new IT; the existing engine-java suite (69 tests) passes and the INFO line is visible in the test output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)