### PR TITLE
chore(intent): vendor-neutral example model aliases + javadoc references

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -925,8 +925,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * ({@link org.eclipse.dirigible.components.intent.model.PostIntent}). Each descriptor drives a
      * generated event handler that, on the source document's {@code event:} event, emits mapped rows
      * into the {@code into:} target (per {@code forEach:} line item), idempotently by
-     * {@code idempotentBy}. See kf-catalog PROPOSAL_EVENT_POSTING.md. This is the structural glue; the
-     * handler template + BPMN/listener wiring is the next stage.
+     * {@code idempotentBy}. This is the structural glue; the handler template + BPMN/listener wiring is
+     * the next stage.
      */
     private static List<Map<String, Object>> buildPosts(IntentModel model, Map<String, EntityIntent> byName,
             Map<String, String> compositionParents) {
@@ -1080,7 +1080,7 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * ({@link org.eclipse.dirigible.components.intent.model.AggregateIntent}). Each drives a generated
      * handler that maintains a running sum/count of a source entity's field, grouped by its to-one
      * relations, upserted into a separate target entity keyed by that group. Structural glue; the
-     * keyed-upsert handler template is the next stage. See kf-catalog PROPOSAL_AGGREGATE_CHECKS.md.
+     * keyed-upsert handler template is the next stage.
      */
     private static List<Map<String, Object>> buildAggregates(IntentModel model, Map<String, EntityIntent> byName,
             Map<String, String> compositionParents) {

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -222,7 +222,7 @@ composition is opt-in.
   target (childless nodes), depth-indents the options, and the generated REST validation rejects an
   FK to a node with children (e.g. a journal line references an analytical account, never a
   synthetic one). The target entity must declare `hierarchy`. Canonical pair:
-    `- { name: Account, kind: manyToOne, to: Account, model: kf-accounts, required: true, leafOnly: true }`
+    `- { name: Account, kind: manyToOne, to: Account, model: accounts, required: true, leafOnly: true }`
 - `checks:` (entity-level) - **declarative cross-field / cross-line validations**:
   - `{ kind: exactlyOne, fields: [debit, credit], message: "..." }` (row-level): exactly one of the
     listed own fields is non-null - enforced on every user write (400).
@@ -242,7 +242,7 @@ composition is opt-in.
   ```yaml
   postings:
     - name: salesInvoicePosting
-      event: { onTransition: SalesInvoice, model: kf-mod-sales-invoices, when: "Status == 3" }
+      event: { onTransition: SalesInvoice, model: sales-invoices, when: "Status == 3" }
       creates: JournalEntry            # a LOCAL document entity owning a composition items child
       backReference: SalesInvoice      # creates' to-one back to the source = the at-most-once guard
       map: { entryDate: date, customer: Customer, reason: "Sales invoice {number}" }
@@ -283,7 +283,7 @@ composition is opt-in.
   sibling's document when the source is voided/cancelled - pair it with a `transitions:` void:
   ```yaml
     - name: invoiceStorno
-      event: { onTransition: SalesInvoice, model: kf-billing, when: "Status == 8" }   # the void status
+      event: { onTransition: SalesInvoice, model: sales-invoices, when: "Status == 8" }   # the void status
       reverses: salesInvoicePosting     # sibling posting in this block
       storno: Storno                    # the created entity's to-one SELF-relation to the original
   ```


### PR DESCRIPTION
## What

- `engine-intent/src/main/resources/intent-assistant-guide.md` (the AI assistant's shipped system prompt): the cross-model alias examples used internal suite codenames — now neutral: `model: accounts` for the `leafOnly` canonical pair, and `model: sales-invoices` for **both** posting examples (they reference the same `SalesInvoice` source model, so the two examples are now consistent as well).
- `GlueIntentGenerator.java`: two javadoc notes pointed at external proposal documents by repository name; the design description stays, the repository pointers are removed.

Docs/examples only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)