### PR TITLE
fix(harmonia): printed PDF blob URL outlives its tab; popup-blocked prints download instead (#6511)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -266,8 +266,21 @@ document.addEventListener('alpine:init', () => {
         }
         const blob = await response.blob();
         const url = URL.createObjectURL(blob);
-        window.open(url, '_blank');
-        setTimeout(() => URL.revokeObjectURL(url), 60000);
+        // The object URL must outlive the tab that renders it: a timed revoke kills the PDF
+        // viewer's reload/print the moment it fires (observed live - the blob tab worked once,
+        // then "the file was removed"). The URL is released when THIS page unloads, which is the
+        // blob's natural owner lifetime; a print-sized PDF held until then costs nothing.
+        const opened = window.open(url, '_blank');
+        if (!opened) {
+          // Popup blocked - the open runs after async work, outside the click's gesture stack.
+          // Fall back to a download, which the browser always allows.
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = '${name}-' + this.id + '.pdf';
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+        }
       } catch (e) {
         console.error('Print failed', e);
         this.printError = 'Print failed';

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-page.js.template
@@ -599,8 +599,21 @@ document.addEventListener('alpine:init', () => {
         }
         const blob = await response.blob();
         const url = URL.createObjectURL(blob);
-        window.open(url, '_blank');
-        setTimeout(() => URL.revokeObjectURL(url), 60000);
+        // The object URL must outlive the tab that renders it: a timed revoke kills the PDF
+        // viewer's reload/print the moment it fires (observed live - the blob tab worked once,
+        // then "the file was removed"). The URL is released when THIS page unloads, which is the
+        // blob's natural owner lifetime; a print-sized PDF held until then costs nothing.
+        const opened = window.open(url, '_blank');
+        if (!opened) {
+          // Popup blocked - the open runs after async work, outside the click's gesture stack.
+          // Fall back to a download, which the browser always allows.
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = '${name}-' + this.id + '.pdf';
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+        }
       } catch (e) {
         console.error('Print failed', e);
         this.printError = 'Print failed';


### PR DESCRIPTION
Closes #6511.

The generated print flows (`document-page.js.template`, `manage/form-page.js.template`) opened the rendered PDF at `URL.createObjectURL(blob)` and revoked it on a **60-second timer**. Revoking does not close the tab — it kills the URL under the still-open PDF viewer, so a reload or print from that tab after the timer fails with a dead `blob:` URL (the reported "it appeared, then it got removed"). Separately, `window.open` runs after `await`s — outside the click's gesture stack — so a popup blocker made the print fail with no visible error (`window.open` → null).

Two changes, both print sites:

- **No timed revoke.** The object URL is released when the SPA page unloads — the blob's natural owner lifetime. A print-sized PDF held until then costs nothing, and the opened tab stays reloadable/printable indefinitely.
- **Popup-blocked fallback.** When `window.open` returns null, the PDF downloads via a temporary anchor (`download="<Entity>-<id>.pdf"`), which browsers always allow without a gesture.

The report/export flows already use the safe immediate-download pattern (`a.click()` then revoke) and are untouched.

Template-only: reaches deployed apps on regeneration (same regen sweep that picks up the other print/UI fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)