### PR TITLE
fix(harmonia): composition-parent FK never renders as a detail-form input (#6513)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -84,7 +84,11 @@
 ## editable inputs here - they render in the read-only details block below, above the buttons. They
 ## still stay in the form model so they round-trip on edit. Calculated fields remain inline (read-only).
 ## The EntityStatus FK (DOCUMENT_STATUS) is excluded too - it renders as the title-bar badge above.
-#if(!$property.dataAutoIncrement && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && !($property.auditType && $property.auditType != "NONE"))
+## The COMPOSITION-parent FK is never an input: a detail is created from its master's panel, which
+## presets the FK via the create query param (and an edit round-trips it) - exactly like every other
+## master-detail surface (items dialog, detail tables). Offering the parent as a dropdown invites
+## re-parenting by accident and is redundant inside the detail dialog.
+#if(!$property.dataAutoIncrement && $property.isReadOnlyProperty != "true" && $property.widgetType != "DOCUMENT_STATUS" && $property.relationshipType != "COMPOSITION" && !($property.auditType && $property.auditType != "NONE"))
 #set($readonly = ($property.isCalculatedProperty == "true"))
 ## A non-setting association dropdown gets an inline "Add new / Refresh" control and spans the full row.
 #set($lookup = ($property.widgetType == "DROPDOWN" && $property.relationshipEntityName && $property.relationshipEntityPerspectiveName != "Settings" && !$readonly))

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEngineIT.java
@@ -1403,6 +1403,13 @@ class IntentEngineIT extends IntegrationTest {
         assertTrue(documentView.contains("openHref(row)"),
                 "the files panel rows must offer the inline Open action for stored snapshot versions");
 
+        // A detail's form never offers its COMPOSITION-parent FK as an input: the detail is created
+        // from its master's panel, which presets the FK via the create query param - offering the
+        // parent as a dropdown invites re-parenting by accident and is redundant in the dialog.
+        String itemForm = contentOf("gen/orders/views/Order/OrderItem-form.html");
+        assertFalse(itemForm.contains("f_Order\""), "the composition-parent FK must not render as a form input, got a f_Order control");
+        assertTrue(itemForm.contains("f_Quantity\""), "the detail's own fields still render as inputs");
+
         // The generic item-dialog machinery is model-independent but must be present for line items.
         assertTrue(documentPage.contains("applyDraftDependsOn") && documentPage.contains("dialogOptionsFor"),
                 "the item dialog should carry the metadata-driven dependsOn machinery");


### PR DESCRIPTION
Closes #6513.

The generated detail create/edit form (e.g. a company's bank-account dialog, #6509) still rendered the composition-parent FK ("Company") as an editable dropdown. The parent is never the user's choice on a detail form — the master's panel presets it via the create query param and an edit round-trips the stored value — and every other master-detail surface already hides the master FK (the document items dialog and the detail tables exclude it by construction).

One-line template fix: the editable grid in `manage/form-view.html.template` skips properties with `relationshipType="COMPOSITION"`, alongside the existing exclusions (PK, read-only/system, DOCUMENT_STATUS, audit). The value stays in the form model — preset on create, loaded on edit — so binding and validation are unchanged; only the input is gone. A dropdown options fetch for it no longer matters visually and is left untouched (harmless).

`IntentEngineIT` locks the emission: the generated `OrderItem-form.html` contains no `f_Order` control while `f_Quantity` still renders.

Template-only — reaches deployed apps on the next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)