### PR TITLE
fix(harmonia): items-table text wraps at word boundaries in a bounded block (#6515)

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -247,10 +247,16 @@
             <tr x-h-table-row data-hoverable="true">
               <template x-for="col in editColumns" :key="col.name">
                 <!-- x-h-table-cell bakes whitespace-nowrap; a sentence-long item name is NORMAL
-                     invoice data, so text cells override it and wrap within their column. -->
-                <td x-h-table-cell :class="col.number ? 'text-right' : ''"
-                    :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
-                    x-text="cellDisplay(col, row)"></td>
+                     invoice data, so text cells wrap - AT WORD BOUNDARIES, inside a bounded block.
+                     (overflow-wrap:anywhere on the cell let the column collapse to ~one character
+                     per line: it reduces the column's min-content to a single character. The block's
+                     break-word keeps min-content = the longest word; max-width caps the paragraph.) -->
+                <td x-h-table-cell :class="col.number ? 'text-right' : ''">
+                  <template x-if="col.number"><span x-text="cellDisplay(col, row)"></span></template>
+                  <template x-if="!col.number">
+                    <div style="white-space: normal; overflow-wrap: break-word; max-width: 28rem;" x-text="cellDisplay(col, row)"></div>
+                  </template>
+                </td>
               </template>
               <td x-h-table-cell data-row-actions x-show="!isPreview" @click.stop>
                 <button x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions">
@@ -377,9 +383,12 @@
                 <template x-for="row in rows" :key="row[def.primaryKey]">
                   <tr x-h-table-row data-hoverable="true">
                     <template x-for="col in def.columns" :key="col.name">
-                      <td x-h-table-cell :class="col.number ? 'text-right' : ''"
-                          :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
-                          x-text="cellValue(col, row)"></td>
+                      <td x-h-table-cell :class="col.number ? 'text-right' : ''">
+                        <template x-if="col.number"><span x-text="cellValue(col, row)"></span></template>
+                        <template x-if="!col.number">
+                          <div style="white-space: normal; overflow-wrap: break-word; max-width: 28rem;" x-text="cellValue(col, row)"></div>
+                        </template>
+                      </td>
                     </template>
                     <td x-h-table-cell data-row-actions x-show="!isPreview">
                       <button x-h-button data-variant="transparent" data-size="sm" aria-label="Delete" @click="askDelete(row)"><i role="img" x-h-lucide data-lucide="trash-2"></i></button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/manage/form-view.html.template
@@ -297,9 +297,12 @@
                   <template x-for="row in rows" :key="row[def.primaryKey]">
                     <tr x-h-table-row data-hoverable="true">
                       <template x-for="col in def.columns" :key="col.name">
-                        <td x-h-table-cell :class="col.number ? 'text-right' : ''"
-                            :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
-                            x-text="cellValue(col, row)"></td>
+                        <td x-h-table-cell :class="col.number ? 'text-right' : ''">
+                          <template x-if="col.number"><span x-text="cellValue(col, row)"></span></template>
+                          <template x-if="!col.number">
+                            <div style="white-space: normal; overflow-wrap: break-word; max-width: 28rem;" x-text="cellValue(col, row)"></div>
+                          </template>
+                        </td>
                       </template>
                       <td x-h-table-cell data-row-actions x-show="!isPreview">
                         <button type="button" x-h-menu-trigger.dropdown x-h-table-cell-button aria-label="Row actions"><i role="img" x-h-lucide data-lucide="ellipsis"></i></button>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/master/master-view.html.template
@@ -233,9 +233,12 @@
                     <template x-for="row in rows" :key="row[def.primaryKey]">
                       <tr x-h-table-row data-hoverable="true">
                         <template x-for="col in def.columns" :key="col.name">
-                          <td x-h-table-cell :class="col.number ? 'text-right' : ''"
-                              :style="col.number ? '' : 'white-space: normal; overflow-wrap: anywhere'"
-                              x-text="cellValue(col, row)"></td>
+                          <td x-h-table-cell :class="col.number ? 'text-right' : ''">
+                            <template x-if="col.number"><span x-text="cellValue(col, row)"></span></template>
+                            <template x-if="!col.number">
+                              <div style="white-space: normal; overflow-wrap: break-word; max-width: 28rem;" x-text="cellValue(col, row)"></div>
+                            </template>
+                          </td>
                         </template>
                         <!-- Read-only browse pane: children are added/edited/deleted from the record's
                              Edit form (where these same panels are editable), NOT here. Only the


### PR DESCRIPTION
Closes #6515. Follow-up to #6494 after live feedback: `overflow-wrap: anywhere` on the cell reduces the column's **min-content to one character**, so the auto table layout starves the Name column and a long item name renders one syllable per line.

The cell content now renders in a bounded block — `white-space: normal; overflow-wrap: break-word; max-width: 28rem` — so:

- wrapping happens at **word boundaries** (a genuinely unbroken over-long token still breaks rather than overflowing),
- the column's min-content is the **longest word** — it cannot collapse,
- the 28rem cap keeps one text column from hogging the table; anything wider scrolls in the table's own container (#6494).

Numeric cells keep nowrap + right alignment. Applied to the document line-items table and the three shared detail-panel tables; the chat bubble keeps `anywhere` deliberately (width-bounded bubble, arbitrary tokens). Template-only — reaches apps on the next regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)