### PR TITLE
fix(dao): document-totals recompute refreshes expression-calculated header fields (#6519)

### DIFF
--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -529,9 +529,27 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
             return null;
         }
         recalculate(entity);
+#foreach ($property in $properties)
+#if($property.isCalculatedProperty && !$property.calculatedActionOnUpdate && $property.calculatedPropertyExpressionUpdate)
+#if($foreach.first)
+        // The header's expression-calculated fields follow the totals they derive from (e.g.
+        // balance = total - paid): an items change moves the totals, so the derived expressions are
+        // refreshed here and persisted in the same targeted write - otherwise they stay stale (or
+        // null, printing an empty amount) until the next explicit header save. Calculated ACTIONS
+        // are deliberately NOT run here: a server call-out may mint or mutate state and belongs to
+        // the explicit save/update paths only.
+#end
+#calcAssign($property $property.calculatedPropertyExpressionUpdate)
+#end
+#end
         java.util.Map<String, Object> totals = new java.util.LinkedHashMap<>();
 #foreach($f in $documentMaster.fields)
         totals.put("${f.field}", entity.${f.field});
+#end
+#foreach ($property in $properties)
+#if($property.isCalculatedProperty && !$property.calculatedActionOnUpdate && $property.calculatedPropertyExpressionUpdate)
+        totals.put("${property.name}", entity.${property.name});
+#end
 #end
         super.updateProperties(id, totals);
         return entity;

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -404,6 +404,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   - { name: id,     type: integer, primaryKey: true, generated: true }
                   - { name: note,   type: string,  length: 200 }
                   - { name: amount, type: decimal, aggregate: true }
+                  # expression-calculated from the aggregate: the document-totals recompute must
+                  # refresh it on every line change, or it stays stale/null until a header save
+                  # (the unpaid-invoice Balance printed empty).
+                  - { name: balanceDue, type: decimal, calculatedOnCreate: "Amount", calculatedOnUpdate: "Amount" }
                 relations:
                   - { name: Person, kind: manyToOne, to: Person }
                   - { name: Status, kind: manyToOne, to: EntryStatus, function: EntityStatus, init: 1 }
@@ -814,6 +818,12 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertFalse(billRepository.replaceAll("\\s+", " ")
                                   .contains("recalculate(entity); return super.update(entity);"),
                 "the document-totals recompute must not fall back to the full-row write");
+        // recalculate() also refreshes the header's EXPRESSION-calculated fields (balanceDue derives
+        // from the aggregate amount) and persists them in the same targeted write - actions are
+        // deliberately not run there.
+        String billHeaderRepository = contentOf("gen/emission/data/bill/BillRepository.java");
+        assertTrue(billHeaderRepository.contains("totals.put(\"BalanceDue\", entity.BalanceDue)"),
+                "the totals recompute must persist the refreshed calculated field: " + billHeaderRepository);
         String billLineRepository = contentOf("gen/emission/data/bill/BillLineRepository.java");
         assertTrue(billLineRepository.contains("new BillRepository().recalculate("),
                 "a line change must trigger the master's document-totals recompute");
@@ -1545,6 +1555,25 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                                                           .statusCode(200)
                                                           .extract()
                                                           .path("Id")));
+        // A line change must refresh the header's expression-calculated field in the same recompute:
+        // balanceDue (= amount) follows the aggregate the moment the line lands - it must never stay
+        // null/stale until an explicit header save (the unpaid-invoice Balance printed empty).
+        restAssuredExecutor.execute(() -> given().contentType("application/json")
+                                                 .body("{\"Amount\":250,\"Bill\":" + bill.get() + "}")
+                                                 .when()
+                                                 .post(API + "/bill/BillLineController")
+                                                 .then()
+                                                 .statusCode(200));
+        restAssuredExecutor.execute(() -> {
+            Object balanceDue = given().when()
+                                       .get(API + "/bill/BillController/" + bill.get())
+                                       .then()
+                                       .statusCode(200)
+                                       .extract()
+                                       .path("BalanceDue");
+            assertTrue(balanceDue instanceof Number && Math.abs(((Number) balanceDue).doubleValue() - 250.0) < 0.001,
+                    "the calculated header field must follow the totals recompute, got: " + balanceDue);
+        });
         restAssuredExecutor.execute(() -> given().contentType("application/json")
                                                  .body("{\"id\":" + bill.get() + "}")
                                                  .when()


### PR DESCRIPTION
Closes #6519.

Live failure: an issued, unpaid invoice printed an empty "TOTAL DUE" — `Paid`/`Balance` were NULL. The settlement rollup writes them only on allocation events, and expression-calculated fields were re-evaluated only on an explicit header save — while the totals they derive from move on every **line** change.

`recalculate()` (the targeted document-totals recompute that line repositories call after every item write) now additionally re-evaluates the header's **expression**-calculated `calculatedOnUpdate` fields via the shared `Calc` evaluator (null inputs read as 0 per its contract) and includes them in the same targeted `updateProperties` write — so `balance = Total - Paid` follows the totals from the first line onward and stays correct between allocations. Calculated **actions** are deliberately excluded: a server call-out may mint or mutate state and belongs to the explicit save/update paths only (documented in-code).

Authoring note (suite side): `paid` defaults to 0 and `balance` declares `calculatedOnCreate/OnUpdate: "Total - Paid"` — Calc identifiers are the **PascalCase property names**.

**Test:** `IntentEmissionCoverageIT` — the coverage document gains `balanceDue` calculated from its aggregate `Amount`; asserts the emitted repository persists the refreshed value in the recompute's targeted write, and at runtime posting a line makes the header's `BalanceDue` equal the line total immediately, with no header save in between. Full fixture compile+publish, 1/1 green locally.

Template-only — reaches deployed apps on regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)