### PR TITLE
feat(intent): print scaffold emits a document-shaped layout, not a field dump

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGenerator.java
@@ -177,28 +177,41 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
                 .append("-print\">\n");
         template.append("    <page width=\"595\" height=\"842\" padding=\"40\">\n\n");
 
-        // header: humanized title + the document number (when a documentTitle field exists)
-        template.append("        <header>\n");
-        template.append("            <text align=\"right\" style=\"title\">")
-                .append(escape(label))
-                .append("</text>\n");
+        // Header: the humanized title on the left, the document number (when a documentTitle field
+        // exists) on the right - the classic printed-document header line.
         FieldIntent number = documentTitleField(master);
+        template.append("        <header>\n");
         if (number != null) {
-            template.append("            <text align=\"right\" style=\"subtitle\">{{document.")
+            template.append("            <row>\n");
+            template.append("                <stack width=\"*\">\n");
+            template.append("                    <text style=\"title\">")
+                    .append(escape(label))
+                    .append("</text>\n");
+            template.append("                </stack>\n");
+            template.append("                <stack width=\"*\">\n");
+            template.append("                    <text align=\"right\" style=\"subtitle\">{{document.")
                     .append(IntentNaming.pascalCase(number.getName()))
                     .append("}}</text>\n");
+            template.append("                </stack>\n");
+            template.append("            </row>\n");
+        } else {
+            template.append("            <text style=\"title\">")
+                    .append(escape(label))
+                    .append("</text>\n");
         }
         template.append("            <line/>\n");
         template.append("        </header>\n\n");
 
-        // header fields: plain non-aggregate fields + to-one relations (labels resolved client-side)
-        template.append("        <section>\n");
+        // Header data in two columns: the plain non-aggregate fields on the left, the to-one
+        // relation labels on the right - two weighted stacks instead of one long field list.
+        List<String> plainFields = new ArrayList<>();
         for (FieldIntent field : master.getFields()) {
             if (field.isPrimaryKey() || field.isAggregate() || field == number) {
                 continue;
             }
-            appendField(template, "            ", field.getName());
+            plainFields.add(field.getName());
         }
+        List<String> relationFields = new ArrayList<>();
         for (RelationIntent relation : master.getRelations()) {
             if (!isToOne(relation) || relation.getName() == null) {
                 continue;
@@ -211,10 +224,32 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
                                                                          .isBlank();
             if (crossModel || !IntentEntities.labelFieldOf(byName.get(relation.getTo()))
                                              .isEmpty()) {
-                appendField(template, "            ", relation.getName());
+                relationFields.add(relation.getName());
             }
         }
-        template.append("        </section>\n\n");
+        if (!plainFields.isEmpty() && !relationFields.isEmpty()) {
+            template.append("        <row gap=\"16\">\n");
+            template.append("            <stack width=\"*\">\n");
+            for (String name : plainFields) {
+                appendField(template, "                ", name);
+            }
+            template.append("            </stack>\n");
+            template.append("            <stack width=\"*\">\n");
+            for (String name : relationFields) {
+                appendField(template, "                ", name);
+            }
+            template.append("            </stack>\n");
+            template.append("        </row>\n\n");
+        } else {
+            template.append("        <section>\n");
+            for (String name : plainFields) {
+                appendField(template, "            ", name);
+            }
+            for (String name : relationFields) {
+                appendField(template, "            ", name);
+            }
+            template.append("        </section>\n\n");
+        }
 
         // line items
         template.append("        <table source=\"items\">\n");
@@ -243,18 +278,41 @@ public class PrintIntentGenerator implements IntentTargetGenerator {
             }
         }
         if (!aggregates.isEmpty()) {
-            template.append("        <section align=\"right\">\n");
             FieldIntent total = totalField(aggregates);
-            for (FieldIntent aggregate : aggregates) {
-                if (aggregate == total) {
-                    continue;
+            // Totals as label/value COLUMNS (a row of weighted stacks - 2* spacer, labels, values)
+            // so the figures align under each other; a right-aligned label:value line per total
+            // leaves the values ragged.
+            if (aggregates.size() > 1) {
+                template.append("        <row>\n");
+                template.append("            <stack width=\"2*\">\n");
+                template.append("            </stack>\n");
+                template.append("            <stack width=\"*\">\n");
+                for (FieldIntent aggregate : aggregates) {
+                    if (aggregate == total) {
+                        continue;
+                    }
+                    template.append("                <text align=\"right\">")
+                            .append(escape(IntentNaming.humanize(aggregate.getName())))
+                            .append(":</text>\n");
                 }
-                appendField(template, "            ", aggregate.getName());
+                template.append("            </stack>\n");
+                template.append("            <stack width=\"*\">\n");
+                for (FieldIntent aggregate : aggregates) {
+                    if (aggregate == total) {
+                        continue;
+                    }
+                    template.append("                <text align=\"right\">{{document.")
+                            .append(IntentNaming.pascalCase(aggregate.getName()))
+                            .append("}}</text>\n");
+                }
+                template.append("            </stack>\n");
+                template.append("        </row>\n");
             }
-            template.append("            <total align=\"right\">{{document.")
+            template.append("        <total align=\"right\">")
+                    .append(escape(IntentNaming.humanize(total.getName())))
+                    .append(": {{document.")
                     .append(IntentNaming.pascalCase(total.getName()))
-                    .append("}}</total>\n");
-            template.append("        </section>\n\n");
+                    .append("}}</total>\n\n");
         }
 
         // Footer: the label plus the document number when one exists. NEVER the primary key - the

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/print/PrintIntentGeneratorTest.java
@@ -94,9 +94,14 @@ class PrintIntentGeneratorTest {
         assertTrue(template.contains("<table source=\"items\">"));
         assertTrue(template.contains("<column width=\"3*\" label=\"Name\">{{Name}}</column>"));
         assertTrue(template.contains("<column width=\"*\" align=\"right\" label=\"Quantity\">{{Quantity}}</column>"));
-        // totals: net as a field, total emphasized
-        assertTrue(template.contains("<field label=\"Net\">{{document.Net}}</field>"));
-        assertTrue(template.contains("<total align=\"right\">{{document.Total}}</total>"));
+        // header data in two columns: plain fields left, relation labels right
+        assertTrue(template.contains("<row gap=\"16\">"));
+        // totals: label/value columns (a weighted row with a 2* spacer) so the figures align under
+        // each other; the total emphasized after the row, carrying its label
+        assertTrue(template.contains("<stack width=\"2*\">"));
+        assertTrue(template.contains("<text align=\"right\">Net:</text>"));
+        assertTrue(template.contains("<text align=\"right\">{{document.Net}}</text>"));
+        assertTrue(template.contains("<total align=\"right\">Total: {{document.Total}}</total>"));
     }
 
     @Test


### PR DESCRIPTION
## Problem

The generated `standard.print` scaffold renders every header field as one long list and every total as a right-aligned `label: value` string - so totals print ragged (values never align as a column) and the page reads as a field dump rather than a business document.

## Change

The scaffold now emits:
- a **header row**: humanized title left, document number (documentTitle field) right;
- **header data in two weighted columns** - plain fields left, to-one relation labels right (falls back to the flat section when either side is empty);
- **totals as label/value columns**: a weighted row (`2*` spacer + labels + values stacks, right-aligned) so figures align under each other, with the emphasized `<total>` after the row carrying its label.

## Contract

- The scaffold/feeder placeholder contract is untouched - same keys, new layout (`PrintScaffoldFeederContractTest` green).
- The emitted template still parses with the document DSL (`parseDocument` assertion in `PrintIntentGeneratorTest`, updated to assert the new layout).
- `writeModelFileIfAbsent` semantics unchanged - existing hand-adapted templates are never overwritten; only fresh documents get the new scaffold.
- engine-intent unit suite: 300 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)