### PR TITLE
feat(intent): month/week fields first-class on every surface - type-aware now defaults, formatted labels, my/partner pickers

### DIFF
--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/GlueIntentGenerator.java
@@ -226,7 +226,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             if (days != null) {
                 entry.put("kind", "days");
                 entry.put("dayField", IntentNaming.pascalCase(child.getDayField()));
-                entry.put("fieldAssignments", childAssignments(java.util.Map.of(), child.getDefaults(), rowVar));
+                entry.put("fieldAssignments", childAssignments(java.util.Map.of(), child.getDefaults(), rowVar,
+                        temporalKinds(crossModel ? null : byName.get(child.getTo()), target)));
             } else {
                 entry.put("kind", "entity");
                 String collection = String.valueOf(child.getForEach()
@@ -241,7 +242,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                                                            .next();
                 entry.put("matchProperty", IntentNaming.pascalCase(condition.getKey()));
                 entry.put("matchSourceExpression", "entity." + IntentNaming.pascalCase(String.valueOf(condition.getValue())));
-                entry.put("fieldAssignments", childAssignments(toStringMap(child.getMap()), child.getDefaults(), rowVar));
+                entry.put("fieldAssignments", childAssignments(toStringMap(child.getMap()), child.getDefaults(), rowVar,
+                        temporalKinds(crossModel ? null : byName.get(child.getTo()), target)));
             }
             entry.put("rowVar", rowVar);
             if (child.getChildren() != null && !child.getChildren()
@@ -642,7 +644,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
             e.put("toModel", crossModel ? g.getUses() : "");
             e.put("toPerspective", toPerspective);
             e.put("toPk", toPk);
-            e.put("fieldAssignments", assignments(g.getMap(), g.getDefaults(), "source"));
+            e.put("fieldAssignments",
+                    assignments(g.getMap(), g.getDefaults(), "source", temporalKinds(crossModel ? null : byName.get(g.getTo()), target)));
             // Completion hook: the SOURCE's EntityStatus FK is set to this seed id after the target
             // is created (empty = no hook). Pre-resolved to the PascalCase FK property.
             String sourceStatusProperty = "";
@@ -679,8 +682,11 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 e.put("toFkProperty", IntentNaming.pascalCase(g.getTo()));
                 // childAssignments (not assignments) so a numeric item default renders as BigDecimal -
                 // line-item columns (quantity/price/amount) are decimal, and a bare int literal does
-                // not convert to the generated BigDecimal field.
-                e.put("itemFieldAssignments", childAssignments(items.getMap(), items.getDefaults(), "srcItem"));
+                // not convert to the generated BigDecimal field. The item target lives in the SAME
+                // model as the header target, so a cross-model header implies a resolvable item.
+                CrossModelSupport.TargetInfo itemTarget = uses == null ? null : CrossModelSupport.resolve(context, uses, items.getTo());
+                e.put("itemFieldAssignments", childAssignments(items.getMap(), items.getDefaults(), "srcItem",
+                        temporalKinds(crossModel ? null : byName.get(items.getTo()), itemTarget)));
             } else {
                 e.put("fromItemEntity", "");
                 e.put("toItemEntity", "");
@@ -1468,10 +1474,12 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     /**
      * Pre-render the target field assignments for a generate mapping: a {@code map} entry copies a
      * source property ({@code <sourceVar>.<Prop>}); a {@code defaults} entry sets {@code now} (today's
-     * date) or a literal. The expression is rendered here (in Java, testable) so the Velocity template
-     * only emits {@code target.<prop> = <expr>;} - no expression logic in the template.
+     * date, in the target field's own shape - see {@code literalExpression}) or a literal. The
+     * expression is rendered here (in Java, testable) so the Velocity template only emits
+     * {@code target.<prop> = <expr>;} - no expression logic in the template.
      */
-    private static List<Map<String, Object>> assignments(Map<String, String> map, Map<String, String> defaults, String sourceVar) {
+    private static List<Map<String, Object>> assignments(Map<String, String> map, Map<String, String> defaults, String sourceVar,
+            java.util.function.Function<String, String> temporalKinds) {
         List<Map<String, Object>> list = new ArrayList<>();
         if (map != null) {
             for (Map.Entry<String, String> entry : map.entrySet()) {
@@ -1488,7 +1496,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                                                      .isBlank()) {
                     continue;
                 }
-                list.add(assignment(entry.getKey(), literalExpression(entry.getValue())));
+                list.add(assignment(entry.getKey(),
+                        literalExpression(entry.getValue(), temporalKinds.apply(IntentNaming.pascalCase(entry.getKey())))));
             }
         }
         return list;
@@ -1499,24 +1508,60 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
      * child shapes (hours, amounts) are decimal columns, and a bare int literal does not convert to the
      * generated {@code BigDecimal} field.
      */
-    private static List<Map<String, Object>> childAssignments(Map<String, String> map, Map<String, String> defaults, String sourceVar) {
+    private static List<Map<String, Object>> childAssignments(Map<String, String> map, Map<String, String> defaults, String sourceVar,
+            java.util.function.Function<String, String> temporalKinds) {
         Map<String, String> typedDefaults = new LinkedHashMap<>();
         if (defaults != null) {
             typedDefaults.putAll(defaults);
         }
-        List<Map<String, Object>> list = assignments(map, java.util.Map.of(), sourceVar);
+        List<Map<String, Object>> list = assignments(map, java.util.Map.of(), sourceVar, temporalKinds);
         for (Map.Entry<String, String> entry : typedDefaults.entrySet()) {
             if (entry.getValue() == null || entry.getValue()
                                                  .isBlank()) {
                 continue;
             }
-            String expression = literalExpression(entry.getValue());
+            String expression = literalExpression(entry.getValue(), temporalKinds.apply(IntentNaming.pascalCase(entry.getKey())));
             if (expression.matches("-?\\d+(\\.\\d+)?")) {
                 expression = "new java.math.BigDecimal(\"" + expression + "\")";
             }
             list.add(assignment(entry.getKey(), expression));
         }
         return list;
+    }
+
+    /**
+     * The logical temporal kind of the TARGET entity's fields, for the type-aware {@code now} default:
+     * PascalCase property name -> {@code month} / {@code week}; anything else absent (null). A
+     * same-model target reads its intent fields directly; a cross-model target reads the owner model's
+     * widget types through {@link CrossModelSupport.TargetInfo#propertyWidgets()} - the {@code .model}
+     * is the only cross-model carrier of the LOGICAL type, since month/week are plain VARCHAR at the
+     * JDBC level. An unresolved target (unit test / convention fallback) keeps the untyped behavior.
+     */
+    private static java.util.function.Function<String, String> temporalKinds(EntityIntent local, CrossModelSupport.TargetInfo target) {
+        Map<String, String> kinds = new LinkedHashMap<>();
+        if (local != null && local.getFields() != null) {
+            for (FieldIntent field : local.getFields()) {
+                if (field.getName() == null || field.getType() == null) {
+                    continue;
+                }
+                String type = field.getType()
+                                   .toLowerCase(java.util.Locale.ROOT);
+                if ("month".equals(type) || "week".equals(type)) {
+                    kinds.put(IntentNaming.pascalCase(field.getName()), type);
+                }
+            }
+        }
+        if (target != null && target.propertyWidgets() != null) {
+            for (Map.Entry<String, String> widget : target.propertyWidgets()
+                                                          .entrySet()) {
+                if ("MONTH".equals(widget.getValue())) {
+                    kinds.put(widget.getKey(), "month");
+                } else if ("WEEK".equals(widget.getValue())) {
+                    kinds.put(widget.getKey(), "week");
+                }
+            }
+        }
+        return kinds::get;
     }
 
     private static Map<String, Object> assignment(String targetProperty, String expression) {
@@ -1527,12 +1572,23 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
     }
 
     /**
-     * A Java expression for a {@code defaults} value: {@code now} -> today's {@code LocalDate}; an
-     * integer / decimal / boolean literal -> its Java form; anything else -> a quoted Java string.
+     * A Java expression for a {@code defaults} value: {@code now} -> today's value in the TARGET
+     * field's own shape - a {@code month} field gets the {@code YYYY-MM} string, a {@code week} field
+     * the {@code YYYY-Www} ISO-week string, anything else today's {@code LocalDate} (month/week are
+     * plain {@code String} properties on the generated entity, so the untyped {@code LocalDate.now()}
+     * would not even compile against them); an integer / decimal / boolean literal -> its Java form;
+     * anything else -> a quoted Java string.
      */
-    private static String literalExpression(String value) {
+    private static String literalExpression(String value, String temporalKind) {
         String v = value.trim();
         if ("now".equals(v)) {
+            if ("month".equals(temporalKind)) {
+                return "java.time.YearMonth.now().toString()";
+            }
+            if ("week".equals(temporalKind)) {
+                return "String.format(\"%04d-W%02d\", java.time.LocalDate.now().get(java.time.temporal.IsoFields.WEEK_BASED_YEAR), "
+                        + "java.time.LocalDate.now().get(java.time.temporal.IsoFields.WEEK_OF_WEEK_BASED_YEAR))";
+            }
             return "java.time.LocalDate.now()";
         }
         if ("true".equals(v) || "false".equals(v)) {
@@ -1896,7 +1952,8 @@ public class GlueIntentGenerator implements IntentTargetGenerator {
                 entry.put("genToModel", crossModel ? g.getUses() : "");
                 entry.put("genToPerspective", toPerspective);
                 entry.put("genToPk", toPk);
-                entry.put("genFieldAssignments", assignments(g.getMap(), g.getDefaults(), "entity"));
+                entry.put("genFieldAssignments", assignments(g.getMap(), g.getDefaults(), "entity",
+                        temporalKinds(crossModel ? null : byName.get(g.getTo()), target)));
                 if (g.getChildren() != null && !g.getChildren()
                                                  .isEmpty()) {
                     // Collection-driven children: one row per element of a source collection, saved

--- a/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/CrossModelSupport.java
+++ b/components/engine/engine-intent/src/main/java/org/eclipse/dirigible/components/intent/generator/edm/CrossModelSupport.java
@@ -69,9 +69,14 @@ public final class CrossModelSupport {
      * @param propertyNames the target's property names (PascalCase), for validating references to its
      *        properties (a {@code dependsOn} {@code valueFrom}/{@code filterBy}); {@code null} when the
      *        model was not resolved (convention fallback) - callers then skip the check
+     * @param propertyWidgets the target's property name → widget type (e.g. {@code Period} →
+     *        {@code MONTH}) - the only place a consumer can learn a cross-model field's LOGICAL type
+     *        ({@code month}/{@code week} are VARCHAR at the JDBC level); {@code null} when the model
+     *        was not resolved - callers then fall back to the untyped behavior
      */
     public record TargetInfo(boolean resolved, String perspectiveName, String tableDataName, String keyField, String keyColumn,
-            String labelField, String fkType, java.util.Set<String> propertyNames, String hierarchyProperty, String identityProperty) {
+            String labelField, String fkType, java.util.Set<String> propertyNames, String hierarchyProperty, String identityProperty,
+            java.util.Map<String, String> propertyWidgets) {
     }
 
     @SuppressWarnings("unchecked")
@@ -146,8 +151,10 @@ public final class CrossModelSupport {
                 String fkType = "INTEGER";
                 String labelField = "Name";
                 java.util.Set<String> propertyNames = null;
+                java.util.Map<String, String> propertyWidgets = null;
                 if (properties != null) {
                     propertyNames = new java.util.LinkedHashSet<>();
+                    propertyWidgets = new java.util.LinkedHashMap<>();
                     for (Map<String, Object> p : properties) {
                         if ("true".equals(String.valueOf(p.get("dataPrimaryKey")))) {
                             keyField = str(p.get("name"), keyField);
@@ -157,6 +164,10 @@ public final class CrossModelSupport {
                         String propertyName = str(p.get("name"), null);
                         if (propertyName != null) {
                             propertyNames.add(propertyName);
+                            String widget = str(p.get("widgetType"), null);
+                            if (widget != null) {
+                                propertyWidgets.put(propertyName, widget);
+                            }
                         }
                     }
                     labelField = labelField(properties, keyField);
@@ -164,7 +175,7 @@ public final class CrossModelSupport {
                 String hierarchyProperty = str(entity.get("hierarchyProperty"), null);
                 String identityProperty = str(entity.get("identityProperty"), null);
                 return new TargetInfo(true, perspective, tableDataName, keyField, keyColumn, labelField, fkType, propertyNames,
-                        hierarchyProperty, identityProperty);
+                        hierarchyProperty, identityProperty, propertyWidgets);
             }
         } catch (RuntimeException e) {
             LOGGER.warn("Failed to read owner model [{}] for cross-model target [{}]", modelPath, targetEntity, e);
@@ -199,7 +210,7 @@ public final class CrossModelSupport {
     private static TargetInfo convention(String alias, String targetEntity) {
         String table = IntentNaming.upperSnake(alias) + "_" + IntentNaming.upperSnake(targetEntity);
         String keyColumn = IntentNaming.upperSnake(targetEntity) + "_ID";
-        return new TargetInfo(false, targetEntity, table, "Id", keyColumn, "Name", "INTEGER", null, null, null);
+        return new TargetInfo(false, targetEntity, table, "Id", keyColumn, "Name", "INTEGER", null, null, null, null);
     }
 
     /**

--- a/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
+++ b/components/engine/engine-intent/src/main/resources/intent-assistant-guide.md
@@ -381,8 +381,9 @@ the entity.
 **Display labels (`label:` on an entity):** `label: "{number} - {date|yyyy MMMM} - {Customer.name}"`
 generates a stored, read-only `Name` property recomputed on every write - lookups and dropdowns
 then show it everywhere. Tokens: own fields or ONE-hop to-one relation properties; `|format` is a
-date pattern for temporal values; deeper paths are rejected - compose by referencing the related
-entity's own generated label (`{Parent.Name}`). Not allowed next to an authored `name` field, and
+date pattern for temporal values - a `month` field's `YYYY-MM` string formats through it too
+(`{period|yyyy MMMM}` renders "2026 July"); deeper paths are rejected - compose by referencing the
+related entity's own generated label (`{Parent.Name}`). Not allowed next to an authored `name` field, and
 a token must never reference a `sensitive` field. Prefer a label for every document-ish entity a
 user will pick in a dropdown (a raw id is what renders otherwise).
 
@@ -1007,7 +1008,9 @@ generates:
 entity (add a `uses:` alias when the target lives in another model); `forEntity` must be a declared
 entity; `scope` is `entity` or `page` (default `entity`). Every `map` value must be a **field or
 to-one relation** of the source entity - one-hop `relation.field` paths are not yet supported. `map`
-copies a source value; `defaults` sets a constant (`now` = today's date, or a literal). Do **not** map
+copies a source value; `defaults` sets a constant (`now` = today, rendered in the target field's own
+shape - a `date` field gets today's date, a `month` field the current `YYYY-MM`, a `week` field the
+current `YYYY-Www` - or a literal). Do **not** map
 the target's identity, document number, status or the item->master foreign key: they are left for the
 target to mint - the clone is saved through the **target's** generated repository, so its create-time
 logic (numbering, status init, calculated fields) fires naturally. `sourceStatus` (optional) flips the
@@ -1351,7 +1354,8 @@ EmployeeTimesheet for each active employee". Per matching row, a new target reco
 saved through the target's generated repository, so its create-time logic (document numbering, status
 init, calculated fields) fires. The **row is the source**, so `from` is implicit (the schedule's
 `entity`); `map` copies a field or to-one relation of the row onto a target property, `defaults` sets
-`now` or a literal. The target may live in another model via `uses:` (same as `generates`).
+`now` (rendered in the target field's own shape - date / `YYYY-MM` month / `YYYY-Www` week) or a
+literal. The target may live in another model via `uses:` (same as `generates`).
 
 ```yaml
 schedules:

--- a/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
+++ b/components/engine/engine-intent/src/test/java/org/eclipse/dirigible/components/intent/generator/GlueSchedulesTest.java
@@ -79,6 +79,53 @@ class GlueSchedulesTest {
         assertTrue(fields.contains(Map.of("targetProp", "Period", "expr", "java.time.LocalDate.now()")), "fields: " + fields);
     }
 
+    @SuppressWarnings("unchecked")
+    @Test
+    void generateScheduleRendersNowInTheTargetFieldsOwnShape() {
+        // A month/week field is a plain String on the generated entity (VARCHAR at the JDBC
+        // level), so the untyped LocalDate.now() would not even compile against it - `now` must
+        // render the target field's own value shape.
+        String yaml = """
+                name: hr
+                entities:
+                  - name: Employee
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: status, type: string }
+                  - name: EmployeeTimesheet
+                    fields:
+                      - { name: id, type: integer, primaryKey: true, generated: true }
+                      - { name: period, type: month }
+                      - { name: slot, type: week }
+                      - { name: bookedOn, type: date }
+                    relations:
+                      - { name: Employee, kind: manyToOne, to: Employee }
+                schedules:
+                  - name: monthly-timesheets
+                    cron: "0 0 1 1 * ?"
+                    entity: Employee
+                    generate:
+                      to: EmployeeTimesheet
+                      map:
+                        Employee: id
+                      defaults:
+                        Period: now
+                        Slot: now
+                        BookedOn: now
+                """;
+        IntentModel model = IntentParser.parse(yaml);
+        Map<String, Object> s = GlueIntentGenerator.buildSchedulesForTest(model)
+                                                   .get(0);
+        List<Map<String, Object>> fields = (List<Map<String, Object>>) s.get("genFieldAssignments");
+        assertTrue(fields.contains(Map.of("targetProp", "Period", "expr", "java.time.YearMonth.now().toString()")),
+                "a month field's now must be the YYYY-MM string: " + fields);
+        assertTrue(fields.stream()
+                         .anyMatch(f -> "Slot".equals(f.get("targetProp")) && ((String) f.get("expr")).contains("WEEK_BASED_YEAR")),
+                "a week field's now must be the YYYY-Www ISO-week string: " + fields);
+        assertTrue(fields.contains(Map.of("targetProp", "BookedOn", "expr", "java.time.LocalDate.now()")),
+                "a date field keeps today's LocalDate: " + fields);
+    }
+
     @Test
     void generateScheduleResolvesCrossModelTarget() {
         String yaml = """

--- a/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
+++ b/components/template/template-application-dao-java/src/main/resources/META-INF/dirigible/template-application-dao-java/data/Repository.java.template
@@ -593,6 +593,17 @@ public class ${name}Repository extends JavaRepository<${name}Entity> {
             return DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH)
                                     .format(temporal);
         }
+        // A month field stores the picker's YYYY-MM string - parse it back to a temporal so a
+        // |format token renders "2026 July" instead of the raw string. Fail-soft: a value that is
+        // not a real month, or a pattern demanding fields a month lacks (dd), keeps the raw string.
+        if (pattern != null && value instanceof String string && string.matches("\\d{4}-\\d{2}")) {
+            try {
+                return DateTimeFormatter.ofPattern(pattern, Locale.ENGLISH)
+                                        .format(java.time.YearMonth.parse(string));
+            } catch (RuntimeException e) {
+                return string;
+            }
+        }
         return String.valueOf(value);
     }
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-document-view.html.template
@@ -67,6 +67,20 @@
           <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
           <div x-h-time-picker-popup></div>
         </div>
+#elseif($property.widgetType == "MONTH")
+        <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-month-picker>
+          <input type="text" />
+          <button x-h-month-picker-trigger aria-label="Choose month"></button>
+          <div x-h-month-picker-popup x-model="form.${property.name}"></div>
+        </div>
+#elseif($property.widgetType == "WEEK")
+        <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-week-picker>
+          <input type="text" />
+          <button x-h-week-picker-trigger aria-label="Choose week"></button>
+          <div x-h-week-picker-popup x-model="form.${property.name}"></div>
+        </div>
 #else
         <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/my/my-form-view.html.template
@@ -71,6 +71,20 @@
           <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
           <div x-h-time-picker-popup></div>
         </div>
+#elseif($property.widgetType == "MONTH")
+        <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-month-picker>
+          <input type="text" />
+          <button x-h-month-picker-trigger aria-label="Choose month"></button>
+          <div x-h-month-picker-popup x-model="form.${property.name}"></div>
+        </div>
+#elseif($property.widgetType == "WEEK")
+        <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-week-picker>
+          <input type="text" />
+          <button x-h-week-picker-trigger aria-label="Choose week"></button>
+          <div x-h-week-picker-popup x-model="form.${property.name}"></div>
+        </div>
 #else
         <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-document-view.html.template
@@ -67,6 +67,20 @@
           <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
           <div x-h-time-picker-popup></div>
         </div>
+#elseif($property.widgetType == "MONTH")
+        <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-month-picker>
+          <input type="text" />
+          <button x-h-month-picker-trigger aria-label="Choose month"></button>
+          <div x-h-month-picker-popup x-model="form.${property.name}"></div>
+        </div>
+#elseif($property.widgetType == "WEEK")
+        <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-week-picker>
+          <input type="text" />
+          <button x-h-week-picker-trigger aria-label="Choose week"></button>
+          <div x-h-week-picker-popup x-model="form.${property.name}"></div>
+        </div>
 #else
         <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end

--- a/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
+++ b/components/template/template-application-ui-harmonia-java/src/main/resources/META-INF/dirigible/template-application-ui-harmonia-java/ui/partner/partner-form-view.html.template
@@ -71,6 +71,20 @@
           <input type="text" x-h-time-picker-input x-model="form.${property.name}" />
           <div x-h-time-picker-popup></div>
         </div>
+#elseif($property.widgetType == "MONTH")
+        <!-- Harmonia month picker: model is a YYYY-MM string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-month-picker>
+          <input type="text" />
+          <button x-h-month-picker-trigger aria-label="Choose month"></button>
+          <div x-h-month-picker-popup x-model="form.${property.name}"></div>
+        </div>
+#elseif($property.widgetType == "WEEK")
+        <!-- Harmonia week picker: model is a YYYY-Www ISO-week string, so form.${property.name} round-trips unchanged. -->
+        <div x-h-week-picker>
+          <input type="text" />
+          <button x-h-week-picker-trigger aria-label="Choose week"></button>
+          <div x-h-week-picker-popup x-model="form.${property.name}"></div>
+        </div>
 #else
         <input x-h-input type="text" x-model="form.${property.name}"#if($property.widgetPattern) pattern="${property.widgetPattern}"#end />
 #end

--- a/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
+++ b/tests/tests-integrations/src/main/java/org/eclipse/dirigible/integration/tests/api/IntentEmissionCoverageIT.java
@@ -220,11 +220,15 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                   # Deliberately NOT on `email` - that is the identity and holds the USERNAME (`admin`).
                   - { name: contactEmail, type: string, length: 320, pattern: '^[^@]+@[^@]+\\.[a-z]{2,}$' }
 
+              # period is a month field: YYYY-MM string storage, month-picker widget on EVERY
+              # writable surface (power + my), a |format label token rendering "2026 July", and
+              # the schedule's `Period: now` below emitting the string shape (not LocalDate).
               - name: Claim
-                label: "{note} ({Person.name})"
+                label: "{note} ({Person.name}) {period|yyyy MMMM}"
                 fields:
                   - { name: id,   type: integer, primaryKey: true, generated: true }
                   - { name: note, type: string, length: 200 }
+                  - { name: period, type: month }
                   - { name: rate, type: decimal, sensitive: true }
                   - { name: totalCost, type: decimal }
                 relations:
@@ -512,7 +516,7 @@ class IntentEmissionCoverageIT extends IntegrationTest {
                 generate:
                   to: Claim
                   map: { Person: id }
-                  defaults: { note: monthly }
+                  defaults: { note: monthly, Period: now }
                   children:
                     - to: ClaimLine
                       parent: Claim
@@ -1076,6 +1080,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(job.contains("savedTarget"), "the scheduled generation must save the parent and keep its id for the children");
         assertTrue(job.contains("getDayOfWeek"), "a days child must iterate the working days of the month");
         assertTrue(job.contains("ClaimLineRepository"), "the child rows must be saved through the child's repository");
+        // type-aware now: a month field is a String on the generated entity, so the default must
+        // render the YYYY-MM string - the untyped LocalDate.now() would not even compile.
+        assertTrue(job.contains(".Period = java.time.YearMonth.now().toString()"),
+                "a month field's `now` default must render the YYYY-MM string, not LocalDate");
+
+        // month widget: the YYYY-MM field renders the Harmonia month picker on BOTH writable
+        // surfaces - the power form and the personal form (my-shell parity).
+        assertTrue(contentOf("gen/emission/views/Claim/Claim-form.html").contains("x-h-month-picker"),
+                "a month field must render the Harmonia month picker on the power form");
+        assertTrue(contentOf("gen/emission/views/my/Claim-form.html").contains("x-h-month-picker"),
+                "a month field must render the Harmonia month picker on the personal form too");
 
         // documentItemsLayout: chat - the .model marker is resolved (body property from the child's
         // messageBody field), and the Harmonia document view + page render the items pane as an
@@ -1261,6 +1276,10 @@ class IntentEmissionCoverageIT extends IntegrationTest {
         assertTrue(claimRepository.contains("computeName"), "label must emit the display-name computation into the repository");
         assertTrue(claimRepository.contains("related.Name"),
                 "a one-hop label token must load the related record and read its display property");
+        // A month field is a YYYY-MM String (not a TemporalAccessor), so a |format label token
+        // must parse it back to a temporal - otherwise the label degrades to the raw "2026-07".
+        assertTrue(claimRepository.contains("YearMonth.parse"),
+                "a |format token on a month field must parse the YYYY-MM string back to a temporal");
         // A workflow setter/writer targeted write keeps the stored display Name current: the label
         // repository OVERRIDES updateProperties to recompute it on that path too.
         assertTrue(claimRepository.contains("public int updateProperties(") && claimRepository.contains("computeName(entity)"),
@@ -1690,15 +1709,17 @@ class IntentEmissionCoverageIT extends IntegrationTest {
 
         // Writes force the owner and ignore the sensitive field, whatever the client sends.
         restAssuredExecutor.execute(() -> given().contentType("application/json")
-                                                 .body("{\"Note\":\"spoofed\",\"Person\":2,\"Rate\":999}")
+                                                 .body("{\"Note\":\"spoofed\",\"Person\":2,\"Rate\":999,\"Period\":\"2026-07\"}")
                                                  .when()
                                                  .post(API + "/claim/ClaimMyController")
                                                  .then()
                                                  .statusCode(200)
                                                  .body("Person", equalTo(1))
                                                  .body("Rate", nullValue())
-                                                 // label: the stored display name computed on write - "{note} ({Person.name})".
-                                                 .body("Name", equalTo("spoofed (Admin)")));
+                                                 // label: the stored display name computed on write -
+                                                 // "{note} ({Person.name}) {period|yyyy MMMM}"; the month
+                                                 // value formats through the pattern, never the raw 2026-07.
+                                                 .body("Name", equalTo("spoofed (Admin) 2026 July")));
         restAssuredExecutor.execute(() -> given().contentType("application/json")
                                                  .body("{\"Note\":\"edited\",\"Person\":2,\"Rate\":999}")
                                                  .when()


### PR DESCRIPTION
Adopting a \`type: month\` field (the YYYY-MM string + month-picker widget) on a real reporting-period column surfaced three gaps that together made the type unusable on a document families' period columns:

## 1. \`defaults: <field>: now\` emits code that cannot compile against a month/week target

A schedules/generates default rendered \`java.time.LocalDate.now()\` unconditionally. A month/week field is a plain \`String\` on the generated entity (VARCHAR at the JDBC level), so the emitted job fails javac - and since client Java compiles as one all-or-nothing batch, one such default takes every module's beans down.

\`now\` is now rendered in the TARGET field's own shape:
- \`month\` -> \`java.time.YearMonth.now().toString()\` (YYYY-MM)
- \`week\` -> the YYYY-Www ISO-week string
- anything else -> \`LocalDate.now()\` (unchanged)

The target field's logical type is resolved from the local intent for same-model targets, and from the owner model's widget types for cross-model ones: \`CrossModelSupport.TargetInfo\` gains \`propertyWidgets\` (name -> widgetType), because month/week are indistinguishable from any other VARCHAR at the JDBC level - the \`.model\` widget type is the only cross-model carrier of the logical type.

## 2. A \`|format\` label token degrades a month value to the raw string

\`formatLabelValue\` only formatted \`TemporalAccessor\` values, so \`label: "{period|yyyy MMMM}"\` stored \`2026-07\` instead of \`2026 July\`. The generated repository now parses a \`YYYY-MM\` string back to a \`YearMonth\` when a pattern is present - fail-soft: a non-month value, or a pattern demanding fields a month lacks (\`dd\`), keeps the raw string.

## 3. The my/partner surfaces render a month field as a plain text input

The manage form and document templates had MONTH/WEEK branches; the four my/partner form and document templates did not, so a month field degraded to a bare text input on exactly the surfaces a period-carrying personal record renders on. All four now emit the same \`x-h-month-picker\` / \`x-h-week-picker\` blocks the power form does.

## Coverage

- \`IntentEmissionCoverageIT\`: the Claim fixture gains a month \`period\` (schedule default \`Period: now\`, label \`{period|yyyy MMMM}\`); asserts the YearMonth job emission, the month picker on the power AND my forms, the \`YearMonth.parse\` label branch, and at runtime a created record's \`Name\` reading \`... 2026 July\` (ran green locally: 1/1).
- \`GlueSchedulesTest\`: the month/week/date \`now\` shapes (engine-intent suite green: 301/301).
- Assistant guide updated (defaults \`now\` shape at both call sites, label month formatting).

Additionally verified on an isolated instance with a two-model workspace (a consumer module's schedule generating into another model's month field): the emitted job carries the YearMonth shape resolved through the owner \`.model\`, the full client-Java batch compiles, and a POSTed record's computed label formats the month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)