### PR TITLE
fix(harmonia): the document items table shows the display columns, not every editable column

### DIFF
--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-page.js.template
@@ -197,6 +197,14 @@ document.addEventListener('alpine:init', () => {
     },
 
     itemColumns() { const d = this.def(); return (d && d.editColumns) || []; },
+    // The read-only items TABLE shows the display columns (major fields - `major: false` hides a
+    // field/relation from the table) with their full edit metadata; the dialog keeps itemColumns().
+    tableColumns() {
+      const d = this.def();
+      if (!d) return [];
+      const visible = new Set((d.columns || []).map(c => c.name));
+      return (d.editColumns || []).filter(c => visible.has(c.name));
+    },
 
     displayItem(row, col) {
       const v = row[col.name];

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -138,7 +138,7 @@
         <table x-h-table data-borders="rows">
           <thead x-h-table-header>
             <tr x-h-table-row>
-              <template x-for="col in itemColumns()" :key="col.name">
+              <template x-for="col in tableColumns()" :key="col.name">
                 <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label)"></th>
               </template>
 #if(!$personalReadOnly)
@@ -149,7 +149,7 @@
           <tbody x-h-table-body>
             <template x-for="row in items" :key="row[itemsDef.primaryKey]">
               <tr x-h-table-row data-hoverable="true" class="cursor-pointer" @click="openItem(row)">
-                <template x-for="col in itemColumns()" :key="col.name">
+                <template x-for="col in tableColumns()" :key="col.name">
                   <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="displayItem(row, col)"></td>
                 </template>
 #if(!$personalReadOnly)
@@ -160,7 +160,7 @@
               </tr>
             </template>
             <tr x-show="items.length === 0">
-              <td x-h-table-cell :colspan="itemColumns().length#if(!$personalReadOnly) + 1#end" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
+              <td x-h-table-cell :colspan="tableColumns().length#if(!$personalReadOnly) + 1#end" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
             </tr>
           </tbody>
         </table>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-page.js.template
@@ -187,6 +187,14 @@ document.addEventListener('alpine:init', () => {
     },
 
     itemColumns() { const d = this.def(); return (d && d.editColumns) || []; },
+    // The read-only items TABLE shows the display columns (major fields - `major: false` hides a
+    // field/relation from the table) with their full edit metadata; the dialog keeps itemColumns().
+    tableColumns() {
+      const d = this.def();
+      if (!d) return [];
+      const visible = new Set((d.columns || []).map(c => c.name));
+      return (d.editColumns || []).filter(c => visible.has(c.name));
+    },
 
     displayItem(row, col) {
       const v = row[col.name];

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -90,7 +90,7 @@
         <table x-h-table data-borders="rows">
           <thead x-h-table-header>
             <tr x-h-table-row>
-              <template x-for="col in itemColumns()" :key="col.name">
+              <template x-for="col in tableColumns()" :key="col.name">
                 <th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label)"></th>
               </template>
               <th x-h-table-head scope="col"></th>
@@ -99,7 +99,7 @@
           <tbody x-h-table-body>
             <template x-for="row in items" :key="row[itemsDef.primaryKey]">
               <tr x-h-table-row data-hoverable="true" class="cursor-pointer" @click="openItem(row)">
-                <template x-for="col in itemColumns()" :key="col.name">
+                <template x-for="col in tableColumns()" :key="col.name">
                   <td x-h-table-cell :class="col.number ? 'text-right' : ''" x-text="displayItem(row, col)"></td>
                 </template>
                 <td x-h-table-cell class="text-right">
@@ -108,7 +108,7 @@
               </tr>
             </template>
             <tr x-show="items.length === 0">
-              <td x-h-table-cell :colspan="itemColumns().length + 1" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
+              <td x-h-table-cell :colspan="tableColumns().length + 1" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
             </tr>
           </tbody>
         </table>

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-page.js.template
@@ -593,6 +593,16 @@ document.addEventListener('alpine:init', () => {
     // ----- Items (read-only table + add/edit dialog, server-side) --------------------------------
     get editColumns() { return (this.itemsDef && this.itemsDef.editColumns) || []; },
 
+    // The columns the read-only items TABLE shows: the display columns (major fields - `major:
+    // false` hides a field/relation from the table), carried with their full edit metadata so
+    // lookup labels, dates and number patterns still render. The add/edit DIALOG keeps the full
+    // editColumns (a hidden trigger like Product must stay editable there).
+    get tableColumns() {
+      if (!this.itemsDef) return [];
+      const visible = new Set((this.itemsDef.columns || []).map(c => c.name));
+      return this.editColumns.filter(c => visible.has(c.name));
+    },
+
     async loadItems() {
       if (!this.itemsDef || this.id == null) { this.items = []; this.itemsState = 'empty'; return; }
       this.itemsState = 'loading';

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/perspective/document/document-view.html.template
@@ -238,14 +238,14 @@
       <table x-h-table data-borders="rows" class="w-full">
         <thead x-h-table-header>
           <tr x-h-table-row>
-            <template x-for="col in editColumns" :key="col.name"><th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label)"></th></template>
+            <template x-for="col in tableColumns" :key="col.name"><th x-h-table-head scope="col" :class="col.number ? 'text-right' : ''" x-text="T(col.tkey, col.label)"></th></template>
             <th x-h-table-head scope="col" x-show="!isPreview"></th>
           </tr>
         </thead>
         <tbody x-h-table-body>
           <template x-for="(row, idx) in items" :key="row[itemsDef.primaryKey] != null ? row[itemsDef.primaryKey] : idx">
             <tr x-h-table-row data-hoverable="true">
-              <template x-for="col in editColumns" :key="col.name">
+              <template x-for="col in tableColumns" :key="col.name">
                 <!-- x-h-table-cell bakes whitespace-nowrap; a sentence-long item name is NORMAL
                      invoice data, so text cells wrap - AT WORD BOUNDARIES, inside a bounded block.
                      (overflow-wrap:anywhere on the cell let the column collapse to ~one character
@@ -271,7 +271,7 @@
             </tr>
           </template>
           <tr x-show="items.length === 0">
-            <td x-h-table-cell :colspan="editColumns.length + (isPreview ? 0 : 1)" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
+            <td x-h-table-cell :colspan="tableColumns.length + (isPreview ? 0 : 1)" class="text-center" x-text="T('$projectName:${tprefix}.messages.noData', 'No line items yet.')"></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Problem

The document page's read-only items table (application shell, My shell, Partner shell) renders `editColumns` - the full metadata meant for the add/edit dialog. A relation the model hides from tables (`major: false`, honored by the display-column list) therefore still appears as a table column: a line-item's Product picker, UoM and tax-rate selectors all render as columns although the Name/quantity/derived-amount columns are the document's actual reading surface.

## Fix

The table iterates a filtered set: the display columns (which honor `major: false`) carried with their full edit metadata, so lookup labels, date and number formatting keep working. The dialog keeps `editColumns` - a hidden Depends-On trigger (pick a Product → name/price/UoM/tax fill in) must stay editable there. Same change on all three shells; colspans follow.

Verified live: a regenerated invoice document renders the reduced table (name/quantity/price/discount/vat-rate/net/vat/total) while the line dialog still offers Product/UoM/TaxRate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)